### PR TITLE
Included field might not be set

### DIFF
--- a/example/factories/__init__.py
+++ b/example/factories/__init__.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 import factory
 from faker import Factory as FakerFactory
-from example.models import Blog, Author, Entry, Comment
+from example.models import Blog, Author, AuthorBio, Entry, Comment
 
 faker = FakerFactory.create()
 faker.seed(983843)
@@ -21,6 +21,14 @@ class AuthorFactory(factory.django.DjangoModelFactory):
 
     name = factory.LazyAttribute(lambda x: faker.name())
     email = factory.LazyAttribute(lambda x: faker.email())
+
+
+class AuthorBioFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = AuthorBio
+
+    author = factory.SubFactory(AuthorFactory)
+    body = factory.LazyAttribute(lambda x: faker.text())
 
 
 class EntryFactory(factory.django.DjangoModelFactory):

--- a/example/models.py
+++ b/example/models.py
@@ -35,6 +35,15 @@ class Author(BaseModel):
 
 
 @python_2_unicode_compatible
+class AuthorBio(BaseModel):
+    author = models.OneToOneField(Author, related_name='bio')
+    body = models.TextField()
+
+    def __str__(self):
+        return self.author.name
+
+
+@python_2_unicode_compatible
 class Entry(BaseModel):
     blog = models.ForeignKey(Blog)
     headline = models.CharField(max_length=255)

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework_json_api import serializers, relations
-from example.models import Blog, Entry, Author, Comment
+from example.models import Blog, Entry, Author, AuthorBio, Comment
 
 
 class BlogSerializer(serializers.ModelSerializer):
@@ -38,11 +38,21 @@ class EntrySerializer(serializers.ModelSerializer):
                 'authors', 'comments', 'suggested',)
 
 
+class AuthorBioSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = AuthorBio
+        fields = ('author', 'body',)
+
+
 class AuthorSerializer(serializers.ModelSerializer):
+    included_serializers = {
+        'bio': AuthorBioSerializer
+    }
 
     class Meta:
         model = Author
-        fields = ('name', 'email',)
+        fields = ('name', 'email', 'bio')
 
 
 class CommentSerializer(serializers.ModelSerializer):

--- a/example/tests/conftest.py
+++ b/example/tests/conftest.py
@@ -1,10 +1,11 @@
 import pytest
 from pytest_factoryboy import register
 
-from example.factories import BlogFactory, AuthorFactory, EntryFactory, CommentFactory
+from example.factories import BlogFactory, AuthorFactory, AuthorBioFactory, EntryFactory, CommentFactory
 
 register(BlogFactory)
 register(AuthorFactory)
+register(AuthorBioFactory)
 register(EntryFactory)
 register(CommentFactory)
 

--- a/example/tests/integration/test_includes.py
+++ b/example/tests/integration/test_includes.py
@@ -36,3 +36,17 @@ def test_dynamic_related_data_is_included(single_entry, entry_factory, client):
     assert [x.get('type') for x in included] == ['entries'], 'Dynamic included types are incorrect'
     assert len(included) == 1, 'The dynamically included blog entries are of an incorrect count'
 
+
+def test_missing_field_not_included(author_bio_factory, author_factory, client):
+    # First author does not have a bio
+    author = author_factory()
+    response = client.get(reverse('author-detail', args=[author.pk])+'?include=bio')
+    data = load_json(response.content)
+    assert 'included' not in data
+    # Second author does
+    bio = author_bio_factory()
+    response = client.get(reverse('author-detail', args=[bio.author.pk])+'?include=bio')
+    data = load_json(response.content)
+    assert 'included' in data
+    assert len(data['included']) == 1
+    assert data['included'][0]['attributes']['body'] == bio.body

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -257,6 +257,8 @@ class JSONRenderer(renderers.JSONRenderer):
                     # For ManyRelatedFields if `related_name` is not set we need to access `foo_set` from `source`
                     relation_instance_or_manager = getattr(resource_instance, field.child_relation.source)
                 except AttributeError:
+                    if not hasattr(current_serializer, field.source):
+                        continue
                     serializer_method = getattr(current_serializer, field.source)
                     relation_instance_or_manager = serializer_method(resource_instance)
 


### PR DESCRIPTION
I have three models:
 * Account
 * AccountTypeA
 * AccountTypeB

AccountTypeA/AccountTypeB each have a OneToOneField to Account. Account can only be of type A or B, not both. In my AccountSerializer I've included the attributes for both the reversed relationships. I've also included the AccountTypeA/AccountTypeB serializers in included_serializers.

extract_included expects both fields to be present on every account instance when in reality each account will have either the A or B relation. This pull request makes extract_included to ignore missing fields.