### PR TITLE
Parsing of included data in JSON request

### DIFF
--- a/example/tests/test_parsers.py
+++ b/example/tests/test_parsers.py
@@ -7,17 +7,19 @@ from rest_framework_json_api.parsers import JSONParser
 
 class TestJSONParser(TestCase):
 
-    def setUp(self):
-        class MockRequest(object):
+    @staticmethod
+    def _data_to_json_stream(data):
+        string = json.dumps(data)
+        return BytesIO(string.encode('utf-8'))
 
+    def test_parse_include_metadata(self):
+        class MockRequest(object):
             def __init__(self):
                 self.method = 'GET'
 
-        request = MockRequest()
-
-        self.parser_context = {'request': request, 'kwargs': {}, 'view': 'BlogViewSet'}
-
-        data = {
+        parser = JSONParser()
+        parser_context = {'request': MockRequest(), 'kwargs': {}, 'view': 'BlogViewSet'}
+        request_data = {
             'data': {
                 'id': 123,
                 'type': 'Blog'
@@ -26,13 +28,55 @@ class TestJSONParser(TestCase):
                 'random_key': 'random_value'
             }
         }
+        result_data = parser.parse(self._data_to_json_stream(request_data), None, parser_context)
+        self.assertEqual(result_data['_meta'], {'random_key': 'random_value'})
 
-        self.string = json.dumps(data)
+    def test_parse_with_included(self):
+        """ test parsing of incoming JSON which includes referenced entities """
+        class ViewMock(object):
+            resource_name = 'author-bios'
 
-    def test_parse_include_metadata(self):
         parser = JSONParser()
+        request_data = {
+            "data": {
+                "type": "author-bios",
+                "id": "author-bio-1",
+                "attributes": {
+                    "body": "This author is cool",
+                },
+                "relationships": {
+                    "author": {
+                        "data": {
+                            "type": "authors",
+                            "id": "author-1"
+                        }
+                    },
+                }
+            },
+            "included": [{
+                "type": "authors",
+                "id": "author-1",
+                "attributes": {
+                    "name": "Homer Simpson",
+                    "email": "homer@simpson.com"
+                },
+            }]
+        }
+        result_data = parser.parse(self._data_to_json_stream(request_data), parser_context={'view': ViewMock()})
 
-        stream = BytesIO(self.string.encode('utf-8'))
-        data = parser.parse(stream, None, self.parser_context)
-
-        self.assertEqual(data['_meta'], {'random_key': 'random_value'})
+        expected_data = {
+            'id': 'author-bio-1',
+            'body': 'This author is cool',
+            'author': {
+                'type': 'authors',
+                'id': 'author-1'
+            },
+            '_included': {
+                'authors': [{
+                    'id': 'author-1',
+                    'name': 'Homer Simpson',
+                    'email': 'homer@simpson.com',
+                }]
+            },
+        }
+        self.assertEqual(result_data, expected_data)


### PR DESCRIPTION
Included resources are used to optimize the number of requests that has to be made to the server when fetching an entity. See: http://jsonapi.org/format/#document-compound-documents

Similar concept can be used also when creating entity. If entity contains relation to another entity,  its data can be directly included in the request.

This pull request extends parser so that "included" key is not ignored in JSON request. Instead, it parses the data and adds them under "_included" key in the parsing result.

