### PR TITLE
Refactor tests.

### DIFF
--- a/example/tests/integration/test_meta.py
+++ b/example/tests/integration/test_meta.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from django.core.urlresolvers import reverse
 
 import pytest
-from example.tests.utils import dump_json, redump_json
+from example.tests.utils import load_json
 
 pytestmark = pytest.mark.django_db
 
@@ -36,10 +36,9 @@ def test_top_level_meta_for_list_view(blog, client):
     }
 
     response = client.get(reverse("blog-list"))
-    content_dump = redump_json(response.content)
-    expected_dump = dump_json(expected)
+    parsed_content = load_json(response.content)
 
-    assert content_dump == expected_dump
+    assert expected == parsed_content
 
 
 def test_top_level_meta_for_detail_view(blog, client):
@@ -64,7 +63,6 @@ def test_top_level_meta_for_detail_view(blog, client):
     }
 
     response = client.get(reverse("blog-detail", kwargs={'pk': blog.pk}))
-    content_dump = redump_json(response.content)
-    expected_dump = dump_json(expected)
+    parsed_content = load_json(response.content)
 
-    assert content_dump == expected_dump
+    assert expected == parsed_content

--- a/example/tests/integration/test_non_paginated_responses.py
+++ b/example/tests/integration/test_non_paginated_responses.py
@@ -6,7 +6,7 @@ import pytest
 from example.views import EntryViewSet
 from rest_framework_json_api.pagination import PageNumberPagination
 
-from example.tests.utils import dump_json, redump_json
+from example.tests.utils import load_json
 
 pytestmark = pytest.mark.django_db
 
@@ -101,7 +101,6 @@ def test_multiple_entries_no_pagination(multiple_entries, rf):
     response = view(request)
     response.render()
 
-    content_dump = redump_json(response.content)
-    expected_dump = dump_json(expected)
+    parsed_content = load_json(response.content)
 
-    assert content_dump == expected_dump
+    assert expected == parsed_content

--- a/example/tests/integration/test_pagination.py
+++ b/example/tests/integration/test_pagination.py
@@ -1,7 +1,7 @@
 from django.core.urlresolvers import reverse
 
 import pytest
-from example.tests.utils import dump_json, redump_json
+from example.tests.utils import load_json
 
 pytestmark = pytest.mark.django_db
 
@@ -63,7 +63,6 @@ def test_pagination_with_single_entry(single_entry, client):
     }
 
     response = client.get(reverse("entry-list"))
-    content_dump = redump_json(response.content)
-    expected_dump = dump_json(expected)
+    parsed_content = load_json(response.content)
 
-    assert content_dump == expected_dump
+    assert expected == parsed_content

--- a/example/tests/test_format_keys.py
+++ b/example/tests/test_format_keys.py
@@ -1,10 +1,9 @@
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
-from django.conf import settings
 from django.utils import encoding
 
 from example.tests import TestBase
-from example.tests.utils import dump_json, redump_json
+from example.tests.utils import load_json
 
 
 class FormatKeysSetTests(TestBase):
@@ -53,7 +52,6 @@ class FormatKeysSetTests(TestBase):
             }
         }
 
-        content_dump = redump_json(response.content)
-        expected_dump = dump_json(expected)
+        parsed_content = load_json(response.content)
 
-        assert expected_dump == content_dump
+        assert expected == parsed_content

--- a/example/tests/test_generic_validation.py
+++ b/example/tests/test_generic_validation.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from rest_framework.serializers import ValidationError
 
 from example.tests import TestBase
-from example.tests.utils import dump_json, redump_json
+from example.tests.utils import load_json
 
 
 class GenericValidationTest(TestBase):
@@ -34,7 +34,6 @@ class GenericValidationTest(TestBase):
             }]
         }
 
-        content_dump = redump_json(response.content)
-        expected_dump = dump_json(expected)
+        parsed_content = load_json(response.content)
 
-        assert expected_dump == content_dump
+        assert expected == parsed_content

--- a/example/tests/test_generic_viewset.py
+++ b/example/tests/test_generic_viewset.py
@@ -4,7 +4,7 @@ from django.core.urlresolvers import reverse
 from django.conf import settings
 
 from example.tests import TestBase
-from example.tests.utils import dump_json, redump_json
+from example.tests.utils import load_json
 
 
 class GenericViewSet(TestBase):
@@ -38,10 +38,9 @@ class GenericViewSet(TestBase):
             'email': 'miles@example.com'
         }
 
-        content_dump = redump_json(response.content)
-        expected_dump = dump_json(expected)
+        parsed_content = load_json(response.content)
 
-        assert expected_dump == content_dump
+        assert expected == parsed_content
 
 
     def test_ember_expected_renderer(self):
@@ -66,10 +65,9 @@ class GenericViewSet(TestBase):
             }
         }
 
-        content_dump = redump_json(response.content)
-        expected_dump = dump_json(expected)
+        parsed_content = load_json(response.content)
 
