### PR TITLE
import OrderedDict from the standard library

### DIFF
--- a/rest_framework_json_api/pagination.py
+++ b/rest_framework_json_api/pagination.py
@@ -1,9 +1,9 @@
 """
 Pagination fields
 """
+from collections import OrderedDict
 from rest_framework import serializers
 from rest_framework.views import Response
-from rest_framework.compat import OrderedDict
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.templatetags.rest_framework import replace_query_param
 

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -4,10 +4,10 @@ Utils.
 import copy
 
 import inflection
+from collections import OrderedDict
 from django.conf import settings
 from django.utils import six, encoding
 from django.utils.translation import ugettext_lazy as _
-from rest_framework.compat import OrderedDict
 from rest_framework.serializers import BaseSerializer, ListSerializer, ModelSerializer
 from rest_framework.relations import RelatedField, HyperlinkedRelatedField, PrimaryKeyRelatedField, \
     HyperlinkedIdentityField

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import django
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch
@@ -12,7 +13,7 @@ from rest_framework.serializers import Serializer
 
 from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.serializers import ResourceIdentifierObjectSerializer
-from rest_framework_json_api.utils import format_relation_name, get_resource_type_from_instance, OrderedDict, Hyperlink
+from rest_framework_json_api.utils import format_relation_name, get_resource_type_from_instance, Hyperlink
 
 
 class RelationshipView(generics.GenericAPIView):


### PR DESCRIPTION
OrderedDict has been removed from rest_framework.compat upstream,
because it is no longer necessary now that python 2.6 is unsupported