### PR TITLE
Fixed get_resource_name in case of non-model backed serializer.

### DIFF
--- a/example/tests/unit/test_utils.py
+++ b/example/tests/unit/test_utils.py
@@ -15,6 +15,11 @@ from rest_framework_json_api.utils import get_included_serializers
 pytestmark = pytest.mark.django_db
 
 
+class NonModelResourceSerializer(serializers.Serializer):
+    class Meta:
+        resource_name = 'users'
+
+
 class ResourceSerializer(serializers.ModelSerializer):
     class Meta:
         fields = ('username',)
@@ -50,6 +55,11 @@ def test_get_resource_name():
 
     view.serializer_class.Meta.resource_name = 'rcustom'
     assert 'rcustom' == utils.get_resource_name(context), 'set on serializer'
+
+    view = GenericAPIView()
+    view.serializer_class = NonModelResourceSerializer
+    context = {'view': view}
+    assert 'users' == utils.get_resource_name(context), 'derived from non-model serializer'
 
 
 def test_format_keys():

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -214,10 +214,10 @@ def get_resource_type_from_manager(manager):
 
 
 def get_resource_type_from_serializer(serializer):
-    return getattr(
-        serializer.Meta,
-        'resource_name',
-        get_resource_type_from_model(serializer.Meta.model))
+    if hasattr(serializer.Meta, 'resource_name'):
+        return serializer.Meta.resource_name
+    else:
+        return get_resource_type_from_model(serializer.Meta.model)
 
 
 def get_included_serializers(serializer):


### PR DESCRIPTION
Fixed get_resource_name in case of non-model backed serializer. Seems that `getattr` evaluates the default regardless of whether the default case is used ([Similar SO Question](http://stackoverflow.com/questions/31443989/python-getattr-with-another-attribute-as-the-default)). For serializers without a `meta.Model` this poses a problem. 

Closes #219 