### PR TITLE
Fix sparse fieldset RuntimeError under python3.5

### DIFF
--- a/example/tests/integration/test_sparse_fieldsets.py
+++ b/example/tests/integration/test_sparse_fieldsets.py
@@ -1,0 +1,13 @@
+from django.core.urlresolvers import reverse
+
+import pytest
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_sparse_fieldset_ordered_dict_error(multiple_entries, client):
+    base_url = reverse('entry-list')
+    querystring = '?fields[entries]=blog,headline'
+    response = client.get(base_url + querystring)  # RuntimeError: OrderedDict mutated during iteration
+    assert response.status_code == 200  # succeed if we didn't fail due to the above RuntimeError

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -53,7 +53,9 @@ class SparseFieldsetsMixin(object):
                 pass
             else:
                 fieldset = request.query_params.get(param_name).split(',')
-                for field_name, field in self.fields.items():
+                # iterate over a *copy* of self.fields' underlying OrderedDict, because we may modify the
+                # original during the iteration. self.fields is a `rest_framework.utils.serializer_helpers.BindingDict`
+                for field_name, field in self.fields.fields.copy().items():
                     if field_name == api_settings.URL_FIELD_NAME:  # leave self link there
                         continue
                     if field_name not in fieldset:


### PR DESCRIPTION
With Python 3.5, using sparse fieldsets causes a `RuntimeError: OrderedDict mutated during iteration`. 

This patch fixes the bug, in `SparseFieldsetMixin`, by iterating over a copy of the `OrderedDict`, so that the original may be modified in the loop.

The `OrderedDict` in question is the underlying `OrderedDict` of the `BindingDict` returned by the `fields` property on `Serializer`.

If curious, see section [4.10.1](https://docs.python.org/3/library/stdtypes.html#dictionary-view-objects) of the python standard library docs for more information about why this RuntimeError was being thrown in the first place.