### PR TITLE
Don't set `id` to None when it's not submitted with the request

### DIFF
--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -92,7 +92,7 @@ class JSONParser(parsers.JSONParser):
                 raise ParseError("The resource identifier object must contain an 'id' member")
 
             # Construct the return data
-            parsed_data = {'id': data.get('id')}
+            parsed_data = {'id': data.get('id')} if 'id' in data else {}
             parsed_data.update(self.parse_attributes(data))
             parsed_data.update(self.parse_relationships(data))
             parsed_data.update(self.parse_metadata(result))


### PR DESCRIPTION
Currently the parser always sets `request.data['id']` even for POST requests that often don't include it. This doesn't play well with some serializer options like `default`. If `id` is part of `serializer.initial_data` then it will not be replaced by the field's default value even if it is `None`.