### PR TITLE
Revert "Prevent django from throwing errors if url is None"

### DIFF
--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -202,9 +202,9 @@ def extract_id_from_url(url):
 def extract_id(fields, resource):
     for field_name, field in six.iteritems(fields):
         if field_name == 'id':
-            return encoding.force_text(resource.get(field_name)) if resource.get(field_name) else None
+            return encoding.force_text(resource.get(field_name))
         if field_name == api_settings.URL_FIELD_NAME:
-            return extract_id_from_url(resource.get(field_name)) if resource.get(field_name) else None
+            return extract_id_from_url(resource.get(field_name))
 
 
 def extract_attributes(fields, resource):


### PR DESCRIPTION
Reverts django-json-api/django-rest-framework-json-api#75 as extract_id method is removed in #82