### PR TITLE
Fix resource name inconsistency between `included` and `relationships`

### DIFF
--- a/example/tests/integration/test_model_resource_name.py
+++ b/example/tests/integration/test_model_resource_name.py
@@ -103,6 +103,11 @@ class TestResourceNameConsistency:
 
         _check_relationship_and_included_comment_type_are_the_same(client, reverse("entry-list"))
 
+    def test_type_match_on_included_and_inline_without_serializer_resource_name(self, client):
+        serializers.CommentSerializer.Meta.resource_name = None
+
+        _check_relationship_and_included_comment_type_are_the_same(client, reverse("entry-list"))
+
     def test_type_match_on_included_and_inline_with_serializer_resource_name_and_JSONAPIMeta(self, client):
         models.Comment.__bases__ += (_PatchedModel,)
         serializers.CommentSerializer.Meta.resource_name = "resource_name_from_serializer"

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -292,9 +292,13 @@ class JSONRenderer(renderers.JSONRenderer):
                     for position in range(len(serializer_data)):
                         serializer_resource = serializer_data[position]
                         nested_resource_instance = relation_queryset[position]
+                        resource_type = (
+                            relation_type or
+                            utils.get_resource_type_from_instance(nested_resource_instance)
+                        )
                         included_data.append(
                             JSONRenderer.build_json_resource_obj(
-                                serializer_fields, serializer_resource, nested_resource_instance, relation_type
+                                serializer_fields, serializer_resource, nested_resource_instance, resource_type
                             )
                         )
                         included_data.extend(


### PR DESCRIPTION
When setting `resource_name = None`, the related instance's resource
name is used in `relationships`, but `None` is used in `included`.

This is related to
#94
and #124