### PR TITLE
Gracefully handle no data

### DIFF
--- a/example/tests/test_parsers.py
+++ b/example/tests/test_parsers.py
@@ -1,7 +1,9 @@
 import json
+from io import BytesIO
 
 from django.test import TestCase
-from io import BytesIO
+from rest_framework.exceptions import ParseError
+
 from rest_framework_json_api.parsers import JSONParser
 
 
@@ -36,3 +38,13 @@ class TestJSONParser(TestCase):
         data = parser.parse(stream, None, self.parser_context)
 
         self.assertEqual(data['_meta'], {'random_key': 'random_value'})
+
+
+    def test_parse_include_metadata(self):
+        parser = JSONParser()
+
+        string = json.dumps([])
+        stream = BytesIO(string.encode('utf-8'))
+
+        with self.assertRaises(ParseError):
+            parser.parse(stream, None, self.parser_context)


### PR DESCRIPTION
Currently the parser fails with "AttributeError: 'list' object has no attribute 'get'" when the passed JSON is not a dictionary. This causes Server Error (500) response.

The diff looks big, but I've just added the type check and moved the error from the bottom to the beginning. The rest is the same code but unindented.
