### PR TITLE
When a `pk` was used as a relationship value a json error was thrown

### DIFF
--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -109,7 +109,11 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
 
     def to_internal_value(self, data):
         if isinstance(data, six.text_type):
-            data = json.loads(data)
+            try:
+                data = json.loads(data)
+            except ValueError:
+                # show a useful error if they send a `pk` instead of resource object
+                self.fail('incorrect_type', data_type=type(data).__name__)
         if not isinstance(data, dict):
             self.fail('incorrect_type', data_type=type(data).__name__)
         expected_relation_type = get_resource_type_from_queryset(self.queryset)


### PR DESCRIPTION
For this (incorrect) but natural payload the related field would `json.loads`
the `bar` related attribute:
``` py
{
    "data": {
        "type": "foo",
        "attributes": {
            "bar": "1",
        }
    }
}
```
a json ValueError would be thrown instead of the more helpful
"Expected resource identifier object, received unicode"