### PR TITLE
Add isort & flake8 settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.eggs/
 
 # Installer logs
 pip-log.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ env:
 
   - DJANGO=">=1.10,<1.11" DRF=">=3.4,<3.5"
 before_install:
-  # Force an upgrade of py to avoid VersionConflict
+  # Force an upgrade of py & pytest to avoid VersionConflict
   - pip install --upgrade py
+  - pip install "pytest>=2.8,<3"
   - pip install codecov
 install:
   - pip install Django${DJANGO} djangorestframework${DRF}

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,17 @@ test = pytest
 
 [wheel]
 universal = 1
+
+[flake8]
+ignore = E501
+max-line-length = 100
+
+[isort]
+known_django = django
+sections = FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER
+default_section = THIRDPARTY
+known_standard_library = factory,mock,requests
+known_first_party = rest_framework_json_api
+multi_line_output = 3
+line_length = 100
+indent = 4

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     tests_require=[
         'pytest-factoryboy',
         'pytest-django',
-        'pytest>=2.8',
+        'pytest>=2.8,<3',
     ] + mock,
     zip_safe=False,
 )


### PR DESCRIPTION
Isort & flake8 rules for contributors using these tools in their editor.
Also pinned pytest version, to get tests to pass. (pytest-factoryboy doesn't yet support pytest3+).