### PR TITLE
Feature/drf serializer support

### DIFF
--- a/example/tests/test_utils.py
+++ b/example/tests/test_utils.py
@@ -1,0 +1,22 @@
+"""
+Test rest_framework_json_api's utils functions.
+"""
+from rest_framework_json_api import utils
+
+from ..serializers import EntrySerializer
+from ..tests import TestBase
+
+
+class GetRelatedResourceTests(TestBase):
+    """
+    Ensure the `get_related_resource_type` function returns correct types.
+    """
+
+    def test_reverse_relation(self):
+        """
+        Ensure reverse foreign keys have their types identified correctly.
+        """
+        serializer = EntrySerializer()
+        field = serializer.fields['comments']
+
+        self.assertEqual(utils.get_related_resource_type(field), 'comments')

--- a/example/tests/test_utils.py
+++ b/example/tests/test_utils.py
@@ -20,3 +20,12 @@ class GetRelatedResourceTests(TestBase):
         field = serializer.fields['comments']
 
         self.assertEqual(utils.get_related_resource_type(field), 'comments')
+
+    def test_m2m_relation(self):
+        """
+        Ensure m2ms have their types identified correctly.
+        """
+        serializer = EntrySerializer()
+        field = serializer.fields['authors']
+
+        self.assertEqual(utils.get_related_resource_type(field), 'authors')

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -2,19 +2,19 @@
 Utils.
 """
 import copy
+import inspect
 import warnings
 from collections import OrderedDict
-import inspect
 
 import inflection
+from rest_framework import exceptions
+from rest_framework.exceptions import APIException
+
 from django.conf import settings
-from django.utils import encoding
-from django.utils import six
+from django.db.models import Manager
+from django.utils import encoding, six
 from django.utils.module_loading import import_string as import_class_from_dotted_path
 from django.utils.translation import ugettext_lazy as _
-from django.db.models import Manager
-from rest_framework.exceptions import APIException
-from rest_framework import exceptions
 
 try:
     from rest_framework.serializers import ManyRelatedField
@@ -87,6 +87,7 @@ def get_serializer_fields(serializer):
                 pass
         return fields
 
+
 def format_keys(obj, format_type=None):
     """
     Takes either a dict or list and returns it with camelized keys only if
@@ -148,6 +149,7 @@ def format_relation_name(value, format_type=None):
     pluralize = getattr(settings, 'JSON_API_PLURALIZE_RELATION_TYPE', None)
     return format_resource_type(value, format_type, pluralize)
 
+
 def format_resource_type(value, format_type=None, pluralize=None):
     if format_type is None:
         format_type = getattr(settings, 'JSON_API_FORMAT_TYPES', False)
@@ -184,7 +186,7 @@ def get_related_resource_type(relation):
         elif hasattr(parent_serializer, 'parent') and hasattr(parent_serializer.parent, 'Meta'):
             parent_model = getattr(parent_serializer.parent.Meta, 'model', None)
 
-        if parent_model is not  None:
+        if parent_model is not None:
             if relation.source:
                 if relation.source != '*':
                     parent_model_relation = getattr(parent_model, relation.source)
@@ -199,6 +201,8 @@ def get_related_resource_type(relation):
                 except AttributeError:
                     # Django 1.7
                     relation_model = parent_model_relation.related.model
+            elif hasattr(parent_model_relation, 'rel'):
+                relation_model = parent_model_relation.rel.related_model
             elif hasattr(parent_model_relation, 'field'):
                 try:
                     relation_model = parent_model_relation.field.remote_field.model


### PR DESCRIPTION
Fixes #273.

I didn't end up explicitly importing drf serializers and writing tests for them. The original plan was to just have an extra set of tests that swap out the jsonapi `serializers` module with drf's original one, however the example app makes use of several serializer features available only to jsonapi, which means i'd've had to write a separate set of plain drf serializers, with their own tests.

For fear of bloating the repo too much (and wanting to save myself some time), I instead just added a `test_utils.py` for testing jsonapi's `utils.py`. This identified the bug, which I fixed.

Please note, this just _happens_ to fix the reverse/m2m functionality for default drf serializers that got broken in 0aedffb, but does not guarantee them to work in general or if other things change.

I feel this is probs the least messy approach, as it might become completely infeasible to support the default drf serializers if jsonapi evolves enough in the future.

~~This is built on #272, please merge that one first.~~
Rebased.