### PR TITLE
Added nested included serializer support for remapped relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ v2.3.0
 * Fix for apps that don't use `django.contrib.contenttypes`.
 * Fix `resource_name` support for POST requests and nested serializers
 * Enforcing flake8 linting
+* Added nested included serializer support for remapped relations
 
 v2.2.0
 

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -105,10 +105,25 @@ class AuthorSerializer(serializers.ModelSerializer):
         fields = ('name', 'email', 'bio')
 
 
+class WriterSerializer(serializers.ModelSerializer):
+    included_serializers = {
+        'bio': AuthorBioSerializer
+    }
+
+    class Meta:
+        model = Author
+        fields = ('name', 'email', 'bio')
+        resource_name = 'writers'
+
+
 class CommentSerializer(serializers.ModelSerializer):
+    # testing remapping of related name
+    writer = relations.ResourceRelatedField(source='author', read_only=True)
+
     included_serializers = {
         'entry': EntrySerializer,
-        'author': AuthorSerializer
+        'author': AuthorSerializer,
+        'writer': WriterSerializer
     }
 
     class Meta:

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -102,6 +102,12 @@ class TestModelSerializer(object):
                             "id": str(comment.author.pk)
                         }
                     },
+                    "writer": {
+                        "data": {
+                            "type": "writers",
+                            "id": str(comment.author.pk)
+                        }
+                    },
                 }
             }
         }

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -273,6 +273,30 @@ class JSONRenderer(renderers.JSONRenderer):
         return utils.format_keys(data)
 
     @classmethod
+    def extract_relation_instance(cls, field_name, field, resource_instance, serializer):
+        relation_instance = None
+
+        try:
+            relation_instance = getattr(resource_instance, field_name)
+        except AttributeError:
+            try:
+                # For ManyRelatedFields if `related_name` is not set
+                # we need to access `foo_set` from `source`
+                relation_instance = getattr(resource_instance, field.child_relation.source)
+            except AttributeError:
+                if hasattr(serializer, field.source):
+                    serializer_method = getattr(serializer, field.source)
+                    relation_instance = serializer_method(resource_instance)
+                else:
+                    # case when source is a simple remap on resource_instance
+                    try:
+                        relation_instance = getattr(resource_instance, field.source)
+                    except AttributeError:
+                        pass
+
+        return relation_instance
+
+    @classmethod
     def extract_included(cls, fields, resource, resource_instance, included_resources):
         # this function may be called with an empty record (example: Browsable Interface)
         if not resource_instance:
@@ -304,19 +328,9 @@ class JSONRenderer(renderers.JSONRenderer):
                 if field_name not in [node.split('.')[0] for node in included_resources]:
                     continue
 
-            try:
-                relation_instance = getattr(resource_instance, field_name)
-            except AttributeError:
-                try:
-                    # For ManyRelatedFields if `related_name` is not set we need to access `foo_set`
-                    # from `source`
-                    relation_instance = getattr(resource_instance, field.child_relation.source)
-                except AttributeError:
-                    if not hasattr(current_serializer, field.source):
-                        continue
-                    serializer_method = getattr(current_serializer, field.source)
-                    relation_instance = serializer_method(resource_instance)
-
+            relation_instance = cls.extract_relation_instance(
+                field_name, field, resource_instance, current_serializer
+            )
             if isinstance(relation_instance, Manager):
                 relation_instance = relation_instance.all()
 

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -274,6 +274,12 @@ class JSONRenderer(renderers.JSONRenderer):
 
     @classmethod
     def extract_relation_instance(cls, field_name, field, resource_instance, serializer):
+        """
+        Determines what instance represents given relation and extracts it.
+
+        Relation instance is determined by given field_name or source configured on
+        field. As fallback is a serializer method called with name of field's source.
+        """
         relation_instance = None
 
         try:


### PR DESCRIPTION
In ResourceRelatedField it is possible to rename/remap a field so it can be represented in the api with a different name using the source attribute. This works well however if I request to include this relationship in `included` it won't be returned.

I have added a test which should make it clearer what issue this PR addresses.