-        assert expected_dump == content_dump
+        assert expected == parsed_content
 
     def test_default_validation_exceptions(self):
         """
@@ -96,10 +94,9 @@ class GenericViewSet(TestBase):
         response = self.client.post('/identities', {
             'email': 'bar', 'first_name': 'alajflajaljalajlfjafljalj'})
 
-        content_dump = redump_json(response.content)
-        expected_dump = dump_json(expected)
+        parsed_content = load_json(response.content)
 
-        assert expected_dump == content_dump
+        assert expected == parsed_content
 
     def test_custom_validation_exceptions(self):
         """
@@ -124,7 +121,6 @@ class GenericViewSet(TestBase):
         response = self.client.post('/identities', {
             'email': 'bar', 'last_name': 'alajflajaljalajlfjafljalj'})
 
-        content_dump = redump_json(response.content)
-        expected_dump = dump_json(expected)
+        parsed_content = load_json(response.content)
 
-        assert expected_dump == content_dump
+        assert expected == parsed_content

--- a/example/tests/test_model_viewsets.py
+++ b/example/tests/test_model_viewsets.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from django.conf import settings
 
 from example.tests import TestBase
-from example.tests.utils import dump_json, redump_json
+from example.tests.utils import dump_json, load_json
 
 
 class ModelViewSetTests(TestBase):
@@ -64,10 +64,9 @@ class ModelViewSetTests(TestBase):
             }
         }
 
-        content_dump = redump_json(response.content)
-        expected_dump = dump_json(expected)
+        parsed_content = load_json(response.content)
 
-        assert expected_dump == content_dump
+        assert expected == parsed_content
 
     def test_page_two_in_list_result(self):
         """
@@ -104,10 +103,9 @@ class ModelViewSetTests(TestBase):
             }
         }
 
-        content_dump = redump_json(response.content)
-        expected_dump = dump_json(expected)
+        parsed_content = load_json(response.content)
 
-        assert expected_dump == content_dump
+        assert expected == parsed_content
 
     def test_page_range_in_list_result(self):
         """
@@ -155,10 +153,9 @@ class ModelViewSetTests(TestBase):
             }
         }
 
-        content_dump = redump_json(response.content)
-        expected_dump = dump_json(expected)
+        parsed_content = load_json(response.content)
 
-        assert expected_dump == content_dump
+        assert expected == parsed_content
 
     def test_key_in_detail_result(self):
         """
@@ -179,10 +176,9 @@ class ModelViewSetTests(TestBase):
             }
         }
 
-        content_dump = redump_json(response.content)
-        expected_dump = dump_json(expected)
+        parsed_content = load_json(response.content)
 
-        assert expected_dump == content_dump
+        assert expected == parsed_content
 
     def test_patch_requires_id(self):
         """
@@ -224,10 +220,9 @@ class ModelViewSetTests(TestBase):
                                    content_type='application/vnd.api+json',
                                    data=dump_json(data))
 
-        content_dump = redump_json(response.content)
-        expected_dump = dump_json(data)
+        parsed_content = load_json(response.content)
 
-        assert expected_dump == content_dump
+        assert data == parsed_content
 
         # is it updated?
         self.assertEqual(

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -8,7 +8,7 @@ from rest_framework_json_api.serializers import ResourceIdentifierObjectSerializ
 from example.models import Blog, Entry, Author
 
 import pytest
-from example.tests.utils import dump_json, redump_json
+from example.tests.utils import load_json
 
 pytestmark = pytest.mark.django_db
 
@@ -108,7 +108,6 @@ class TestModelSerializer(object):
 
         assert response.status_code == 200
 
-        actual = redump_json(response.content)
-        expected_json = dump_json(expected)
+        parsed_content = load_json(response.content)
 
-        assert actual == expected_json
+        assert expected == parsed_content

--- a/example/tests/utils.py
+++ b/example/tests/utils.py
@@ -19,24 +19,3 @@ def dump_json(data):
     }
 
     return force_bytes(json.dumps(data, **json_kwargs))
-
-
-def redump_json(data):
-    '''
-    The response.content is already a JSON formatted string BUT
-    we don't know anything about its formatting, in particular,
-    the indent and separators arguments. DRF has a complex method to
-    determine what values to use for each argument and unfortunately,
-    the methods aren't the same in all DRF versions.
-
-    So what to do? LOAD the JSON formmated string (response.content)
-    as a Python object and DUMP it again and hence the name of this function.
-
-    This will guarantee that we're comparing two similarly formatted JSON
-    strings. Only the formatting similarity is guaranteed. As for the content,
-    that's what the tests are for!
-    '''
-
-    data = json.loads(force_text(data))
-
-    return dump_json(data)


### PR DESCRIPTION
Pytest gives cleaner output if you compare list/dictionaries instead of dumped jsons. It is also easier to read tests.