### PR TITLE
Added the ability to specify a resource_name on Models

### DIFF
--- a/example/models.py
+++ b/example/models.py
@@ -35,18 +35,6 @@ class Author(BaseModel):
 
 
 @python_2_unicode_compatible
-class RenamedAuthor(Author):
-    class Meta:
-        proxy = True
-
-    class JSONAPIMeta:
-        resource_name = "super-author"
-
-    def __str__(self):
-        return self.name
-
-
-@python_2_unicode_compatible
 class Entry(BaseModel):
     blog = models.ForeignKey(Blog)
     headline = models.CharField(max_length=255)

--- a/example/models.py
+++ b/example/models.py
@@ -35,6 +35,18 @@ class Author(BaseModel):
 
 
 @python_2_unicode_compatible
+class RenamedAuthor(Author):
+    class Meta:
+        proxy = True
+
+    class JSONAPIMeta:
+        resource_name = "super-author"
+
+    def __str__(self):
+        return self.name
+
+
+@python_2_unicode_compatible
 class Entry(BaseModel):
     blog = models.ForeignKey(Blog)
     headline = models.CharField(max_length=255)

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework_json_api import serializers, relations
-from example.models import Blog, Entry, Author, Comment
+from example.models import Blog, Entry, Author, Comment, RenamedAuthor
 
 
 class BlogSerializer(serializers.ModelSerializer):
@@ -42,6 +42,13 @@ class AuthorSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Author
+        fields = ('name', 'email',)
+
+
+class RenamedAuthorSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = RenamedAuthor
         fields = ('name', 'email',)
 
 

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework_json_api import serializers, relations
-from example.models import Blog, Entry, Author, Comment, RenamedAuthor
+from example.models import Blog, Entry, Author, Comment
 
 
 class BlogSerializer(serializers.ModelSerializer):
@@ -35,20 +35,13 @@ class EntrySerializer(serializers.ModelSerializer):
     class Meta:
         model = Entry
         fields = ('blog', 'headline', 'body_text', 'pub_date', 'mod_date',
-                'authors', 'comments', 'suggested',)
+                  'authors', 'comments', 'suggested',)
 
 
 class AuthorSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Author
-        fields = ('name', 'email',)
-
-
-class RenamedAuthorSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = RenamedAuthor
         fields = ('name', 'email',)
 
 

--- a/example/tests/integration/test_model_resource_name.py
+++ b/example/tests/integration/test_model_resource_name.py
@@ -1,0 +1,13 @@
+import pytest
+from django.core.urlresolvers import reverse
+
+from example.tests.utils import load_json
+
+pytestmark = pytest.mark.django_db
+
+
+def test_model_resource_name_on_list(single_entry, client):
+    response = client.get(reverse("renamed-authors-list"))
+    data = load_json(response.content)['data']
+    # name should be super-author instead of model name RenamedAuthor
+    assert [x.get('type') for x in data] == ['super-author'], 'List included types are incorrect'

--- a/example/tests/integration/test_model_resource_name.py
+++ b/example/tests/integration/test_model_resource_name.py
@@ -8,20 +8,27 @@ from example import models, serializers
 pytestmark = pytest.mark.django_db
 
 
-def test_model_resource_name_on_list(single_entry, client):
-    response = client.get(reverse("renamed-authors-list"))
+class _PatchedModel:
+    class JSONAPIMeta:
+        resource_name = "resource_name_from_JSONAPIMeta"
+
+
+def test_match_model_resource_name_on_list(single_entry, client):
+    models.Comment.__bases__ += (_PatchedModel,)
+    response = client.get(reverse("comment-list"))
     data = load_json(response.content)['data']
     # name should be super-author instead of model name RenamedAuthor
-    assert [x.get('type') for x in data] == ['super-author'], 'List included types are incorrect'
+    assert [x.get('type') for x in data] == ['resource_name_from_JSONAPIMeta'], 'List included types are incorrect'
+
 
 @pytest.mark.usefixtures("single_entry")
 class ResourceNameConsistencyTest(APITestCase):
