### PR TITLE
Update example for usage of relation options

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -192,7 +192,7 @@ Example without pluralization:
                 ...
         },
         "relationships": {
-            "home_towns": {
+            "home_town": {
                 "data": [{
                     "type": "home_town",
                     "id": 3
@@ -215,7 +215,7 @@ When set to pluralize:
                 ...
         },
         "relationships": {
-            "home_towns": {
+            "home_town": {
                 "data": [{
                     "type": "home_towns",
                     "id": 3


### PR DESCRIPTION
From my experience in my app, the pluralization of the relation key happens inside the "data" array, on the value for "type", and not on the outer "home_town" key inside "relationships".

Edit: The behavior I describe above is what the Ember-Data JSONAPIAdapter expects, so the correction is simply related to documentation, not implementation.