### PR TITLE
Upgrade py.test to 2.9.2.

### DIFF
--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -1,5 +1,5 @@
 -e .
-pytest==2.8.2
+pytest>=2.9.0,<3.0
 pytest-django
 pytest-factoryboy
 fake-factory


### PR DESCRIPTION
On 2.8.2 the tests didn't run for me (Python 3.5.2). I got this exception:

```
pkg_resources.VersionConflict: (pytest 2.8.2 (/Users/amw/.virtualenvs/jsonapi/lib/python3.5/site-packages), Requirement.parse('pytest>=2.9'))
```

This PR upgrades py.test to 2.9.2 which worked great on a clean virtualenv with python 3.5.2.

On pytest 3.x tests seem to be failing at the moment.