### PR TITLE
SerializerMethodResourceRelatedField with many=True does not show up in included

### DIFF
--- a/example/serializers.py
+++ b/example/serializers.py
@@ -35,6 +35,7 @@ class EntrySerializer(serializers.ModelSerializer):
         'authors': 'example.serializers.AuthorSerializer',
         'comments': 'example.serializers.CommentSerializer',
         'featured': 'example.serializers.EntrySerializer',
+        'suggested': 'example.serializers.EntrySerializer',
     }
 
     body_format = serializers.SerializerMethodField()

--- a/example/tests/integration/test_includes.py
+++ b/example/tests/integration/test_includes.py
@@ -50,6 +50,15 @@ def test_dynamic_related_data_is_included(single_entry, entry_factory, client):
     assert len(included) == 1, 'The dynamically included blog entries are of an incorrect count'
 
 
+def test_dynamic_many_related_data_is_included(single_entry, entry_factory, client):
+    entry_factory()
+    response = client.get(reverse("entry-detail", kwargs={'pk': single_entry.pk}) + '?include=suggested')
+    included = load_json(response.content).get('included')
+
+    assert included
+    assert [x.get('type') for x in included] == ['entries'], 'Dynamic included types are incorrect'
+
+
 def test_missing_field_not_included(author_bio_factory, author_factory, client):
     # First author does not have a bio
     author = author_factory(bio=None)

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -283,7 +283,12 @@ class JSONRenderer(renderers.JSONRenderer):
                 serializer_class = included_serializers.get(field_name)
                 if relation_instance_or_manager is None:
                     continue
-                field = serializer_class(relation_instance_or_manager, context=context)
+
+                many = field._kwargs.get('child_relation', None) is not None
+
+                field = serializer_class(relation_instance_or_manager,
+                                         many=many,
+                                         context=context)
                 serializer_data = field.data
 
             if isinstance(field, ListSerializer):


### PR DESCRIPTION
When using a `SerializerMethodResourceRelatedField` in a serializer, with `many=True` being set, and the request is asking for to include it (via the `?include`) parameter, the field is not included in the result.

This PR adds a test and a fairly hackish fix (by checking is a 'child_relation' is present in the `_kwargs` parameter, when the field is evaluated for includes).