### PR TITLE
Modify exception_handler for a string error like AuthenticationError

### DIFF
--- a/rest_framework_json_api/exceptions.py
+++ b/rest_framework_json_api/exceptions.py
@@ -27,9 +27,14 @@ def exception_handler(exc, context):
             field = format_value(field)
             pointer = '/data/attributes/{}'.format(field)
             # see if they passed a dictionary to ValidationError manually
-            # or a string in case of AuthenticationError
-            if isinstance(error, dict) or isinstance(error, str):
+            if isinstance(error, dict):
                 errors.append(error)
+            # or a string in case of AuthenticationError
+            elif isinstance(error, str):
+                # An error MUST be a JSON object in JSON API spec
+                errors.append({
+                    'detail': error
+                })
             else:
                 for message in error:
                     errors.append({

--- a/rest_framework_json_api/exceptions.py
+++ b/rest_framework_json_api/exceptions.py
@@ -27,7 +27,8 @@ def exception_handler(exc, context):
             field = format_value(field)
             pointer = '/data/attributes/{}'.format(field)
             # see if they passed a dictionary to ValidationError manually
-            if isinstance(error, dict):
+            # or a string in case of AuthenticationError
+            if isinstance(error, dict) or isinstance(error, str):
                 errors.append(error)
             else:
                 for message in error:


### PR DESCRIPTION
When I specified `permission_classes = (permissions.IsAuthenticated,)` and called an API, I got a string error.
This pull request modify `exception_handler` for that case.

Could you take a look and merge this?
Thanks!