-    
+
     def test_type_match_on_included_and_inline_base(self):
         self._check_relationship_and_included_comment_type_are_the_same(reverse("entry-list"))
 
     def test_type_match_on_included_and_inline_with_JSONAPIMeta(self):
-        models.Comment.__bases__ += (self._PatchedModel,)
+        models.Comment.__bases__ += (_PatchedModel,)
 
         self._check_relationship_and_included_comment_type_are_the_same(reverse("entry-list"))
 
@@ -31,7 +38,7 @@ class ResourceNameConsistencyTest(APITestCase):
         self._check_relationship_and_included_comment_type_are_the_same(reverse("entry-list"))
 
     def test_type_match_on_included_and_inline_with_serializer_resource_name_and_JSONAPIMeta(self):
-        models.Comment.__bases__ += (self._PatchedModel,)
+        models.Comment.__bases__ += (_PatchedModel,)
         serializers.CommentSerializer.Meta.resource_name = "resource_name_from_serializer"
 
         self._check_relationship_and_included_comment_type_are_the_same(reverse("entry-list"))
@@ -45,12 +52,12 @@ class ResourceNameConsistencyTest(APITestCase):
         self._check_resource_and_relationship_comment_type_match()
 
     def test_resource_and_relationship_type_match_with_JSONAPIMeta(self):
-        models.Comment.__bases__ += (self._PatchedModel,)
+        models.Comment.__bases__ += (_PatchedModel,)
 
         self._check_resource_and_relationship_comment_type_match()
 
     def test_resource_and_relationship_type_match_with_serializer_resource_name_and_JSONAPIMeta(self):
-        models.Comment.__bases__ += (self._PatchedModel,)
+        models.Comment.__bases__ += (_PatchedModel,)
         serializers.CommentSerializer.Meta.resource_name = "resource_name_from_serializer"
 
         self._check_resource_and_relationship_comment_type_match()
@@ -81,9 +88,3 @@ class ResourceNameConsistencyTest(APITestCase):
             delattr(serializers.CommentSerializer.Meta, "resource_name")
         except AttributeError:
             pass
-
-    class _PatchedModel:
-
-        class JSONAPIMeta:
-            resource_name = "resource_name_from_JSONAPIMeta"
-            

--- a/example/tests/integration/test_model_resource_name.py
+++ b/example/tests/integration/test_model_resource_name.py
@@ -3,7 +3,6 @@ from django.core.urlresolvers import reverse
 
 from example.tests.utils import load_json
 
-from rest_framework.test import APITestCase
 from example import models, serializers, views
 pytestmark = pytest.mark.django_db
 
@@ -13,46 +12,69 @@ class _PatchedModel:
         resource_name = "resource_name_from_JSONAPIMeta"
 
 
+def _check_resource_and_relationship_comment_type_match(django_client):
+    entry_response = django_client.get(reverse("entry-list"))
+    comment_response = django_client.get(reverse("comment-list"))
+
+    comment_resource_type = load_json(comment_response.content).get('data')[0].get('type')
+    comment_relationship_type = load_json(entry_response.content).get(
+        'data')[0].get('relationships').get('comments').get('data')[0].get('type')
+
+    assert comment_resource_type == comment_relationship_type, "The resource type seen in the relationships and head resource do not match"
+
+
+def _check_relationship_and_included_comment_type_are_the_same(django_client, url):
+    response = django_client.get(url + "?include=comments")
+    data = load_json(response.content).get('data')[0]
+    comment = load_json(response.content).get('included')[0]
+
+    comment_relationship_type = data.get('relationships').get('comments').get('data')[0].get('type')
+    comment_included_type = comment.get('type')
+
+    assert comment_relationship_type == comment_included_type, "The resource type seen in the relationships and included do not match"
+
+
 @pytest.mark.usefixtures("single_entry")
-class ModelResourceNameTests(APITestCase):
-    def test_model_resource_name_on_list(self):
+class TestModelResourceName:
+
+    def test_model_resource_name_on_list(self, client):
         models.Comment.__bases__ += (_PatchedModel,)
