### PR TITLE
Optimize/relationship extraction

### DIFF
--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -86,20 +86,18 @@ class JSONRenderer(renderers.JSONRenderer):
                 continue
 
             source = field.source
-            try:
-                relation_instance_or_manager = getattr(resource_instance, source)
-            except AttributeError:
-                # if the field is not defined on the model then we check the serializer
-                # and if no value is there we skip over the field completely
-                serializer_method = getattr(field.parent, source, None)
-                if serializer_method and hasattr(serializer_method, '__call__'):
-                    relation_instance_or_manager = serializer_method(resource_instance)
-                else:
-                    continue
-
+            serializer_method = getattr(field.parent, source, None)
             relation_type = utils.get_related_resource_type(field)
 
             if isinstance(field, relations.HyperlinkedIdentityField):
+                try:
+                    relation_instance_or_manager = getattr(resource_instance, source)
+                except AttributeError:
+                    if serializer_method and hasattr(serializer_method, '__call__'):
+                        relation_instance_or_manager = serializer_method(resource_instance)
+                    else:
+                        continue
+
                 # special case for HyperlinkedIdentityField
                 relation_data = list()
 
@@ -123,6 +121,14 @@ class JSONRenderer(renderers.JSONRenderer):
                 continue
 
             if isinstance(field, ResourceRelatedField):
+                try:
+                    relation_instance_or_manager = getattr(resource_instance, source)
+                except AttributeError:
+                    if serializer_method and hasattr(serializer_method, '__call__'):
+                        relation_instance_or_manager = serializer_method(resource_instance)
+                    else:
+                        continue
+
                 # special case for ResourceRelatedField
                 relation_data = {
                     'data': resource.get(field_name)
@@ -137,8 +143,15 @@ class JSONRenderer(renderers.JSONRenderer):
                 continue
 
             if isinstance(field, (relations.PrimaryKeyRelatedField, relations.HyperlinkedRelatedField)):
-                relation_id = relation_instance_or_manager.pk if resource.get(field_name) else None
+                try:
+                    relation = getattr(resource_instance, '%s_id' % field.source)
+                except AttributeError:
+                    if serializer_method and hasattr(serializer_method, '__call__'):
+                        relation = serializer_method(resource_instance).pk
+                    else:
+                        continue
 
+                relation_id = relation if resource.get(field_name) else None
                 relation_data = {
                     'data': (
                         OrderedDict([('type', relation_type), ('id', encoding.force_text(relation_id))])
@@ -153,6 +166,13 @@ class JSONRenderer(renderers.JSONRenderer):
                 continue
 
             if isinstance(field, relations.ManyRelatedField):
+                try:
+                    relation_instance_or_manager = getattr(resource_instance, source)
+                except AttributeError:
+                    if serializer_method and hasattr(serializer_method, '__call__'):
+                        relation_instance_or_manager = serializer_method(resource_instance)
+                    else:
+                        continue
 
                 if isinstance(field.child_relation, ResourceRelatedField):
                     # special case for ResourceRelatedField
@@ -193,6 +213,14 @@ class JSONRenderer(renderers.JSONRenderer):
                 continue
 
             if isinstance(field, ListSerializer):
+                try:
+                    relation_instance_or_manager = getattr(resource_instance, source)
+                except AttributeError:
+                    if serializer_method and hasattr(serializer_method, '__call__'):
+                        relation_instance_or_manager = serializer_method(resource_instance)
+                    else:
+                        continue
+
                 relation_data = list()
 
                 serializer_data = resource.get(field_name)
@@ -210,6 +238,14 @@ class JSONRenderer(renderers.JSONRenderer):
                     continue
 
             if isinstance(field, ModelSerializer):
+                try:
+                    relation_instance_or_manager = getattr(resource_instance, source)
+                except AttributeError:
+                    if serializer_method and hasattr(serializer_method, '__call__'):
+                        relation_instance_or_manager = serializer_method(resource_instance)
+                    else:
+                        continue
+
                 relation_model = field.Meta.model
                 relation_type = utils.format_resource_type(relation_model.__name__)
 

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -451,11 +451,7 @@ class JSONRenderer(renderers.JSONRenderer):
         if resource_name == 'errors':
             return self.render_errors(data, accepted_media_type, renderer_context)
 
-        include_resources_param = request.query_params.get('include') if request else None
-        if include_resources_param:
-            included_resources = include_resources_param.split(',')
-        else:
-            included_resources = list()
+        included_resources = utils.get_included_resources(request)
 
         json_api_data = data
         json_api_included = list()

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -89,14 +89,12 @@ class IncludedResourcesValidationMixin(object):
                 validate_path(this_included_serializer, new_included_field_path, path)
 
         if request and view:
-            include_resources_param = request.query_params.get('include') if request else None
-            if include_resources_param:
-                included_resources = include_resources_param.split(',')
-                for included_field_name in included_resources:
-                    included_field_path = included_field_name.split('.')
-                    this_serializer_class = view.get_serializer_class()
-                    # lets validate the current path
-                    validate_path(this_serializer_class, included_field_path, included_field_name)
+            included_resources = utils.get_included_resources(request)
+            for included_field_name in included_resources:
+                included_field_path = included_field_name.split('.')
+                this_serializer_class = view.get_serializer_class()
+                # lets validate the current path
+                validate_path(this_serializer_class, included_field_path, included_field_name)
 
         super(IncludedResourcesValidationMixin, self).__init__(*args, **kwargs)
 

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -232,6 +232,15 @@ def get_resource_type_from_serializer(serializer):
         return get_resource_type_from_model(serializer.Meta.model)
 
 
+def get_included_resources(request):
+    included_args = list()
+    if request:
+        include_resources_param = request.query_params.get('include')
+        if include_resources_param:
+            included_args = include_resources_param.split(',')
+    return included_args
+
+
 def get_included_serializers(serializer):
     included_serializers = copy.copy(getattr(serializer, 'included_serializers', dict()))
 

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -16,17 +16,18 @@ from rest_framework.serializers import Serializer
 
 from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.serializers import ResourceIdentifierObjectSerializer
-from rest_framework_json_api.utils import get_resource_type_from_instance, OrderedDict, Hyperlink
+from rest_framework_json_api.utils import (
+    get_resource_type_from_instance,
+    OrderedDict,
+    Hyperlink,
+    get_included_resources,
+)
 
 
 class ModelViewSet(viewsets.ModelViewSet):
     def get_queryset(self, *args, **kwargs):
         qs = super().get_queryset(*args, **kwargs)
-        include_resources_param = self.request.query_params.get('include') if self.request else None
-        if include_resources_param:
-            included_resources = include_resources_param.split(',')
-        else:
-            included_resources = list()
+        included_resources = get_included_resources(self.request)
         for included in included_resources:
             if not hasattr(qs.model, included):
                 continue


### PR DESCRIPTION
Some options to reduce the number of queries made when using relationships.

Currently the number of db queries made explodes out when either:

- Including just the primary key as a field in a serializer, without actually "including" it
- Actually "including" relationships

without prefetching on the viewset's queryset. For complicated models it can be very expensive to defensively prefetch _everything_ every time, so these changes attempt to only fetch them from the db when needed.