### PR TITLE
Don't force translation of request attribute names

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Jerel Unruh <mail@unruhdesigns.com>
 Greg Aker <greg@gregaker.net>
+Adam Wróbel <https://adamwrobel.com>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v2.3.0
+
+* When `JSON_API_FORMAT_KEYS` is False (the default) do not translate request
+  attributes and relations to snake\_case format. This conversion was unexpected
+  and there was no way to turn it off.
+
 v2.2.0
 
 * Add support for Django REST Framework 3.5 and 3.6

--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -4,6 +4,8 @@ Parsers
 from rest_framework import parsers
 from rest_framework.exceptions import ParseError
 
+from django.conf import settings
+
 from . import utils, renderers, exceptions
 
 
@@ -29,12 +31,27 @@ class JSONParser(parsers.JSONParser):
 
     @staticmethod
     def parse_attributes(data):
-        return utils.format_keys(data.get('attributes'), 'underscore') if data.get('attributes') else dict()
+        attributes = data.get('attributes')
+        uses_format_translation = getattr(settings, 'JSON_API_FORMAT_KEYS', False)
+
+        if not attributes:
+            return dict()
+        elif uses_format_translation:
+            # convert back to python/rest_framework's preferred underscore format
+            return utils.format_keys(attributes, 'underscore')
+        else:
+            return attributes
 
     @staticmethod
     def parse_relationships(data):
-        relationships = (utils.format_keys(data.get('relationships'), 'underscore')
-                         if data.get('relationships') else dict())
+        uses_format_translation = getattr(settings, 'JSON_API_FORMAT_KEYS', False)
+        relationships = data.get('relationships')
+
+        if not relationships:
+            relationships = dict()
+        elif uses_format_translation:
+            # convert back to python/rest_framework's preferred underscore format
+            relationships = utils.format_keys(relationships, 'underscore')
 
         # Parse the relationships
         parsed_relationships = dict()


### PR DESCRIPTION
This attribute key translation was advertised to be "off by default", but was in fact forced in parser. This commit makes it so that request attributes and relations are only translated back to snake_case format if JSON_API_FORMAT_KEYS setting is set.

I'm not mad – I don't have my model/serializer attributes named someField or SomeField. My use case is quite simple: I have a JSONField where I accept some black-box content for storage. I need to be able to return the data as it was submitted to me by users of the API.
