### PR TITLE
Small change to ResourceIdentifierObjectSerializer

### DIFF
--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -13,8 +13,10 @@ class ResourceIdentifierObjectSerializer(BaseSerializer):
         'incorrect_type': _('Incorrect type. Expected pk value, received {data_type}.'),
     }
 
+    model_class = None
+
     def __init__(self, *args, **kwargs):
-        self.model_class = kwargs.pop('model_class', None)
+        self.model_class = kwargs.pop('model_class', self.model_class)
         if 'instance' not in kwargs and not self.model_class:
             raise RuntimeError('ResourceIdentifierObjectsSerializer must be initialized with a model class.')
         super(ResourceIdentifierObjectSerializer, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Allows `model_class` to be optionally defined as a class attribute.
When defined as a class attribute, `model class` may still be
overwritten on instantiation via kwarg.