### PR TITLE
Allow exception handler to be used by normal DRF views

### DIFF
--- a/rest_framework_json_api/exceptions.py
+++ b/rest_framework_json_api/exceptions.py
@@ -1,7 +1,16 @@
+from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import status, exceptions
 
 from rest_framework_json_api import utils
+from rest_framework_json_api import renderers
+
+
+def rendered_with_json_api(view):
+    for renderer_class in getattr(view, 'renderer_classes', []):
+        if issubclass(renderer_class, renderers.JSONRenderer):
+            return True
+    return False
 
 
 def exception_handler(exc, context):
@@ -12,11 +21,26 @@ def exception_handler(exc, context):
     #
     # Also see: https://github.com/django-json-api/django-rest-framework-json-api/issues/158
     from rest_framework.views import exception_handler as drf_exception_handler
-    response = drf_exception_handler(exc, context)
 
+    # Render exception with DRF
+    response = drf_exception_handler(exc, context)
     if not response:
         return response
-    return utils.format_drf_errors(response, context, exc)
+
+    # Use regular DRF format if not rendered by DRF JSON API and not uniform
+    is_json_api_view = rendered_with_json_api(context['view'])
+    is_uniform = getattr(settings, 'JSON_API_UNIFORM_EXCEPTIONS', False)
+    if not is_json_api_view and not is_uniform:
+        return response
+
+    # Convert to DRF JSON API error format
+    response = utils.format_drf_errors(response, context, exc)
+
+    # Add top-level 'errors' object when not rendered by DRF JSON API
+    if not is_json_api_view:
+        response.data = utils.format_errors(response.data)
+
+    return response
 
 
 class Conflict(exceptions.APIException):

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -381,11 +381,8 @@ class JSONRenderer(renderers.JSONRenderer):
         )
 
     def render_errors(self, data, accepted_media_type=None, renderer_context=None):
-        # Get the resource name.
-        if len(data) > 1 and isinstance(data, list):
-            data.sort(key=lambda x: x.get('source', {}).get('pointer', ''))
         return super(JSONRenderer, self).render(
-            {'errors': data}, accepted_media_type, renderer_context
+            utils.format_errors(data), accepted_media_type, renderer_context
         )
 
     def render(self, data, accepted_media_type=None, renderer_context=None):

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -315,4 +315,11 @@ def format_drf_errors(response, context, exc):
 
     context['view'].resource_name = 'errors'
     response.data = errors
+
     return response
+
+
+def format_errors(data):
+    if len(data) > 1 and isinstance(data, list):
+        data.sort(key=lambda x: x.get('source', {}).get('pointer', ''))
+    return {'errors': data}


### PR DESCRIPTION
This fixes #218 and also addresses #214.

If the optional `JSON_API_UNIFORM_EXCEPTIONS` is set to `True`, *all* exceptions will respond with the JSON API format. This is how it used to work, but now for non-JSON-API views, the top-level `errors` object is properly included in the response, fixing #218.

When `JSON_API_UNIFORM_EXCEPTIONS` is `False` (the default), non-JSON-API views will respond with the normal DRF error format, addressing #218 in a way that doesn't require views to manually override `handle_exception` (which is how it was addressed in #222).
