### PR TITLE
Relationship deletion

### DIFF
--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -146,20 +146,20 @@ class TestRelationshipView(APITestCase):
         assert response.status_code == 405, response.content.decode()
 
     def test_delete_relationship_overriding_with_none(self):
-        url = '/entries/{}'.format(self.first_entry.id)
+        url = '/comments/{}'.format(self.second_comment.id)
         request_data = {
             'data': {
-                'type': 'posts',
+                'type': 'comments',
                 'relationships': {
-                    'blog': {
+                    'author': {
                         'data': None
                     }
                 }
             }
         }
         response = self.client.patch(url, data=json.dumps(request_data), content_type='application/vnd.api+json')
-        assert response.status_code == 400, response.content.decode()
-        assert response.data[0]['detail'] == 'This field may not be null.'
+        assert response.status_code == 200, response.content.decode()
+        assert response.data['author'] == None
 
     def test_delete_to_many_relationship_with_no_change(self):
         url = '/entries/{}/relationships/comment_set'.format(self.first_entry.id)

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -145,6 +145,22 @@ class TestRelationshipView(APITestCase):
         response = self.client.delete(url, data=json.dumps(request_data), content_type='application/vnd.api+json')
         assert response.status_code == 405, response.content.decode()
 
+    def test_delete_relationship_overriding_with_none(self):
+        url = '/entries/{}'.format(self.first_entry.id)
+        request_data = {
+            'data': {
+                'type': 'posts',
+                'relationships': {
+                    'blog': {
+                        'data': None
+                    }
+                }
+            }
+        }
+        response = self.client.patch(url, data=json.dumps(request_data), content_type='application/vnd.api+json')
+        assert response.status_code == 400, response.content.decode()
+        assert response.data[0]['detail'] == 'This field may not be null.'
+
     def test_delete_to_many_relationship_with_no_change(self):
         url = '/entries/{}/relationships/comment_set'.format(self.first_entry.id)
         request_data = {

--- a/example/urls_test.py
+++ b/example/urls_test.py
@@ -1,7 +1,7 @@
 from django.conf.urls import include, url
 from rest_framework import routers
 
-from example.views import BlogViewSet, EntryViewSet, AuthorViewSet, EntryRelationshipView, BlogRelationshipView, \
+from example.views import BlogViewSet, EntryViewSet, AuthorViewSet, CommentViewSet, EntryRelationshipView, BlogRelationshipView, \
     CommentRelationshipView, AuthorRelationshipView
 from .api.resources.identity import Identity, GenericIdentity
 
@@ -10,6 +10,7 @@ router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'blogs', BlogViewSet)
 router.register(r'entries', EntryViewSet)
 router.register(r'authors', AuthorViewSet)
+router.register(r'comments', CommentViewSet)
 
 # for the old tests
 router.register(r'identities', Identity)

--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -40,7 +40,7 @@ class JSONParser(parsers.JSONParser):
         parsed_relationships = dict()
         for field_name, field_data in relationships.items():
             field_data = field_data.get('data')
-            if isinstance(field_data, dict):
+            if isinstance(field_data, dict) or field_data is None:
                 parsed_relationships[field_name] = field_data
             elif isinstance(field_data, list):
                 parsed_relationships[field_name] = list(relation for relation in field_data)


### PR DESCRIPTION
Allow the deletion of relationships using the `relationships` values of a request, eg:

```JSON
{
  "data": {
     "id": 1,
     "type": "model",
     "attributes": {
       "name": "test-model",
       "number": 1
     },
     "relationships": {
       "other-model": {"data": null}
     }
  }
}
```

See [JSON API specification](http://jsonapi.org/format/#crud-updating-to-one-relationships)

References  #169