-        response = self.client.get(reverse("comment-list"))
+        response = client.get(reverse("comment-list"))
         data = load_json(response.content)['data'][0]
         # name should be super-author instead of model name RenamedAuthor
         assert (data.get('type') == 'resource_name_from_JSONAPIMeta'), (
             'resource_name from model incorrect on list')
 
     # Precedence tests
-    def test_resource_name_precendence(self):
+    def test_resource_name_precendence(self, client):
         # default
-        response = self.client.get(reverse("comment-list"))
+        response = client.get(reverse("comment-list"))
         data = load_json(response.content)['data'][0]
         assert (data.get('type') == 'comments'), (
             'resource_name from model incorrect on list')
 
         # model > default
         models.Comment.__bases__ += (_PatchedModel,)
-        response = self.client.get(reverse("comment-list"))
+        response = client.get(reverse("comment-list"))
         data = load_json(response.content)['data'][0]
         assert (data.get('type') == 'resource_name_from_JSONAPIMeta'), (
             'resource_name from model incorrect on list')
 
         # serializer > model
         serializers.CommentSerializer.Meta.resource_name = "resource_name_from_serializer"
-        response = self.client.get(reverse("comment-list"))
+        response = client.get(reverse("comment-list"))
         data = load_json(response.content)['data'][0]
         assert (data.get('type') == 'resource_name_from_serializer'), (
             'resource_name from serializer incorrect on list')
 
         # view > serializer > model
         views.CommentViewSet.resource_name = 'resource_name_from_view'
-        response = self.client.get(reverse("comment-list"))
+        response = client.get(reverse("comment-list"))
         data = load_json(response.content)['data'][0]
         assert (data.get('type') == 'resource_name_from_view'), (
             'resource_name from view incorrect on list')
 
-    def tearDown(self):
+    def teardown_method(self, method):
         models.Comment.__bases__ = (models.Comment.__bases__[0],)
         try:
             delattr(serializers.CommentSerializer.Meta, "resource_name")
@@ -65,69 +87,49 @@ class ModelResourceNameTests(APITestCase):
 
 
 @pytest.mark.usefixtures("single_entry")
-class ResourceNameConsistencyTest(APITestCase):
+class TestResourceNameConsistency:
 
     # Included rename tests
-    def test_type_match_on_included_and_inline_base(self):
-        self._check_relationship_and_included_comment_type_are_the_same(reverse("entry-list"))
+    def test_type_match_on_included_and_inline_base(self, client):
+        _check_relationship_and_included_comment_type_are_the_same(client, reverse("entry-list"))
 
-    def test_type_match_on_included_and_inline_with_JSONAPIMeta(self):
+    def test_type_match_on_included_and_inline_with_JSONAPIMeta(self, client):
         models.Comment.__bases__ += (_PatchedModel,)
 
-        self._check_relationship_and_included_comment_type_are_the_same(reverse("entry-list"))
+        _check_relationship_and_included_comment_type_are_the_same(client, reverse("entry-list"))
 
-    def test_type_match_on_included_and_inline_with_serializer_resource_name(self):
+    def test_type_match_on_included_and_inline_with_serializer_resource_name(self, client):
         serializers.CommentSerializer.Meta.resource_name = "resource_name_from_serializer"
 
-        self._check_relationship_and_included_comment_type_are_the_same(reverse("entry-list"))
+        _check_relationship_and_included_comment_type_are_the_same(client, reverse("entry-list"))
 
-    def test_type_match_on_included_and_inline_with_serializer_resource_name_and_JSONAPIMeta(self):
+    def test_type_match_on_included_and_inline_with_serializer_resource_name_and_JSONAPIMeta(self, client):
         models.Comment.__bases__ += (_PatchedModel,)
         serializers.CommentSerializer.Meta.resource_name = "resource_name_from_serializer"
 
-        self._check_relationship_and_included_comment_type_are_the_same(reverse("entry-list"))
+        _check_relationship_and_included_comment_type_are_the_same(client, reverse("entry-list"))
 
     # Relation rename tests
-    def test_resource_and_relationship_type_match(self):
-        self._check_resource_and_relationship_comment_type_match()
+    def test_resource_and_relationship_type_match(self, client):
+        _check_resource_and_relationship_comment_type_match(client)
 
