### PR TITLE
[FEATURE]: support using get_serializer_class on view

### DIFF
--- a/example/views.py
+++ b/example/views.py
@@ -12,8 +12,10 @@ class BlogViewSet(viewsets.ModelViewSet):
 
 class EntryViewSet(viewsets.ModelViewSet):
     queryset = Entry.objects.all()
-    serializer_class = EntrySerializer
     resource_name = 'posts'
+
+    def get_serializer_class(self):
+        return EntrySerializer
 
 
 class AuthorViewSet(viewsets.ModelViewSet):

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -94,7 +94,7 @@ class IncludedResourcesValidationMixin(object):
                 included_resources = include_resources_param.split(',')
                 for included_field_name in included_resources:
                     included_field_path = included_field_name.split('.')
-                    this_serializer_class = view.serializer_class
+                    this_serializer_class = view.get_serializer_class()
                     # lets validate the current path
                     validate_path(this_serializer_class, included_field_path, included_field_name)
 


### PR DESCRIPTION
Maybe a bit too simplistic.  Wish I had an additional test to add, but then I might be overlapping django rest's tests for the `get_serializer_class` method.  Tests fail if view uses `serializer_class` rather than what is in this commit however.

This should now allow users to specify multiple actions and direct the query to different Serializers depending on the request action.