### PR TITLE
Correct error responses for projects with different DRF-configurations

### DIFF
--- a/example/views.py
+++ b/example/views.py
@@ -4,10 +4,20 @@ from example.models import Blog, Entry, Author, Comment
 from example.serializers import (
     BlogSerializer, EntrySerializer, AuthorSerializer, CommentSerializer)
 
+from rest_framework_json_api.utils import format_drf_errors
+
 
 class BlogViewSet(viewsets.ModelViewSet):
     queryset = Blog.objects.all()
     serializer_class = BlogSerializer
+
+
+class BlogCustomViewSet(viewsets.ModelViewSet):
+    queryset = Blog.objects.all()
+    serializer_class = BlogSerializer
+
+    def handle_exception(self, exc):
+        return format_drf_errors(super(BlogCustomViewSet, self).handle_exception(exc), self.get_exception_handler_context(), exc)
 
 
 class EntryViewSet(viewsets.ModelViewSet):

--- a/example/views.py
+++ b/example/views.py
@@ -1,5 +1,10 @@
 from rest_framework import exceptions
 from rest_framework import viewsets
+import rest_framework.parsers
+import rest_framework.renderers
+import rest_framework_json_api.metadata
+import rest_framework_json_api.parsers
+import rest_framework_json_api.renderers
 from rest_framework_json_api.views import RelationshipView
 from example.models import Blog, Entry, Author, Comment
 from example.serializers import (
@@ -15,16 +20,38 @@ class BlogViewSet(viewsets.ModelViewSet):
     serializer_class = BlogSerializer
 
 
-class BlogCustomViewSet(viewsets.ModelViewSet):
-    queryset = Blog.objects.all()
-    serializer_class = BlogSerializer
+class JsonApiViewSet(viewsets.ModelViewSet):
+    """
+    This is an example on how to configure DRF-jsonapi from
+    within a class. It allows using DRF-jsonapi alongside
+    vanilla DRF API views.
+    """
+    parser_classes = [
+        rest_framework_json_api.parsers.JSONParser,
+        rest_framework.parsers.FormParser,
+        rest_framework.parsers.MultiPartParser,
+    ]
+    renderer_classes = [
+        rest_framework_json_api.renderers.JSONRenderer,
+        rest_framework.renderers.BrowsableAPIRenderer,
+    ]
+    metadata_class = rest_framework_json_api.metadata.JSONAPIMetadata
 
     def handle_exception(self, exc):
         if isinstance(exc, exceptions.ValidationError):
+            # some require that validation errors return 422 status
+            # for example ember-data (isInvalid method on adapter)
             exc.status_code = HTTP_422_UNPROCESSABLE_ENTITY
-        response = super(BlogCustomViewSet, self).handle_exception(exc)
+        # exception handler can't be set on class so you have to
+        # override the error response in this method
+        response = super(JsonApiViewSet, self).handle_exception(exc)
         context = self.get_exception_handler_context()
         return format_drf_errors(response, context, exc)
+
+
+class BlogCustomViewSet(JsonApiViewSet):
+    queryset = Blog.objects.all()
+    serializer_class = BlogSerializer
 
 
 class EntryViewSet(viewsets.ModelViewSet):

--- a/example/views.py
+++ b/example/views.py
@@ -1,3 +1,4 @@
+from rest_framework import exceptions
 from rest_framework import viewsets
 from rest_framework_json_api.views import RelationshipView
 from example.models import Blog, Entry, Author, Comment
@@ -5,6 +6,8 @@ from example.serializers import (
     BlogSerializer, EntrySerializer, AuthorSerializer, CommentSerializer)
 
 from rest_framework_json_api.utils import format_drf_errors
+
+HTTP_422_UNPROCESSABLE_ENTITY = 422
 
 
 class BlogViewSet(viewsets.ModelViewSet):
@@ -17,6 +20,8 @@ class BlogCustomViewSet(viewsets.ModelViewSet):
     serializer_class = BlogSerializer
 
     def handle_exception(self, exc):
+        if isinstance(exc, exceptions.ValidationError):
+            exc.status_code = HTTP_422_UNPROCESSABLE_ENTITY
         return format_drf_errors(super(BlogCustomViewSet, self).handle_exception(exc), self.get_exception_handler_context(), exc)
 
 

--- a/example/views.py
+++ b/example/views.py
@@ -22,7 +22,9 @@ class BlogCustomViewSet(viewsets.ModelViewSet):
     def handle_exception(self, exc):
         if isinstance(exc, exceptions.ValidationError):
             exc.status_code = HTTP_422_UNPROCESSABLE_ENTITY
-        return format_drf_errors(super(BlogCustomViewSet, self).handle_exception(exc), self.get_exception_handler_context(), exc)
+        response = super(BlogCustomViewSet, self).handle_exception(exc)
+        context = self.get_exception_handler_context()
+        return format_drf_errors(response, context, exc)
 
 
 class EntryViewSet(viewsets.ModelViewSet):

--- a/rest_framework_json_api/exceptions.py
+++ b/rest_framework_json_api/exceptions.py
@@ -1,9 +1,7 @@
-import inspect
-from django.utils import six, encoding
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import status, exceptions
 
-from rest_framework_json_api.utils import format_value
+from rest_framework_json_api import utils
 
 
 def exception_handler(exc, context):
@@ -18,63 +16,9 @@ def exception_handler(exc, context):
 
     if not response:
         return response
-
-    errors = []
-    # handle generic errors. ValidationError('test') in a view for example
-    if isinstance(response.data, list):
-        for message in response.data:
-            errors.append({
-                'detail': message,
-                'source': {
-                    'pointer': '/data',
-                },
-                'status': encoding.force_text(response.status_code),
-            })
-    # handle all errors thrown from serializers
-    else:
-        for field, error in response.data.items():
-            field = format_value(field)
-            pointer = '/data/attributes/{}'.format(field)
-            # see if they passed a dictionary to ValidationError manually
-            if isinstance(error, dict):
-                errors.append(error)
-            elif isinstance(error, six.string_types):
-                classes = inspect.getmembers(exceptions, inspect.isclass)
-                # DRF sets the `field` to 'detail' for its own exceptions
-                if isinstance(exc, tuple(x[1] for x in classes)):
-                    pointer = '/data'
-                errors.append({
-                    'detail': error,
-                    'source': {
-                        'pointer': pointer,
-                    },
-                    'status': encoding.force_text(response.status_code),
-                })
-            elif isinstance(error, list):
-                for message in error:
-                    errors.append({
-                        'detail': message,
-                        'source': {
-                            'pointer': pointer,
-                        },
-                        'status': encoding.force_text(response.status_code),
-                    })
-            else:
-                errors.append({
-                    'detail': error,
-                    'source': {
-                        'pointer': pointer,
-                    },
-                    'status': encoding.force_text(response.status_code),
-                })
-
-
-    context['view'].resource_name = 'errors'
-    response.data = errors
-    return response
+    return utils.format_drf_errors(response, context, exc)
 
 
 class Conflict(exceptions.APIException):
     status_code = status.HTTP_409_CONFLICT
     default_detail = _('Conflict.')
-

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -3,13 +3,16 @@ Utils.
 """
 import copy
 from collections import OrderedDict
+import inspect
 
 import inflection
 from django.conf import settings
+from django.utils import encoding
 from django.utils import six
 from django.utils.module_loading import import_string as import_class_from_dotted_path
 from django.utils.translation import ugettext_lazy as _
 from rest_framework.exceptions import APIException
+from rest_framework import exceptions
 
 try:
     from rest_framework.serializers import ManyRelatedField
@@ -249,3 +252,58 @@ class Hyperlink(six.text_type):
         return ret
 
     is_hyperlink = True
+
+
+def format_drf_errors(response, context, exc):
+    errors = []
+    # handle generic errors. ValidationError('test') in a view for example
+    if isinstance(response.data, list):
+        for message in response.data:
+            errors.append({
+                'detail': message,
+                'source': {
+                    'pointer': '/data',
+                },
+                'status': encoding.force_text(response.status_code),
+            })
+    # handle all errors thrown from serializers
+    else:
+        for field, error in response.data.items():
+            field = format_value(field)
+            pointer = '/data/attributes/{}'.format(field)
+            # see if they passed a dictionary to ValidationError manually
+            if isinstance(error, dict):
+                errors.append(error)
+            elif isinstance(error, six.string_types):
+                classes = inspect.getmembers(exceptions, inspect.isclass)
+                # DRF sets the `field` to 'detail' for its own exceptions
+                if isinstance(exc, tuple(x[1] for x in classes)):
+                    pointer = '/data'
+                errors.append({
+                    'detail': error,
+                    'source': {
+                        'pointer': pointer,
+                    },
+                    'status': encoding.force_text(response.status_code),
+                })
+            elif isinstance(error, list):
+                for message in error:
+                    errors.append({
+                        'detail': message,
+                        'source': {
+                            'pointer': pointer,
+                        },
+                        'status': encoding.force_text(response.status_code),
+                    })
+            else:
+                errors.append({
+                    'detail': error,
+                    'source': {
+                        'pointer': pointer,
+                    },
+                    'status': encoding.force_text(response.status_code),
+                })
+
+    context['view'].resource_name = 'errors'
+    response.data = errors
+    return response


### PR DESCRIPTION
This makes it easier to haver DRF-jsonapi alongside normal DRF API. Aside of config you can already set on class, like for example:

```python

class DRFJsonApiConfigurationMixin:
    paginator_class = rest_framework_json_api.pagination.PageNumberPagination
    parser_classes = [
        rest_framework_json_api.parsers.JSONParser,
        rest_framework.parsers.FormParser,
        rest_framework.parsers.MultiPartParser,
    ]
    renderer_classes = [
        rest_framework_json_api.renderers.JSONRenderer,
        rest_framework.renderers.BrowsableAPIRenderer,
    ]
    metadata_class = rest_framework_json_api.metadata.JSONAPIMetadata
    paginate_by = 10
    paginate_by_param = 'page_size'
    max_paginate_by = 100
```

exception handler can't be set that way. To get properly formatted error response the views **handle_exception** must be overridden. The **BlogCustomViewSet** shows how it can be done now. Overwriting error response is likely not the optimal way, bu still it's better than copy-pasting the whole method to just change one line.

Also validation errors should return HTTP 422 response code ( http://jsonapi.org/examples/#error-objects-basics ) so you can set it in that method as well. Things like ember and ember-cp-validations by default expect 422 to show backend validation errors.

The **BlogCustomViewSet** should have its own tests but I couldn't force django to change REST_FRAMEWORK setting to a version with the default error handler, even with override_settings decorator. It likely needs a mock on the self.settings.error_handler in the view or something like that.