### PR TITLE
Fix crash with serializers that have fields which do not exist on the…

### DIFF
--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -228,11 +228,12 @@ def extract_relationships(fields, resource, resource_instance):
         if not isinstance(field, (RelatedField, ManyRelatedField, BaseSerializer)):
             continue
 
-        relation_type = get_related_resource_type(field)
         try:
             relation_instance_or_manager = getattr(resource_instance, field_name)
         except AttributeError: # Skip fields defined on the serializer that don't correspond to a field on the model
             continue
+
+        relation_type = get_related_resource_type(field)
 
         if isinstance(field, HyperlinkedIdentityField):
             # special case for HyperlinkedIdentityField

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -229,7 +229,10 @@ def extract_relationships(fields, resource, resource_instance):
             continue
 
         relation_type = get_related_resource_type(field)
-        relation_instance_or_manager = getattr(resource_instance, field_name)
+        try:
+            relation_instance_or_manager = getattr(resource_instance, field_name)
+        except AttributeError: # Skip fields defined on the serializer that don't correspond to a field on the model
+            continue
 
         if isinstance(field, HyperlinkedIdentityField):
             # special case for HyperlinkedIdentityField


### PR DESCRIPTION
… model.

Change utils.extract_relationships to skip fields defined on the serializer
that don't correspond to a field on the model.