### PR TITLE
In OPTIONS responses, indicate include support

### DIFF
--- a/rest_framework_json_api/metadata.py
+++ b/rest_framework_json_api/metadata.py
@@ -131,4 +131,7 @@ class JSONAPIMetadata(SimpleMetadata):
                 for choice_value, choice_name in field.choices.items()
             ]
 
+        if hasattr(serializer, 'included_serializers') and 'relationship_resource' in field_info:
+            field_info['allows_include'] = field.field_name in serializer.included_serializers
+
         return field_info


### PR DESCRIPTION
In the body of responses to OPTIONS requests, add an attribute
'allows_include' to related fields indicating whether the endpoint
supports including this resource via the include parameter.