### PR TITLE
Fix for pagination ‘last’ link to give the real last page

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,4 +4,4 @@ Greg Aker <greg@gregaker.net>
 Jerel Unruh <mail@unruhdesigns.com>
 Matt Layman <http://www.mattlayman.com>
 Oliver Sauder <os@esite.ch>
-
+Yaniv Peer <yanivpeer@gmail.com>

--- a/example/tests/unit/test_pagination.py
+++ b/example/tests/unit/test_pagination.py
@@ -41,7 +41,7 @@ class TestLimitOffset:
         offset = 10
         limit = 5
         count = len(self.queryset)
-        last_offset = count - limit
+        last_offset = (count // limit) * limit
         next_offset = 15
         prev_offset = 5
 

--- a/rest_framework_json_api/pagination.py
+++ b/rest_framework_json_api/pagination.py
@@ -64,7 +64,7 @@ class LimitOffsetPagination(LimitOffsetPagination):
         url = self.request.build_absolute_uri()
         url = replace_query_param(url, self.limit_query_param, self.limit)
 
-        offset = self.count - self.limit
+        offset = (self.count // self.limit) * self.limit
 
         if offset <= 0:
             return remove_query_param(url, self.offset_query_param)


### PR DESCRIPTION
We're working on a project using django-json-api and came across unintuitive behavior for the pagination. The current pagination implementation for the 'last' link is basically a 'total count' - 'limit'. Consider the following example:

Objects = [0-21]
Limit = 10
(first page - offset 0)
0,1,2,3,4,5,6,7,8,9

(clicking 'next' - offset 10)
10,11,12,13,14,15,16,17,18,19

(clicking 'next' - offset 20)
20,21

(clicking 'last' - offset 12)
12,13,14,15,16,17,18,19,20,21

This behavior would make the user completely disoriented in the paging. It makes more sense that 'last' will offset to 20 just the same as clicking 'next'->'next'->'next' and simply return two objects instead of 10.