### PR TITLE
Fix get_related_resource_type

### DIFF
--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -178,6 +178,10 @@ def get_related_resource_type(relation):
         return get_resource_type_from_serializer(relation)
     except AttributeError:
         pass
+
+    if hasattr(relation, 'child_relation'):
+        return get_related_resource_type(relation.child_relation)
+    
     relation_model = None
     if hasattr(relation, '_meta'):
         relation_model = relation._meta.model


### PR DESCRIPTION
To consider child_relation, eg. the default reverse relationship created by m2m. Otherwise it appears to fall back to the parent serializer type.