### PR TITLE
SerializerMethodResourceField

### DIFF
--- a/example/serializers.py
+++ b/example/serializers.py
@@ -26,7 +26,7 @@ class EntrySerializer(serializers.ModelSerializer):
 
     comments = relations.ResourceRelatedField(
             source='comment_set', many=True, read_only=True)
-    suggested = relations.SerializerMethodResourceField(
+    suggested = relations.SerializerMethodResourceRelatedField(
             source='get_suggested', model=Entry, read_only=True)
 
     def get_suggested(self, obj):

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -26,7 +26,7 @@ class EntrySerializer(serializers.ModelSerializer):
 
     comments = relations.ResourceRelatedField(
             source='comment_set', many=True, read_only=True)
-    suggested = relations.ResourceRelatedField(
+    suggested = relations.SerializerMethodResourceField(
             source='get_suggested', model=Entry, read_only=True)
 
     def get_suggested(self, obj):

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -142,7 +142,7 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         ])
 
 
-class SerializerMethodResourceField(ResourceRelatedField):
+class SerializerMethodResourceRelatedField(ResourceRelatedField):
     def get_attribute(self, instance):
         # check for a source fn defined on the serializer instead of the model
         if self.source and hasattr(self.parent, self.source):

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -107,14 +107,6 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
             return_data.update({'related': related_link})
         return return_data
 
-    def get_attribute(self, instance):
-        # check for a source fn defined on the serializer instead of the model
-        if self.source and hasattr(self.parent, self.source):
-            serializer_method = getattr(self.parent, self.source)
-            if hasattr(serializer_method, '__call__'):
-                return serializer_method(instance)
-        return super(ResourceRelatedField, self).get_attribute(instance)
-
     def to_internal_value(self, data):
         if isinstance(data, six.text_type):
             data = json.loads(data)
@@ -149,3 +141,12 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
             for item in queryset
         ])
 
+
+class SerializerMethodResourceField(ResourceRelatedField):
+    def get_attribute(self, instance):
+        # check for a source fn defined on the serializer instead of the model
+        if self.source and hasattr(self.parent, self.source):
+            serializer_method = getattr(self.parent, self.source)
+            if hasattr(serializer_method, '__call__'):
+                return serializer_method(instance)
+        return super(ResourceRelatedField, self).get_attribute(instance)


### PR DESCRIPTION
This refactor separates the dynamic related data feature introduced
in #146 from the regular ResourceRelatedField, instead placing it
in the new SerializerMethodResourceField. As discussed on gitter.