### PR TITLE
included_serializers may be specified with strings

### DIFF
--- a/example/serializers.py
+++ b/example/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from example.models import Blog, Entry, Author
+from example.models import Blog, Entry, Author, Comment
 
 
 class BlogSerializer(serializers.ModelSerializer):
@@ -21,3 +21,10 @@ class AuthorSerializer(serializers.ModelSerializer):
     class Meta:
         model = Author
         fields = ('name', 'email',)
+
+
+class CommentSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Comment
+        fields = ('entry', 'body', 'author',)

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -6,7 +6,6 @@ import inflection
 from django.conf import settings
 from django.utils import six, encoding
 from django.utils.translation import ugettext_lazy as _
-from django.utils.module_loading import import_string
 from rest_framework.compat import OrderedDict
 from rest_framework.serializers import BaseSerializer, ListSerializer, ModelSerializer
 from rest_framework.relations import RelatedField, HyperlinkedRelatedField, PrimaryKeyRelatedField, \
@@ -23,6 +22,12 @@ try:
     from rest_framework_nested.relations import HyperlinkedRouterField
 except ImportError:
     HyperlinkedRouterField = type(None)
+
+import django
+if django.VERSION < (1, 7):
+    from django.utils.module_loading import import_by_path as import_class_from_dotted_path
+else:
+    from django.utils.module_loading import import_string as import_class_from_dotted_path
 
 
 def get_resource_name(context):
@@ -478,7 +483,7 @@ def get_included_serializers(serializer):
             if value == 'self':
                 included_serializers[name] = serializer if isinstance(serializer, type) else serializer.__class__
             else:
-                included_serializers[name] = import_string(value)
+                included_serializers[name] = import_class_from_dotted_path(value)
 
     return included_serializers
 

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -1,10 +1,12 @@
 """
 Utils.
 """
+import copy
 import inflection
 from django.conf import settings
 from django.utils import six, encoding
 from django.utils.translation import ugettext_lazy as _
+from django.utils.module_loading import import_string
 from rest_framework.compat import OrderedDict
 from rest_framework.serializers import BaseSerializer, ListSerializer, ModelSerializer
 from rest_framework.relations import RelatedField, HyperlinkedRelatedField, PrimaryKeyRelatedField, \
@@ -395,12 +397,7 @@ def extract_included(fields, resource, resource_instance, included_resources):
 
     current_serializer = fields.serializer
     context = current_serializer.context
-    included_serializers = getattr(fields.serializer, 'included_serializers', None)
-
-    included_serializers = {
-        key: current_serializer.__class__ if serializer == 'self' else serializer
-        for key, serializer in included_serializers.items()
-        } if included_serializers else dict()
+    included_serializers = get_included_serializers(current_serializer)
 
     for field_name, field in six.iteritems(fields):
         # Skip URL field
@@ -471,6 +468,19 @@ def extract_included(fields, resource, resource_instance, included_resources):
                 )
 
     return format_keys(included_data)
+
+
+def get_included_serializers(serializer):
+    included_serializers = copy.copy(getattr(serializer, 'included_serializers', dict()))
+
+    for name, value in six.iteritems(included_serializers):
+        if not isinstance(value, type):
+            if value == 'self':
+                included_serializers[name] = serializer if isinstance(serializer, type) else serializer.__class__
+            else:
+                included_serializers[name] = import_string(value)
+
+    return included_serializers
 
 
 class Hyperlink(six.text_type):


### PR DESCRIPTION
in the included_serializers class attribute, classes may be specified as a
string containing the absolute python path for the desired class. Thus, the
values in included_serializers may be a class, a string with the python path
of the desired class, or 'self' to specify the class of the current serializer.

for example:

```python
from rest_framework_json_api import serializers
from rest_framework_json_api.relations import ResourceRelatedField

from myapp.models import Thing
from anotherapp.serializers import CategorySerializer

class ThingSerializer(serializers.HyperlinkedModelSerializer):
    class Meta:
        model = Thing
        serializer_related_field = ResourceRelatedField

    included_serializers = {
        'category': CategorySerializer,
        'accessories': 'myapp.serializers.AccessorySerializer',
        'related_things': 'self'  # ThingSerializer
    }
```