### PR TITLE
Override media type + check relation.source to find relation type

### DIFF
--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -29,6 +29,8 @@ class JSONRenderer(renderers.JSONRenderer):
     }
     """
 
+    media_type = 'application/vnd.api+json'
+
     def render(self, data, accepted_media_type=None, renderer_context=None):
         # Get the resource name.
         resource_name = utils.get_resource_name(renderer_context)

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -151,7 +151,8 @@ def get_related_resource_type(relation):
             parent_model = parent_serializer.parent.Meta.model
         parent_model_relation = getattr(
             parent_model,
-            (relation.field_name if relation.field_name else parent_serializer.field_name)
+            (relation.field_name if relation.field_name else
+                (relation.source if relation.source else parent_serializer.field_name))
         )
         if hasattr(parent_model_relation, 'related'):
             relation_model = parent_model_relation.related.model

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -151,8 +151,7 @@ def get_related_resource_type(relation):
             parent_model = parent_serializer.parent.Meta.model
         parent_model_relation = getattr(
             parent_model,
-            (relation.field_name if relation.field_name else
-                (relation.source if relation.source else parent_serializer.field_name))
+            (relation.source if relation.source else parent_serializer.field_name)
         )
         if hasattr(parent_model_relation, 'related'):
             relation_model = parent_model_relation.related.model


### PR DESCRIPTION
Fixing two issues I've discovered:

1. Override media_type on renderers.JSONRenderer as required by the JSON API 1.0 spec. Ember Data has started sending the required Accept: header causing DRF to return a 406 error code if this isn't set.

2. Encountered an issue whereby read_only relations with a source different than the field name could not resolve their resource types as the queryset field is not set when read_only is set on the field (enforced by DRF). Updated the logic to check for the 'source' field as well. 