-    def test_resource_and_relationship_type_match_with_serializer_resource_name(self):
+    def test_resource_and_relationship_type_match_with_serializer_resource_name(self, client):
         serializers.CommentSerializer.Meta.resource_name = "resource_name_from_serializer"
 
-        self._check_resource_and_relationship_comment_type_match()
+        _check_resource_and_relationship_comment_type_match(client)
 
-    def test_resource_and_relationship_type_match_with_JSONAPIMeta(self):
+    def test_resource_and_relationship_type_match_with_JSONAPIMeta(self, client):
         models.Comment.__bases__ += (_PatchedModel,)
 
-        self._check_resource_and_relationship_comment_type_match()
+        _check_resource_and_relationship_comment_type_match(client)
 
-    def test_resource_and_relationship_type_match_with_serializer_resource_name_and_JSONAPIMeta(self):
+    def test_resource_and_relationship_type_match_with_serializer_resource_name_and_JSONAPIMeta(self, client):
         models.Comment.__bases__ += (_PatchedModel,)
         serializers.CommentSerializer.Meta.resource_name = "resource_name_from_serializer"
 
-        self._check_resource_and_relationship_comment_type_match()
+        _check_resource_and_relationship_comment_type_match(client)
 
-    def _check_resource_and_relationship_comment_type_match(self):
-        entry_response = self.client.get(reverse("entry-list"))
-        comment_response = self.client.get(reverse("comment-list"))
-
-        comment_resource_type = load_json(comment_response.content).get('data')[0].get('type')
-        comment_relationship_type = load_json(entry_response.content).get(
-            'data')[0].get('relationships').get('comments').get('data')[0].get('type')
-
-        assert comment_resource_type == comment_relationship_type, "The resource type seen in the relationships and head resource do not match"
-
-    def _check_relationship_and_included_comment_type_are_the_same(self, url):
-        response = self.client.get(url + "?include=comments")
-        data = load_json(response.content).get('data')[0]
-        comment = load_json(response.content).get('included')[0]
-
-        comment_relationship_type = data.get('relationships').get('comments').get('data')[0].get('type')
-        comment_included_type = comment.get('type')
-
-        assert comment_relationship_type == comment_included_type, "The resource type seen in the relationships and included do not match"
-
-    def tearDown(self):
+    def teardown_method(self, method):
         models.Comment.__bases__ = (models.Comment.__bases__[0],)
         try:
             delattr(serializers.CommentSerializer.Meta, "resource_name")

--- a/example/tests/integration/test_model_resource_name.py
+++ b/example/tests/integration/test_model_resource_name.py
@@ -3,6 +3,8 @@ from django.core.urlresolvers import reverse
 
 from example.tests.utils import load_json
 
+from rest_framework.test import APITestCase
+from example import models, serializers
 pytestmark = pytest.mark.django_db
 
 
@@ -11,3 +13,79 @@ def test_model_resource_name_on_list(single_entry, client):
     data = load_json(response.content)['data']
     # name should be super-author instead of model name RenamedAuthor
     assert [x.get('type') for x in data] == ['super-author'], 'List included types are incorrect'
