### PR TITLE
Add option to specify default included resources

### DIFF
--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -4,3 +4,4 @@ pytest-django
 pytest-factoryboy
 fake-factory
 tox
+mock

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -415,12 +415,6 @@ class JSONRenderer(renderers.JSONRenderer):
         if resource_name == 'errors':
             return self.render_errors(data, accepted_media_type, renderer_context)
 
-        include_resources_param = request.query_params.get('include') if request else None
-        if include_resources_param:
-            included_resources = include_resources_param.split(',')
-        else:
-            included_resources = list()
-
         json_api_data = data
         json_api_included = list()
         # initialize json_api_meta with pagination meta or an empty dict
@@ -432,6 +426,13 @@ class JSONRenderer(renderers.JSONRenderer):
             serializer_data = data
 
         serializer = getattr(serializer_data, 'serializer', None)
+
+        # Build a list of included resources
+        included_resources = utils.get_default_included_resources_from_serializer(serializer)
+        include_resources_param = request.query_params.get('include') if request else None
+        if include_resources_param:
+            extra = filter(lambda r: r not in included_resources, include_resources_param.split(','))
+            included_resources.extend(extra)
 
         if serializer is not None:
 

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -428,11 +428,11 @@ class JSONRenderer(renderers.JSONRenderer):
         serializer = getattr(serializer_data, 'serializer', None)
 
         # Build a list of included resources
-        included_resources = utils.get_default_included_resources_from_serializer(serializer)
         include_resources_param = request.query_params.get('include') if request else None
         if include_resources_param:
-            extra = filter(lambda r: r not in included_resources, include_resources_param.split(','))
-            included_resources.extend(extra)
+            included_resources = include_resources_param.split(',')
+        else:
+            included_resources = utils.get_default_included_resources_from_serializer(serializer)
 
         if serializer is not None:
 

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -232,6 +232,13 @@ def get_resource_type_from_serializer(serializer):
         return get_resource_type_from_model(serializer.Meta.model)
 
 
+def get_default_included_resources_from_serializer(serializer):
+    try:
+        return list(serializer.JSONAPIMeta.included_resources)
+    except AttributeError:
+        return []
+
+
 def get_included_serializers(serializer):
     included_serializers = copy.copy(getattr(serializer, 'included_serializers', dict()))
 


### PR DESCRIPTION
Let's provide an extra `JSONAPIMeta` configuration option that specifies
**resources** to be listed in the '`included`' section of the response.

These resources shall be included even if they're not explicitly mentioned
in the 'include' request parameter.