### PR TITLE
For list view, ensure 'results' in data

### DIFF
--- a/rest_framework_json_api/mixins.py
+++ b/rest_framework_json_api/mixins.py
@@ -10,7 +10,7 @@ class MultipleIDMixin(object):
         """
         Override :meth:``get_queryset``
         """
-        ids = dict(self.request.QUERY_PARAMS).get('ids[]')
+        ids = dict(self.request.query_params).get('ids[]')
         if ids:
             self.queryset = self.queryset.filter(id__in=ids)
         return self.queryset

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -57,9 +57,9 @@ class JSONRenderer(renderers.JSONRenderer):
 
         # If detail view then json api spec expects dict, otherwise a list
         # - http://jsonapi.org/format/#document-top-level
-        if view and hasattr(view, 'action') and view.action == 'list':
-            # Check for paginated results
-            results = (data["results"] if isinstance(data, dict) else data)
+        if view and hasattr(view, 'action') and view.action == 'list' and isinstance(data, dict) and 'results' in data:
+
+            results = data["results"]
 
             resource_serializer = results.serializer
 


### PR DESCRIPTION
<h1> Purpose </h1>

There are instances where a list view is not sending 'results' in data so you get a KeyError in `render`. An example is when you send an `options` request on a list resource in the Django Rest Framework. This results in a 'KeyError'.
 
![screen shot 2015-08-14 at 10 28 18 am](https://cloud.githubusercontent.com/assets/9755598/9276001/49619702-426f-11e5-8d17-a0f2d4cb4cd8.png)
![screen shot 2015-08-14 at 10 28 30 am](https://cloud.githubusercontent.com/assets/9755598/9276002/4b3fa78a-426f-11e5-803e-5e370fde526c.png)

<h1> Changes </h1>

Ensures list view has 'results' in data