### PR TITLE
'resource_instance' not needed when building resource object

### DIFF
--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -146,12 +146,15 @@ def format_relation_name(value, format_type=None):
 def build_json_resource_obj(fields, resource, resource_instance, resource_name):
     resource_data = [
         ('type', resource_name),
-        ('id', encoding.force_text(resource_instance.pk)),
-        ('attributes', extract_attributes(fields, resource)),
     ]
-    relationships = extract_relationships(fields, resource, resource_instance)
-    if relationships:
-        resource_data.append(('relationships', relationships))
+    if resource_instance:
+        resource_data.append(('id', encoding.force_text(resource_instance.pk)))
+
+    resource_data.append(('attributes', extract_attributes(fields, resource)))
+    if resource_instance:
+        relationships = extract_relationships(fields, resource, resource_instance)
+        if relationships:
+            resource_data.append(('relationships', relationships))
     # Add 'self' link if field is present and valid
     if api_settings.URL_FIELD_NAME in resource and \
             isinstance(fields[api_settings.URL_FIELD_NAME], RelatedField):


### PR DESCRIPTION
I have
```
class LanguageSerializer(serializers.HyperlinkedModelSerializer):
    class Meta:
        model = Language
        fields = ('id', 'url', 'name')

class LanguageViewSet(viewsets.ModelViewSet):
    queryset = Language.objects.all()
    serializer_class = serializers.LanguageSerializer
```

Using DRF browsable api with rest_framework_json_api JSONRenderer throws exception when navigate to localhost:8000/api/languages/:
```
File "python_venv/lib/python3.4/site-packages/django/core/handlers/base.py", line 164, in get_response
    response = response.render()
  File "python_venv/lib/python3.4/site-packages/django/template/response.py", line 158, in render
    self.content = self.rendered_content
  File "python_venv/lib/python3.4/site-packages/rest_framework/response.py", line 71, in rendered_content
    ret = renderer.render(self.data, media_type, context)
  File "python_venv/lib/python3.4/site-packages/rest_framework/renderers.py", line 669, in render
    context = self.get_context(data, accepted_media_type, renderer_context)
  File "python_venv/lib/python3.4/site-packages/rest_framework/renderers.py", line 613, in get_context
    raw_data_post_form = self.get_raw_data_form(data, view, 'POST', request)
  File "python_venv/lib/python3.4/site-packages/rest_framework/renderers.py", line 561, in get_raw_data_form
    content = renderer.render(serializer.data, accepted, context)
  File "python_venv/src/django-rest-framework-json-api/rest_framework_json_api/renderers.py", line 85, in render
    json_api_data = utils.build_json_resource_obj(fields, data, resource_instance, resource_name)
  File "python_venv/src/django-rest-framework-json-api/rest_framework_json_api/utils.py", line 149, in build_json_resource_obj
    ('id', encoding.force_text(resource_instance.pk)),
AttributeError: 'NoneType' object has no attribute 'pk'
```

It's because DRF browsable emulates POST create and don't provide resource_instance which JSONRenderer expects.

This commit fixes it.