+
+@pytest.mark.usefixtures("single_entry")
+class ResourceNameConsistencyTest(APITestCase):
+    
+    def test_type_match_on_included_and_inline_base(self):
+        self._check_relationship_and_included_comment_type_are_the_same(reverse("entry-list"))
+
+    def test_type_match_on_included_and_inline_with_JSONAPIMeta(self):
+        models.Comment.__bases__ += (self._PatchedModel,)
+
+        self._check_relationship_and_included_comment_type_are_the_same(reverse("entry-list"))
+
+    def test_type_match_on_included_and_inline_with_serializer_resource_name(self):
+        serializers.CommentSerializer.Meta.resource_name = "resource_name_from_serializer"
+
+        self._check_relationship_and_included_comment_type_are_the_same(reverse("entry-list"))
+
+    def test_type_match_on_included_and_inline_with_serializer_resource_name_and_JSONAPIMeta(self):
+        models.Comment.__bases__ += (self._PatchedModel,)
+        serializers.CommentSerializer.Meta.resource_name = "resource_name_from_serializer"
+
+        self._check_relationship_and_included_comment_type_are_the_same(reverse("entry-list"))
+
+    def test_resource_and_relationship_type_match(self):
+        self._check_resource_and_relationship_comment_type_match()
+
+    def test_resource_and_relationship_type_match_with_serializer_resource_name(self):
+        serializers.CommentSerializer.Meta.resource_name = "resource_name_from_serializer"
+
+        self._check_resource_and_relationship_comment_type_match()
+
+    def test_resource_and_relationship_type_match_with_JSONAPIMeta(self):
+        models.Comment.__bases__ += (self._PatchedModel,)
+
+        self._check_resource_and_relationship_comment_type_match()
+
+    def test_resource_and_relationship_type_match_with_serializer_resource_name_and_JSONAPIMeta(self):
+        models.Comment.__bases__ += (self._PatchedModel,)
+        serializers.CommentSerializer.Meta.resource_name = "resource_name_from_serializer"
+
+        self._check_resource_and_relationship_comment_type_match()
+
+    def _check_resource_and_relationship_comment_type_match(self):
+        entry_response = self.client.get(reverse("entry-list"))
+        comment_response = self.client.get(reverse("comment-list"))
+
+        comment_resource_type = load_json(comment_response.content).get('data')[0].get('type')
+        comment_relationship_type = load_json(entry_response.content).get(
+            'data')[0].get('relationships').get('comments').get('data')[0].get('type')
+
+        assert comment_resource_type == comment_relationship_type, "The resource type seen in the relationships and head resource do not match"
+
+    def _check_relationship_and_included_comment_type_are_the_same(self, url):
+        response = self.client.get(url + "?include=comments")
+        data = load_json(response.content).get('data')[0]
+        comment = load_json(response.content).get('included')[0]
+
+        comment_relationship_type = data.get('relationships').get('comments').get('data')[0].get('type')
+        comment_included_type = comment.get('type')
+
+        assert comment_relationship_type == comment_included_type, "The resource type seen in the relationships and included do not match"
+
+    def tearDown(self):
+        models.Comment.__bases__ = (models.Comment.__bases__[0],)
+        try:
+            delattr(serializers.CommentSerializer.Meta, "resource_name")
+        except AttributeError:
+            pass
+
+    class _PatchedModel:
+        class Meta:
+            proxy = True
+
+        class JSONAPIMeta:
+            resource_name = "resource_name_from_JSONAPIMeta"
+            

--- a/example/tests/integration/test_model_resource_name.py
+++ b/example/tests/integration/test_model_resource_name.py
@@ -83,8 +83,6 @@ class ResourceNameConsistencyTest(APITestCase):
             pass
 
     class _PatchedModel:
-        class Meta:
-            proxy = True
 
         class JSONAPIMeta:
             resource_name = "resource_name_from_JSONAPIMeta"

--- a/example/urls_test.py
+++ b/example/urls_test.py
@@ -2,7 +2,7 @@ from django.conf.urls import include, url
 from rest_framework import routers
 
 from example.views import BlogViewSet, EntryViewSet, AuthorViewSet, EntryRelationshipView, BlogRelationshipView, \
-    CommentRelationshipView, AuthorRelationshipView, RenamedAuthorViewSet, CommentViewSet
+    CommentRelationshipView, AuthorRelationshipView, CommentViewSet
 from .api.resources.identity import Identity, GenericIdentity
 
 router = routers.DefaultRouter(trailing_slash=False)
@@ -10,7 +10,6 @@ router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'blogs', BlogViewSet)
 router.register(r'entries', EntryViewSet)
 router.register(r'authors', AuthorViewSet)
-router.register(r'renamed-authors', RenamedAuthorViewSet, base_name='renamed-authors')
 router.register(r'comments', CommentViewSet)
 
 # for the old tests

--- a/example/urls_test.py
+++ b/example/urls_test.py
@@ -2,7 +2,7 @@ from django.conf.urls import include, url
 from rest_framework import routers
 
 from example.views import BlogViewSet, EntryViewSet, AuthorViewSet, EntryRelationshipView, BlogRelationshipView, \
