### PR TITLE
WIP: Issue #155 - support serializers with custom primary keys

### DIFF
--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -70,4 +70,3 @@ class TestResourceIdentifierObjectSerializer(TestCase):
         self.assertTrue(serializer.is_valid(), msg=serializer.errors)
 
         print(serializer.data)
-

--- a/example/views.py
+++ b/example/views.py
@@ -41,4 +41,3 @@ class CommentRelationshipView(RelationshipView):
 class AuthorRelationshipView(RelationshipView):
     queryset = Author.objects.all()
     self_link_view_name = 'author-relationships'
-

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -105,8 +105,8 @@ class JSONRenderer(renderers.JSONRenderer):
             for position in range(len(serializer_data)):
                 resource = serializer_data[position]  # Get current resource
                 resource_instance = resource_serializer.instance[position]  # Get current instance
-                json_api_data.append(
-                    utils.build_json_resource_obj(fields, resource, resource_instance, resource_name))
+                resource_obj = utils.build_json_resource_obj(fields, resource, resource_instance, resource_name)
+                json_api_data.append(resource_obj)
                 included = utils.extract_included(fields, resource, resource_instance, included_resources)
                 if included:
                     json_api_included.extend(included)


### PR DESCRIPTION
This is a first attempt at adding support for alternative primary keys. This is done by removing any hard-coded 'instance.pk' calls, instead first checking if the PK attributes name is in any serialized output. If it is then we return that instead of the `pk` attribute. This works for the following serializers/viewsets:

``` python
class AuthorSerializer(serializers.ModelSerializer):
    id = serializers.CharField(source='email')

    class Meta:
        model = Author  # has (id, email) fields
        fields = ('id',)

class AuthorViewSet(viewsets.ModelViewSet):
    queryset = Author.objects.all()
    serializer_class = AuthorSerializer

    lookup_field = 'email'
```

This produces the following output:

``` json
 {
      "type": "Author",
      "id": "someemail@gmail.com",
      "attributes": {},
}
```

Works for foreign keys and m2m relationships as well as creating new instances (as far as I can tell). I started to write some tests but quickly got a bit lost, so I thought I would submit this for comments before the weekend and maybe tidy it up on Monday if you think it looks promising.
