### PR TITLE
Sparse Fieldsets support

### DIFF
--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -1,6 +1,5 @@
 import json
 
-from rest_framework.exceptions import ValidationError
 from rest_framework.fields import MISSING_ERROR_MESSAGE
 from rest_framework.relations import *
 from django.utils.translation import ugettext_lazy as _
@@ -8,40 +7,6 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.utils import format_relation_name, Hyperlink, \
     get_resource_type_from_queryset, get_resource_type_from_instance
-
-
-class HyperlinkedRelatedField(HyperlinkedRelatedField):
-    """
-    This field exists for the sole purpose of accepting PKs as well as URLs
-    when data is submitted back to the serializer
-    """
-    default_error_messages = {
-        'required': _('This field is required.'),
-        'no_match': _('Invalid hyperlink - No URL match.'),
-        'incorrect_match': _('Invalid hyperlink - Incorrect URL match.'),
-        'does_not_exist': _('Invalid hyperlink - Object does not exist.'),
-        'incorrect_type': _('Incorrect type. Expected URL string, received {data_type}.'),
-        'pk_does_not_exist': _('Invalid pk "{pk_value}" - object does not exist.'),
-        'incorrect_pk_type': _('Incorrect type. Expected pk value, received {data_type}.'),
-    }
-
-    def __init__(self, **kwargs):
-        self.pk_field = kwargs.pop('pk_field', None)
-        super(HyperlinkedRelatedField, self).__init__(**kwargs)
-
-    def to_internal_value(self, data):
-        try:
-            # Try parsing links first for the browseable API
-            return super(HyperlinkedRelatedField, self).to_internal_value(data)
-        except ValidationError:
-            if self.pk_field is not None:
-                data = self.pk_field.to_internal_value(data)
-            try:
-                return self.get_queryset().get(pk=data)
-            except ObjectDoesNotExist:
-                self.fail('pk_does_not_exist', pk_value=data)
-            except (TypeError, ValueError):
-                self.fail('incorrect_pk_type', data_type=type(data).__name__)
 
 
 class ResourceRelatedField(PrimaryKeyRelatedField):

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -215,7 +215,7 @@ def get_resource_type_from_serializer(serializer):
         # Check the meta class for resource_name
         return serializer.Meta.resource_name
     except AttributeError:
-        # Use the serializer model then then pluralize and format
+        # Use the serializer model then pluralize and format
         return format_relation_name(serializer.Meta.model.__name__)
 
 


### PR DESCRIPTION
* Implemented SparseFieldsetsMixin serializer mixin to enable a client to request that an endpoint return only specific fields in the response on a per-type basis by including a fields[TYPE] parameter.
  Spec [Here](http://jsonapi.org/format/#fetching-sparse-fieldsets)