### PR TITLE
Django 1.7 Tests Fix - change legacy pagination check

### DIFF
--- a/example/tests/test_model_viewsets.py
+++ b/example/tests/test_model_viewsets.py
@@ -84,12 +84,13 @@ class ModelViewSetTests(TestBase):
         self.assertIsNone(links.get('next'))
 
         # Older versions of DRF add page=1 for first page. Later trim to root
-        try:
-            self.assertEqual(u'http://testserver/identities',
-                links.get('prev'))
-        except AssertionError:
+        previous_page = links.get('prev')
+        if 'page=1' in previous_page:
             self.assertEqual(u'http://testserver/identities?page=1',
-                links.get('prev'))
+                previous_page)
+        else:
+            self.assertEqual(u'http://testserver/identities',
+                previous_page)
 
     def test_page_range_in_list_result(self):
         """


### PR DESCRIPTION
I am running Django 1.7, Python 2.7, DRF 3.2 and wanted to look at the state of the tests. The only test failure for this setup was the one modified in the PR.

I noticed that when using Django 1.7 something was fishy using a try/catch on an `AssertionError` to test the legacy DRF case of including `?page=1` to the link. Switching to Django 1.8 (changing nothing else) did not have an issue with the try/except wrapping this assertion. 
Digging further I noticed in Django 1.7 the except raised was `exceptions.AssertionError` and in Django 1.8 the exception raised was a `_pytest.assertion.reinterpret.AssertionError`. (Again, changing nothing else) 
At this point I gave up and rewrote the test to not rely on catching an `AssertionError` as that seemed a bit brittle anyway. Everything now passes in my setup. 

Unrelated... I noticed that `?page1` was actually included in all my tests (on the newest DRF). So it seems the comment may be wrong about it not being present in newer DRFs. In that case there may be another bug where `?page=1` is included when it shouldn't be.