### PR TITLE
Avoid choices evaluation on relational fields getting field metadata

### DIFF
--- a/rest_framework_json_api/metadata.py
+++ b/rest_framework_json_api/metadata.py
@@ -128,8 +128,8 @@ class JSONAPIMetadata(SimpleMetadata):
             field_info['children'] = self.get_serializer_info(field)
 
         if (not field_info.get('read_only')
-            and hasattr(field, 'choices')
-            and not field_info.get('relationship_resource')):
+            and not field_info.get('relationship_resource')
+            and hasattr(field, 'choices')):
             field_info['choices'] = [
                 {
                     'value': choice_value,


### PR DESCRIPTION
On relation fields line 131 is getting all the related objects.