### PR TITLE
start testing on Django 1.9a1 and get tests passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,7 @@ env:
   - TOXENV=py33-django18-drf32
   - TOXENV=py34-django18-drf31
   - TOXENV=py34-django18-drf32
+  - TOXENV=py27-django19-drf31
+  - TOXENV=py27-django19-drf32
+  - TOXENV=py34-django19-drf31
+  - TOXENV=py34-django19-drf32

--- a/rest_framework_json_api/metadata.py
+++ b/rest_framework_json_api/metadata.py
@@ -43,10 +43,9 @@ class JSONAPIMetadata(SimpleMetadata):
     })
 
     relation_type_lookup = ClassLookupDict({
-        related.ManyRelatedObjectsDescriptor: 'ManyToMany',
-        related.ReverseManyRelatedObjectsDescriptor: 'ManyToMany',
-        related.ForeignRelatedObjectsDescriptor: 'OneToMany',
-        related.ReverseSingleRelatedObjectDescriptor: 'ManyToOne',
+        related.ManyToManyDescriptor: 'ManyToMany',
+        related.ReverseManyToOneDescriptor: 'OneToMany',
+        related.ForwardManyToOneDescriptor: 'ManyToOne',
     })
 
     def determine_metadata(self, request, view):

--- a/rest_framework_json_api/metadata.py
+++ b/rest_framework_json_api/metadata.py
@@ -45,8 +45,8 @@ class JSONAPIMetadata(SimpleMetadata):
     try:
         relation_type_lookup = ClassLookupDict({
             related.ManyToManyDescriptor: 'ManyToMany',
-            related.ReverseManyToOneDescriptor: 'ManyToOne',
-            related.ForwardManyToOneDescriptor: 'OneToMany',
+            related.ReverseManyToOneDescriptor: 'OneToMany',
+            related.ForwardManyToOneDescriptor: 'ManyToOne',
         })
     except AttributeError:
         relation_type_lookup = ClassLookupDict({

--- a/rest_framework_json_api/metadata.py
+++ b/rest_framework_json_api/metadata.py
@@ -42,11 +42,19 @@ class JSONAPIMetadata(SimpleMetadata):
         serializers.Serializer: 'Serializer',
     })
 
-    relation_type_lookup = ClassLookupDict({
-        related.ManyToManyDescriptor: 'ManyToMany',
-        related.ReverseManyToOneDescriptor: 'OneToMany',
-        related.ForwardManyToOneDescriptor: 'ManyToOne',
-    })
+    try:
+        relation_type_lookup = ClassLookupDict({
+            related.ManyToManyDescriptor: 'ManyToMany',
+            related.ReverseManyToOneDescriptor: 'ManyToOne',
+            related.ForwardManyToOneDescriptor: 'OneToMany',
+        })
+    except AttributeError:
+        relation_type_lookup = ClassLookupDict({
+            related.ManyRelatedObjectsDescriptor: 'ManyToMany',
+            related.ReverseManyRelatedObjectsDescriptor: 'ManyToMany',
+            related.ForeignRelatedObjectsDescriptor: 'OneToMany',
+            related.ReverseSingleRelatedObjectDescriptor: 'ManyToOne',
+        })
 
     def determine_metadata(self, request, view):
         metadata = OrderedDict()

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -1,3 +1,4 @@
+import django
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
 from django.db.models import Model
@@ -85,7 +86,12 @@ class RelationshipView(generics.GenericAPIView):
             serializer = self.get_serializer(data=request.data, model_class=related_model_class, many=True)
             serializer.is_valid(raise_exception=True)
             related_instance_or_manager.all().delete()
-            related_instance_or_manager.add(*serializer.validated_data)
+            # have to set bulk to False since data isn't saved yet
+            if django.VERSION >= (1, 9):
+                related_instance_or_manager.add(*serializer.validated_data,
+                                                bulk=False)
+            else:
+                related_instance_or_manager.add(*serializer.validated_data)
         else:
             related_model_class = related_instance_or_manager.__class__
             serializer = self.get_serializer(data=request.data, model_class=related_model_class)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{27,32,33}-django16-drf{31,32},
     py{27,32,33,34}-django17-drf{31,32},
     py{27,32,33,34}-django18-drf{31,32},
-    py{27,33,34,35}-django19-drf{31,32},
+    py{27,34}-django19-drf{31,32},
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,14 @@ envlist =
     py{27,32,33}-django16-drf{31,32},
     py{27,32,33,34}-django17-drf{31,32},
     py{27,32,33,34}-django18-drf{31,32},
+    py{27,33,34,35}-django19-drf{31,32},
 
 [testenv]
 deps =
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
+    django19: Django>=1.9a1
     drf31: djangorestframework>=3.1,<3.2
     drf32: djangorestframework>=3.2
     -r{toxinidir}/requirements-development.txt


### PR DESCRIPTION
* added appropriate lines to travis/tox for Django 1.9 on Py2.7 and 3.4 (3.2/3.3 not supported by Django 1.9)
* fixed two issues caused by https://github.com/django/django/commits/stable/1.9.x/django/db/models/fields/related_descriptors.py changes