### PR TITLE
Fix the inclusion of relations

### DIFF
--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -413,14 +413,13 @@ def extract_included(fields, resource, resource_instance, included_resources):
         if not isinstance(field, (RelatedField, ManyRelatedField, BaseSerializer)):
             continue
 
-        try:
-            included_resources.remove(field_name)
-            new_included_resources = [key.replace('%s.' % field_name, '', 1) for key in included_resources]
-            relation_instance_or_manager = getattr(resource_instance, field_name)
-            serializer_data = resource.get(field_name)
-        except ValueError:
+        if field_name not in included_resources:
             # Skip fields not in requested included resources
             continue
+        
+        new_included_resources = [key.replace('%s.' % field_name, '', 1) for key in included_resources]
+        relation_instance_or_manager = getattr(resource_instance, field_name)
+        serializer_data = resource.get(field_name)
 
         if isinstance(field, ManyRelatedField):
             serializer_class = included_serializers.get(field_name)


### PR DESCRIPTION
When getting a list and including data from the models in the list, only
the related data of the first model in the list was included

Explanation:
Let's assume a Model `M` that has a foreign key `type` referencing `Type`. Now we get a list of `M` which have different types and include the types (?include=type), only the `Type` of the first reference will be included, because of line 417.