### PR TITLE
Let serializers have empty field lists

### DIFF
--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -77,7 +77,7 @@ def get_serializer_fields(serializer):
         fields = getattr(serializer, 'fields')
         meta = getattr(serializer, 'Meta', None)
 
-    if fields:
+    if fields is not None:
         meta_fields = getattr(meta, 'meta_fields', {})
         for field in meta_fields:
             try:


### PR DESCRIPTION
Currently, `fields = ()` in a serializer doesn't work because `get_serializer_fields` returns `None`