### PR TITLE
Remove check for relation_instance as it was not available in scope

### DIFF
--- a/example/tests/unit/test_renderers.py
+++ b/example/tests/unit/test_renderers.py
@@ -1,0 +1,45 @@
+from example.models import Entry, Comment
+from rest_framework_json_api import serializers, views
+from rest_framework_json_api.renderers import JSONRenderer
+
+
+# serializers
+class RelatedModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Comment
+        fields = ('id',)
+
+
+class DummyTestSerializer(serializers.ModelSerializer):
+    '''
+    This serializer is a simple compound document serializer which includes only
+    a single embedded relation
+    '''
+    related_models = RelatedModelSerializer(
+        source='comment_set', many=True, read_only=True)
+
+    class Meta:
+        model = Entry
+        fields = ('related_models',)
+
+    class JSONAPIMeta:
+        included_resources = ('related_models',)
+
+
+# views
+class DummyTestViewSet(views.ModelViewSet):
+    queryset = Entry.objects.all()
+    serializer_class = DummyTestSerializer
+
+
+def test_simple_reverse_relation_included_renderer():
+    '''
+    Test renderer when a single reverse fk relation is passed.
+    '''
+    serializer = DummyTestSerializer(instance=Entry())
+    renderer = JSONRenderer()
+    rendered = renderer.render(
+        serializer.data,
+        renderer_context={'view': DummyTestViewSet()})
+
+    assert rendered

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -199,7 +199,7 @@ class JSONRenderer(renderers.JSONRenderer):
                 })
                 continue
 
-            if isinstance(field, ListSerializer) and relation_instance is not None:
+            if isinstance(field, ListSerializer):
                 resolved, relation_instance = utils.get_relation_instance(resource_instance, source, field.parent)
                 if not resolved:
                     continue


### PR DESCRIPTION
Closes issue #270

I added a renderer unit test to catch this error. 

Unfortunately the bug only occurred when there was a single relation on the serializer so I had to make some simplified serializers to reproduce the issue.