### PR TITLE
Fixed crash when patching many-to-many relationships in Django >= 1.9

### DIFF
--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -118,12 +118,31 @@ class TestRelationshipView(APITestCase):
         response = self.client.get(url)
         assert response.data == request_data['data']
 
-    def test_patch_to_many_relationship(self):
+    def test_patch_one_to_many_relationship(self):
         url = '/blogs/{}/relationships/entry_set'.format(self.first_entry.id)
         request_data = {
             'data': [{'type': format_resource_type('Entry'), 'id': str(self.first_entry.id)}, ]
         }
         response = self.client.patch(url, data=json.dumps(request_data), content_type='application/vnd.api+json')
+        assert response.status_code == 200, response.content.decode()
+        assert response.data == request_data['data']
+
+        response = self.client.get(url)
+        assert response.data == request_data['data']
+
+    def test_patch_many_to_many_relationship(self):
+        url = '/entries/{}/relationships/authors'.format(self.first_entry.id)
+        request_data = {
+            'data': [
+                {
+                    'type': format_resource_type('Author'),
+                    'id': str(self.author.id)
+                },
+            ]
+        }
+        response = self.client.patch(url,
+                                     data=json.dumps(request_data),
+                                     content_type='application/vnd.api+json')
         assert response.status_code == 200, response.content.decode()
         assert response.data == request_data['data']
 

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -134,7 +134,8 @@ class RelationshipView(generics.GenericAPIView):
             serializer.is_valid(raise_exception=True)
             related_instance_or_manager.all().delete()
             # have to set bulk to False since data isn't saved yet
-            if django.VERSION >= (1, 9):
+            class_name = related_instance_or_manager.__class__.__name__
+            if django.VERSION >= (1, 9) and class_name != 'ManyRelatedManager':
                 related_instance_or_manager.add(*serializer.validated_data,
                                                 bulk=False)
             else:


### PR DESCRIPTION
The app crash with error: `TypeError: add() got an unexpected keyword argument 'bulk'`, when trying to patch many-to-many relationships. In file `example/tests/test_views.py` was added the test catching this error. It's error is possible only in Django >= 1.9, because was added the `bulk` argument in `add()` method for all `Manager` classes, excluding `ManyRelatedManager` class. In file `rest_framework_json_api/views.py` was added check the class name to fix this error.