### PR TITLE
Do not assume multiple queryset evals return in same order

### DIFF
--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -5,6 +5,7 @@ import copy
 from collections import OrderedDict
 
 from django.utils import six, encoding
+from django.db.models.query import QuerySet
 from rest_framework import relations
 from rest_framework import renderers
 from rest_framework.serializers import BaseSerializer, ListSerializer, ModelSerializer
@@ -438,6 +439,17 @@ class JSONRenderer(renderers.JSONRenderer):
             for position in range(len(serializer_data)):
                 resource = serializer_data[position]  # Get current resource
                 resource_instance = resource_serializer.instance[position]  # Get current instance
+
+                # If this is a queryset, ensure that the query is evaluated only once,
+                # and do not assume the ordering of the serializer_data is in the same order,
+                # since queries without an 'order_by' may not return in the same order.  Match
+                # by pk instead.
+                if isinstance(resource_serializer.instance, QuerySet):
+                    pk = resource['id']
+                    resource_instance = filter(lambda item: item.pk == pk,
+                                               list(resource_serializer.instance))[0]
+                else:
+                    resource_instance = resource_serializer.instance[position]  # Get current instance
 
                 json_resource_obj = self.build_json_resource_obj(fields, resource, resource_instance, resource_name)
                 meta = self.extract_meta(resource_serializer, resource)


### PR DESCRIPTION
If a queryset without an order_by runs multiple times and uses an offset, the returned items are not always in the same order. This results in incorrect, missing, or duplicate data in a list view.

This PR checks to see whether the serializer.instance is a queryset. If so, it matches the serializer data to the model by pk. This might potentially be a breaking change if the serializer is a model serializer but does not expose the id field.

This PR also wraps serializer.instance as a list, so that the queryset is not evaluated many times. In other words, `some_queryset[0]` followed by `some_queryset[1]` results in two SQL queries whereas `list(some_queryset)[0]` followed by `list(some_queryset)[1]` is only one.