-    CommentRelationshipView, AuthorRelationshipView
+    CommentRelationshipView, AuthorRelationshipView, RenamedAuthorViewSet
 from .api.resources.identity import Identity, GenericIdentity
 
 router = routers.DefaultRouter(trailing_slash=False)
@@ -10,6 +10,7 @@ router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'blogs', BlogViewSet)
 router.register(r'entries', EntryViewSet)
 router.register(r'authors', AuthorViewSet)
+router.register(r'renamed-authors', RenamedAuthorViewSet, base_name='renamed-authors')
 
 # for the old tests
 router.register(r'identities', Identity)

--- a/example/urls_test.py
+++ b/example/urls_test.py
@@ -2,7 +2,7 @@ from django.conf.urls import include, url
 from rest_framework import routers
 
 from example.views import BlogViewSet, EntryViewSet, AuthorViewSet, EntryRelationshipView, BlogRelationshipView, \
-    CommentRelationshipView, AuthorRelationshipView, RenamedAuthorViewSet
+    CommentRelationshipView, AuthorRelationshipView, RenamedAuthorViewSet, CommentViewSet
 from .api.resources.identity import Identity, GenericIdentity
 
 router = routers.DefaultRouter(trailing_slash=False)
@@ -11,6 +11,7 @@ router.register(r'blogs', BlogViewSet)
 router.register(r'entries', EntryViewSet)
 router.register(r'authors', AuthorViewSet)
 router.register(r'renamed-authors', RenamedAuthorViewSet, base_name='renamed-authors')
+router.register(r'comments', CommentViewSet)
 
 # for the old tests
 router.register(r'identities', Identity)

--- a/example/views.py
+++ b/example/views.py
@@ -1,9 +1,8 @@
 from rest_framework import viewsets
 from rest_framework_json_api.views import RelationshipView
-from example.models import Blog, Entry, Author, Comment, RenamedAuthor
+from example.models import Blog, Entry, Author, Comment
 from example.serializers import (
-        BlogSerializer, EntrySerializer, AuthorSerializer, CommentSerializer,
-        RenamedAuthorSerializer)
+        BlogSerializer, EntrySerializer, AuthorSerializer, CommentSerializer)
 
 
 class BlogViewSet(viewsets.ModelViewSet):
@@ -20,11 +19,6 @@ class EntryViewSet(viewsets.ModelViewSet):
 class AuthorViewSet(viewsets.ModelViewSet):
     queryset = Author.objects.all()
     serializer_class = AuthorSerializer
-
-
-class RenamedAuthorViewSet(viewsets.ModelViewSet):
-    queryset = RenamedAuthor.objects.all()
-    serializer_class = RenamedAuthorSerializer
 
 
 class CommentViewSet(viewsets.ModelViewSet):

--- a/example/views.py
+++ b/example/views.py
@@ -1,8 +1,9 @@
 from rest_framework import viewsets
 from rest_framework_json_api.views import RelationshipView
-from example.models import Blog, Entry, Author, Comment
+from example.models import Blog, Entry, Author, Comment, RenamedAuthor
 from example.serializers import (
-        BlogSerializer, EntrySerializer, AuthorSerializer, CommentSerializer)
+        BlogSerializer, EntrySerializer, AuthorSerializer, CommentSerializer,
+        RenamedAuthorSerializer)
 
 
 class BlogViewSet(viewsets.ModelViewSet):
@@ -19,6 +20,11 @@ class EntryViewSet(viewsets.ModelViewSet):
 class AuthorViewSet(viewsets.ModelViewSet):
     queryset = Author.objects.all()
     serializer_class = AuthorSerializer
+
+
+class RenamedAuthorViewSet(viewsets.ModelViewSet):
+    queryset = RenamedAuthor.objects.all()
+    serializer_class = RenamedAuthorSerializer
 
 
 class CommentViewSet(viewsets.ModelViewSet):
@@ -41,4 +47,3 @@ class CommentRelationshipView(RelationshipView):
 class AuthorRelationshipView(RelationshipView):
     queryset = Author.objects.all()
     self_link_view_name = 'author-relationships'
