### PR TITLE
Accessing by index on Model.objects.all() produces weird behavior

### DIFF
--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -366,7 +366,7 @@ def extract_relationships(fields, resource, resource_instance):
             relation_data = list()
 
             serializer_data = resource.get(field_name)
-            resource_instance_queryset = relation_instance_or_manager.all()
+            resource_instance_queryset = list(relation_instance_or_manager.all())
             if isinstance(serializer_data, list):
                 for position in range(len(serializer_data)):
                     nested_resource_instance = resource_instance_queryset[position]
@@ -438,7 +438,7 @@ def extract_included(fields, resource, resource_instance, included_resources):
             serializer = field.child
             model = serializer.Meta.model
             relation_type = format_relation_name(model.__name__)
-            relation_queryset = relation_instance_or_manager.all()
+            relation_queryset = list(relation_instance_or_manager.all())
 
             # Get the serializer fields
             serializer_fields = get_serializer_fields(serializer)


### PR DESCRIPTION
Namely what should be a list of records like [1, 2, 3] becomes
[1, 1, 2]. The solution is to cast to a list first.

I've verified the fix with tests in my private project and I plan to write a test for this before it's merged. If someone needs it in the meantime here it is.