-

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -5,7 +5,7 @@ from rest_framework.relations import *
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework_json_api.exceptions import Conflict
-from rest_framework_json_api.utils import format_relation_name, Hyperlink, \
+from rest_framework_json_api.utils import Hyperlink, \
     get_resource_type_from_queryset, get_resource_type_from_instance
 
 
@@ -127,7 +127,7 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         else:
             pk = value.pk
 
-        return OrderedDict([('type', format_relation_name(get_resource_type_from_instance(value))), ('id', str(pk))])
+        return OrderedDict([('type', get_resource_type_from_instance(value)), ('id', str(pk))])
 
     @property
     def choices(self):

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -6,7 +6,8 @@ from django.utils.translation import ugettext_lazy as _
 
 from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.utils import Hyperlink, \
-    get_resource_type_from_queryset, get_resource_type_from_instance
+    get_resource_type_from_queryset, get_resource_type_from_instance, \
+    get_included_serializers, get_resource_type_from_serializer
 
 
 class ResourceRelatedField(PrimaryKeyRelatedField):
@@ -127,7 +128,18 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         else:
             pk = value.pk
 
-        return OrderedDict([('type', get_resource_type_from_instance(value)), ('id', str(pk))])
+        # check to see if this resource has a different resource_name when
+        # included and use that name
+        resource_type = None
+        root = getattr(self.parent, 'parent', self.parent)
+        field_name = self.field_name if self.field_name else self.parent.field_name
+        if getattr(root, 'included_serializers', None) is not None:
+            includes = get_included_serializers(root)
+            if field_name in includes.keys():
+                resource_type = get_resource_type_from_serializer(includes[field_name])
+
+        resource_type = resource_type if resource_type else get_resource_type_from_instance(value)
+        return OrderedDict([('type', resource_type), ('id', str(pk))])
 
     @property
     def choices(self):

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -276,8 +276,7 @@ class JSONRenderer(renderers.JSONRenderer):
 
             if isinstance(field, ListSerializer):
                 serializer = field.child
-                model = serializer.Meta.model
-                relation_type = utils.format_relation_name(model.__name__)
+                relation_type = utils.get_resource_type_from_serializer(serializer)
                 relation_queryset = list(relation_instance_or_manager.all())
 
                 # Get the serializer fields
@@ -298,15 +297,16 @@ class JSONRenderer(renderers.JSONRenderer):
                         )
 
             if isinstance(field, ModelSerializer):
-                model = field.Meta.model
-                relation_type = utils.format_relation_name(model.__name__)
+
+                relation_type = utils.get_resource_type_from_serializer(field)
 
                 # Get the serializer fields
                 serializer_fields = utils.get_serializer_fields(field)
                 if serializer_data:
                     included_data.append(
-                        JSONRenderer.build_json_resource_obj(serializer_fields, serializer_data, relation_instance_or_manager,
-                                                     relation_type)
+                        JSONRenderer.build_json_resource_obj(
+                            serializer_fields, serializer_data,
+                            relation_instance_or_manager, relation_type)
                     )
                     included_data.extend(
                         JSONRenderer.extract_included(

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -3,8 +3,9 @@ from rest_framework.exceptions import ParseError
 from rest_framework.serializers import *
 
 from rest_framework_json_api.relations import ResourceRelatedField
-from rest_framework_json_api.utils import format_relation_name, get_resource_type_from_instance, \
-    get_resource_type_from_serializer, get_included_serializers
+from rest_framework_json_api.utils import (
+    get_resource_type_from_model, get_resource_type_from_instance,
+    get_resource_type_from_serializer, get_included_serializers)
 
 
 class ResourceIdentifierObjectSerializer(BaseSerializer):
@@ -24,7 +25,7 @@ class ResourceIdentifierObjectSerializer(BaseSerializer):
 
     def to_representation(self, instance):
         return {
-            'type': format_relation_name(get_resource_type_from_instance(instance)),
+            'type': get_resource_type_from_instance(instance),
             'id': str(instance.pk)
         }
 

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -29,7 +29,7 @@ class ResourceIdentifierObjectSerializer(BaseSerializer):
         }
 
     def to_internal_value(self, data):
-        if data['type'] != format_relation_name(self.model_class.__name__):
+        if data['type'] != get_resource_type_from_model(self.model_class):
             self.fail('incorrect_model_type', model_type=self.model_class, received_type=data['type'])
         pk = data['id']
         try:

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -50,7 +50,7 @@ def get_resource_name(context):
             return get_resource_type_from_serializer(serializer)
         except AttributeError:
             try:
-                resource_name = view.model.__name__
+                resource_name = get_resource_type_from_model(view.model)
             except AttributeError:
                 resource_name = view.__class__.__name__
 
@@ -171,7 +171,7 @@ def get_related_resource_type(relation):
             relation_model = parent_model_relation.field.related.model
         else:
             return get_related_resource_type(parent_model_relation)
-    return format_relation_name(relation_model.__name__)
+    return get_resource_type_from_model(relation_model)
 
 
 def get_instance_or_manager_resource_type(resource_instance_or_manager):
@@ -182,25 +182,31 @@ def get_instance_or_manager_resource_type(resource_instance_or_manager):
     pass
 
 
+def get_resource_type_from_model(model):
+    json_api_meta = getattr(model, 'JSONAPIMeta', None)
+    return getattr(
+        json_api_meta,
+        'resource_name',
+        format_relation_name(model.__name__))
+
+
 def get_resource_type_from_queryset(qs):
-    return format_relation_name(qs.model._meta.model.__name__)
+    return get_resource_type_from_model(qs.model)
 
 
 def get_resource_type_from_instance(instance):
-    return format_relation_name(instance._meta.model.__name__)
+    return get_resource_type_from_model(instance._meta.model)
 
 
 def get_resource_type_from_manager(manager):
-    return format_relation_name(manager.model.__name__)
+    return get_resource_type_from_model(manager.model)
 
 
 def get_resource_type_from_serializer(serializer):
-    try:
-        # Check the meta class for resource_name
-        return serializer.Meta.resource_name
-    except AttributeError:
-        # Use the serializer model then pluralize and format
-        return format_relation_name(serializer.Meta.model.__name__)
+    return getattr(
+        serializer.Meta,
+        'resource_name',
+        get_resource_type_from_model(serializer.Meta.model))
 
 
 def get_included_serializers(serializer):

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -12,7 +12,7 @@ from rest_framework.serializers import Serializer
 
 from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.serializers import ResourceIdentifierObjectSerializer
-from rest_framework_json_api.utils import format_relation_name, get_resource_type_from_instance, OrderedDict, Hyperlink
+from rest_framework_json_api.utils import get_resource_type_from_instance, OrderedDict, Hyperlink
 
 
 class RelationshipView(generics.GenericAPIView):
@@ -154,7 +154,7 @@ class RelationshipView(generics.GenericAPIView):
     def get_resource_name(self):
         if not hasattr(self, '_resource_name'):
             instance = getattr(self.get_object(), self.kwargs['related_field'])
-            self._resource_name = format_relation_name(get_resource_type_from_instance(instance))
+            self._resource_name = get_resource_type_from_instance(instance)
         return self._resource_name
 
     def set_resource_name(self, value):


### PR DESCRIPTION
I mentioned this yesterday on issue #74  and figured I would just open a PR to get opinions on this change. 

This would allow a `resource_name` to be specified on the model. This was required in certain cases (relations: [this line](https://github.com/django-json-api/django-rest-framework-json-api/blob/73bc6d57a1321ec4d831e2a78a1b09d1d6573308/rest_framework_json_api/relations.py#L121)) where no serializer or view could have overridden the resource_name. This would allow the `resource_name` of a model to be overridden globally for that model. 

I haven't written any tests yet as I uncovered a lot of places the model `__name__` property is used, hence WIP. 

EDIT:
Test  TODOs:
- [x] Model resource_name used on a relation
- [x] Model resource_name in included document
- [x] Serializer resource_name override over Model resource_name
- [x] View resource_name override over Model resource_name