### PR TITLE
Add isort to CI process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,10 @@ install:
   - python setup.py install
 script:
   - flake8
-  - isort --check-only --verbose --recursive --diff rest_framework_json_api example
+  - isort --check-only --verbose --recursive --diff rest_framework_json_api
+  # example has extra dependencies that are installed in a dev environment
+  # but are not installed in CI. Explicitly set those packages.
+  - isort --check-only --verbose --recursive --diff --thirdparty polymorphic,pytest_factoryboy example
   - coverage run setup.py -v test
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
   - isort --check-only --verbose --recursive --diff rest_framework_json_api
   # example has extra dependencies that are installed in a dev environment
   # but are not installed in CI. Explicitly set those packages.
-  - isort --check-only --verbose --recursive --diff --thirdparty polymorphic,pytest_factoryboy example
+  - isort --check-only --verbose --recursive --diff --thirdparty pytest --thirdparty polymorphic --thirdparty pytest_factoryboy example
   - coverage run setup.py -v test
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,13 @@ before_install:
   # Force an upgrade of py & pytest to avoid VersionConflict
   - pip install --upgrade py
   - pip install "pytest>=2.8,<3"
-  - pip install codecov flake8
+  - pip install codecov flake8 isort
 install:
   - pip install Django${DJANGO} djangorestframework${DRF}
   - python setup.py install
 script:
   - flake8
+  - isort --check-only --verbose rest_framework_json_api/**/*.py example/**/*.py
   - coverage run setup.py -v test
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - python setup.py install
 script:
   - flake8
-  - isort --check-only --verbose rest_framework_json_api/**/*.py example/**/*.py
+  - isort --check-only --verbose --recursive rest_framework_json_api example
   - coverage run setup.py -v test
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - python setup.py install
 script:
   - flake8
-  - isort --check-only --verbose --recursive rest_framework_json_api example
+  - isort --check-only --verbose --recursive --diff rest_framework_json_api example
   - coverage run setup.py -v test
 after_success:
   - codecov

--- a/example/api/resources/identity.py
+++ b/example/api/resources/identity.py
@@ -1,10 +1,11 @@
 from django.contrib.auth import models as auth_models
 from django.utils import encoding
-
-from rest_framework import viewsets, generics, renderers, parsers, serializers
-from rest_framework.decorators import list_route, detail_route
+from rest_framework import generics, parsers, renderers, serializers, viewsets
+from rest_framework.decorators import detail_route, list_route
 from rest_framework.response import Response
+
 from rest_framework_json_api import mixins, utils
+
 from ..serializers.identity import IdentitySerializer
 from ..serializers.post import PostSerializer
 

--- a/example/models.py
+++ b/example/models.py
@@ -1,9 +1,8 @@
 # -*- encoding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes.fields import GenericForeignKey
-from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from polymorphic.models import PolymorphicModel

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -1,11 +1,21 @@
 from datetime import datetime
 
 import rest_framework
-from rest_framework_json_api import serializers, relations
+
 from packaging import version
+from rest_framework_json_api import relations, serializers
+
 from example.models import (
-    Blog, Entry, Author, AuthorBio, Comment, TaggedItem, Project, ArtProject, ResearchProject,
+    ArtProject,
+    Author,
+    AuthorBio,
+    Blog,
+    Comment,
     Company,
+    Entry,
+    Project,
+    ResearchProject,
+    TaggedItem
 )
 
 

--- a/example/tests/conftest.py
+++ b/example/tests/conftest.py
@@ -2,8 +2,15 @@ import pytest
 from pytest_factoryboy import register
 
 from example.factories import (
-    BlogFactory, AuthorFactory, AuthorBioFactory, EntryFactory, CommentFactory,
-    TaggedItemFactory, ArtProjectFactory, ResearchProjectFactory, CompanyFactory,
+    ArtProjectFactory,
+    AuthorBioFactory,
+    AuthorFactory,
+    BlogFactory,
+    CommentFactory,
+    CompanyFactory,
+    EntryFactory,
+    ResearchProjectFactory,
+    TaggedItemFactory
 )
 
 register(BlogFactory)

--- a/example/tests/integration/test_meta.py
+++ b/example/tests/integration/test_meta.py
@@ -1,7 +1,8 @@
 from datetime import datetime
-from django.core.urlresolvers import reverse
 
 import pytest
+from django.core.urlresolvers import reverse
+
 from example.tests.utils import load_json
 
 pytestmark = pytest.mark.django_db

--- a/example/tests/integration/test_model_resource_name.py
+++ b/example/tests/integration/test_model_resource_name.py
@@ -1,10 +1,11 @@
-import pytest
 from copy import deepcopy
-from example import models, serializers, views
-from example.tests.utils import dump_json, load_json
+
+import pytest
+from django.core.urlresolvers import reverse
 from rest_framework import status
 
-from django.core.urlresolvers import reverse
+from example import models, serializers, views
+from example.tests.utils import dump_json, load_json
 
 pytestmark = pytest.mark.django_db
 

--- a/example/tests/integration/test_non_paginated_responses.py
+++ b/example/tests/integration/test_non_paginated_responses.py
@@ -11,9 +11,6 @@ try:
 except ImportError:
     import mock
 
-
-
-
 pytestmark = pytest.mark.django_db
 
 

--- a/example/tests/integration/test_non_paginated_responses.py
+++ b/example/tests/integration/test_non_paginated_responses.py
@@ -1,16 +1,18 @@
+import pytest
 from django.core.urlresolvers import reverse
+
+from rest_framework_json_api.pagination import PageNumberPagination
+
+from example.tests.utils import load_json
+from example.views import EntryViewSet
 
 try:
     from unittest import mock
 except ImportError:
     import mock
 
-import pytest
 
-from example.views import EntryViewSet
-from rest_framework_json_api.pagination import PageNumberPagination
 
-from example.tests.utils import load_json
 
 pytestmark = pytest.mark.django_db
 

--- a/example/tests/integration/test_pagination.py
+++ b/example/tests/integration/test_pagination.py
@@ -1,12 +1,13 @@
+import pytest
 from django.core.urlresolvers import reverse
+
+from example.tests.utils import load_json
 
 try:
     from unittest import mock
 except ImportError:
     import mock
 
-import pytest
-from example.tests.utils import load_json
 
 pytestmark = pytest.mark.django_db
 

--- a/example/tests/integration/test_polymorphism.py
+++ b/example/tests/integration/test_polymorphism.py
@@ -1,6 +1,7 @@
-import pytest
-import random
 import json
+import random
+
+import pytest
 from django.core.urlresolvers import reverse
 
 from example.tests.utils import load_json

--- a/example/tests/integration/test_sparse_fieldsets.py
+++ b/example/tests/integration/test_sparse_fieldsets.py
@@ -1,7 +1,5 @@
-from django.core.urlresolvers import reverse
-
 import pytest
-
+from django.core.urlresolvers import reverse
 
 pytestmark = pytest.mark.django_db
 

--- a/example/tests/test_generic_validation.py
+++ b/example/tests/test_generic_validation.py
@@ -1,6 +1,5 @@
 from django.core.urlresolvers import reverse
 
-
 from example.tests import TestBase
 from example.tests.utils import load_json
 

--- a/example/tests/test_generic_viewset.py
+++ b/example/tests/test_generic_viewset.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.conf import settings
+from django.core.urlresolvers import reverse
 
 from example.tests import TestBase
 from example.tests.utils import load_json

--- a/example/tests/test_model_viewsets.py
+++ b/example/tests/test_model_viewsets.py
@@ -1,7 +1,7 @@
-from django.contrib.auth import get_user_model
-from django.utils import encoding
-from django.core.urlresolvers import reverse
 from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.urlresolvers import reverse
+from django.utils import encoding
 
 from example.tests import TestBase
 from example.tests.utils import dump_json, load_json

--- a/example/tests/test_multiple_id_mixin.py
+++ b/example/tests/test_multiple_id_mixin.py
@@ -1,7 +1,9 @@
 import json
-from example.tests import TestBase
-from django.utils import encoding
+
 from django.core.urlresolvers import reverse
+from django.utils import encoding
+
+from example.tests import TestBase
 
 
 class MultipleIDMixin(TestBase):

--- a/example/tests/test_relations.py
+++ b/example/tests/test_relations.py
@@ -3,12 +3,13 @@ from __future__ import absolute_import
 from django.utils import timezone
 from rest_framework import serializers
 
-from . import TestBase
 from rest_framework_json_api.exceptions import Conflict
-from rest_framework_json_api.utils import format_resource_type
-from example.models import Blog, Entry, Comment, Author
-from example.serializers import CommentSerializer
 from rest_framework_json_api.relations import ResourceRelatedField
+from rest_framework_json_api.utils import format_resource_type
+
+from . import TestBase
+from example.models import Author, Blog, Comment, Entry
+from example.serializers import CommentSerializer
 
 
 class TestResourceRelatedField(TestBase):

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -1,13 +1,12 @@
+import pytest
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils import timezone
 
-from rest_framework_json_api.utils import format_resource_type
 from rest_framework_json_api.serializers import ResourceIdentifierObjectSerializer
+from rest_framework_json_api.utils import format_resource_type
 
-from example.models import Blog, Entry, Author
-
-import pytest
+from example.models import Author, Blog, Entry
 from example.tests.utils import load_json
 
 pytestmark = pytest.mark.django_db

--- a/example/tests/test_utils.py
+++ b/example/tests/test_utils.py
@@ -3,7 +3,7 @@ Test rest_framework_json_api's utils functions.
 """
 from rest_framework_json_api import utils
 
-from ..serializers import EntrySerializer, AuthorSerializer
+from ..serializers import AuthorSerializer, EntrySerializer
 from ..tests import TestBase
 
 

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -3,15 +3,13 @@ import json
 from django.test import RequestFactory
 from django.utils import timezone
 from rest_framework.reverse import reverse
-
-from rest_framework.test import APITestCase
-from rest_framework.test import force_authenticate
+from rest_framework.test import APITestCase, force_authenticate
 
 from rest_framework_json_api.utils import format_resource_type
-from example.models import Blog, Entry, Comment, Author
 
-from .. import views
 from . import TestBase
+from .. import views
+from example.models import Author, Blog, Comment, Entry
 
 
 class TestRelationshipView(APITestCase):

--- a/example/tests/unit/test_factories.py
+++ b/example/tests/unit/test_factories.py
@@ -1,7 +1,7 @@
 import pytest
 
-from example.models import Blog
 from example.factories import BlogFactory
+from example.models import Blog
 
 pytestmark = pytest.mark.django_db
 

--- a/example/tests/unit/test_pagination.py
+++ b/example/tests/unit/test_pagination.py
@@ -6,7 +6,6 @@ from rest_framework.utils.urls import replace_query_param
 
 from rest_framework_json_api.pagination import LimitOffsetPagination
 
-
 factory = APIRequestFactory()
 
 

--- a/example/tests/unit/test_renderers.py
+++ b/example/tests/unit/test_renderers.py
@@ -1,6 +1,7 @@
-from example.models import Entry, Comment
 from rest_framework_json_api import serializers, views
 from rest_framework_json_api.renderers import JSONRenderer
+
+from example.models import Comment, Entry
 
 
 # serializers

--- a/example/tests/unit/test_utils.py
+++ b/example/tests/unit/test_utils.py
@@ -7,10 +7,10 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from example.serializers import (EntrySerializer, BlogSerializer,
-                                 AuthorSerializer, CommentSerializer)
 from rest_framework_json_api import utils
 from rest_framework_json_api.utils import get_included_serializers
+
+from example.serializers import AuthorSerializer, BlogSerializer, CommentSerializer, EntrySerializer
 
 pytestmark = pytest.mark.django_db
 

--- a/example/urls.py
+++ b/example/urls.py
@@ -2,7 +2,13 @@ from django.conf.urls import include, url
 from rest_framework import routers
 
 from example.views import (
-    BlogViewSet, EntryViewSet, AuthorViewSet, CommentViewSet, CompanyViewset, ProjectViewset)
+    AuthorViewSet,
+    BlogViewSet,
+    CommentViewSet,
+    CompanyViewset,
+    EntryViewSet,
+    ProjectViewset
+)
 
 router = routers.DefaultRouter(trailing_slash=False)
 

--- a/example/urls_test.py
+++ b/example/urls_test.py
@@ -1,12 +1,19 @@
 from django.conf.urls import include, url
 from rest_framework import routers
 
+from .api.resources.identity import GenericIdentity, Identity
 from example.views import (
-    BlogViewSet, EntryViewSet, AuthorViewSet, CommentViewSet, EntryRelationshipView,
-    BlogRelationshipView, CommentRelationshipView, AuthorRelationshipView,
-    CompanyViewset, ProjectViewset,
+    AuthorRelationshipView,
+    AuthorViewSet,
+    BlogRelationshipView,
+    BlogViewSet,
+    CommentRelationshipView,
+    CommentViewSet,
+    CompanyViewset,
+    EntryRelationshipView,
+    EntryViewSet,
+    ProjectViewset
 )
-from .api.resources.identity import Identity, GenericIdentity
 
 router = routers.DefaultRouter(trailing_slash=False)
 

--- a/example/views.py
+++ b/example/views.py
@@ -1,17 +1,22 @@
-from rest_framework import exceptions
 import rest_framework.parsers
 import rest_framework.renderers
+from rest_framework import exceptions
+
 import rest_framework_json_api.metadata
 import rest_framework_json_api.parsers
 import rest_framework_json_api.renderers
-from rest_framework_json_api.views import ModelViewSet, RelationshipView
-from example.models import Blog, Entry, Author, Comment, Company, Project
-from example.serializers import (
-    BlogSerializer, EntrySerializer, AuthorSerializer, CommentSerializer, CompanySerializer,
-    ProjectSerializer,
-)
-
 from rest_framework_json_api.utils import format_drf_errors
+from rest_framework_json_api.views import ModelViewSet, RelationshipView
+
+from example.models import Author, Blog, Comment, Company, Entry, Project
+from example.serializers import (
+    AuthorSerializer,
+    BlogSerializer,
+    CommentSerializer,
+    CompanySerializer,
+    EntrySerializer,
+    ProjectSerializer
+)
 
 HTTP_422_UNPROCESSABLE_ENTITY = 422
 

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -1,11 +1,12 @@
 -e .
+django-polymorphic
+Faker
+isort
+mock
 pytest>=2.9.0,<3.0
 pytest-django
 pytest-factoryboy
-Faker
 recommonmark
 Sphinx
 sphinx_rtd_theme
-django-polymorphic
 tox
-mock

--- a/rest_framework_json_api/exceptions.py
+++ b/rest_framework_json_api/exceptions.py
@@ -1,9 +1,8 @@
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
-from rest_framework import status, exceptions
+from rest_framework import exceptions, status
 
-from rest_framework_json_api import utils
-from rest_framework_json_api import renderers
+from rest_framework_json_api import renderers, utils
 
 
 def rendered_with_json_api(view):

--- a/rest_framework_json_api/pagination.py
+++ b/rest_framework_json_api/pagination.py
@@ -2,9 +2,10 @@
 Pagination fields
 """
 from collections import OrderedDict
-from rest_framework.views import Response
-from rest_framework.pagination import PageNumberPagination, LimitOffsetPagination
+
+from rest_framework.pagination import LimitOffsetPagination, PageNumberPagination
 from rest_framework.utils.urls import remove_query_param, replace_query_param
+from rest_framework.views import Response
 
 
 class PageNumberPagination(PageNumberPagination):

--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -6,7 +6,7 @@ from django.utils import six
 from rest_framework import parsers
 from rest_framework.exceptions import ParseError
 
-from . import utils, renderers, exceptions
+from . import exceptions, renderers, utils
 
 
 class JSONParser(parsers.JSONParser):

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -1,16 +1,20 @@
 import collections
-import inflection
 import json
 
+import inflection
+from django.utils.translation import ugettext_lazy as _
 from rest_framework.fields import MISSING_ERROR_MESSAGE
 from rest_framework.relations import *  # noqa: F403
 from rest_framework.serializers import Serializer
-from django.utils.translation import ugettext_lazy as _
 
 from rest_framework_json_api.exceptions import Conflict
-from rest_framework_json_api.utils import Hyperlink, \
-    get_resource_type_from_queryset, get_resource_type_from_instance, \
-    get_included_serializers, get_resource_type_from_serializer
+from rest_framework_json_api.utils import (
+    Hyperlink,
+    get_included_serializers,
+    get_resource_type_from_instance,
+    get_resource_type_from_queryset,
+    get_resource_type_from_serializer
+)
 
 LINKS_PARAMS = [
     'self_link_view_name',

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -6,10 +6,9 @@ from collections import OrderedDict
 
 import inflection
 from django.db.models import Manager
-from django.utils import six, encoding
-from rest_framework import relations
-from rest_framework import renderers
-from rest_framework.serializers import BaseSerializer, Serializer, ListSerializer
+from django.utils import encoding, six
+from rest_framework import relations, renderers
+from rest_framework.serializers import BaseSerializer, ListSerializer, Serializer
 from rest_framework.settings import api_settings
 
 from rest_framework_json_api import utils

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -1,16 +1,19 @@
 import inflection
-
 from django.db.models.query import QuerySet
-from django.utils.translation import ugettext_lazy as _
 from django.utils import six
+from django.utils.translation import ugettext_lazy as _
 from rest_framework.exceptions import ParseError
 from rest_framework.serializers import *  # noqa: F403
 
-from rest_framework_json_api.relations import ResourceRelatedField
 from rest_framework_json_api.exceptions import Conflict
+from rest_framework_json_api.relations import ResourceRelatedField
 from rest_framework_json_api.utils import (
-    get_resource_type_from_model, get_resource_type_from_instance,
-    get_resource_type_from_serializer, get_included_serializers, get_included_resources)
+    get_included_resources,
+    get_included_serializers,
+    get_resource_type_from_instance,
+    get_resource_type_from_model,
+    get_resource_type_from_serializer
+)
 
 
 class ResourceIdentifierObjectSerializer(BaseSerializer):

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -6,16 +6,15 @@ import inspect
 import warnings
 from collections import OrderedDict
 
-import inflection
-from rest_framework import exceptions
-from rest_framework.exceptions import APIException
-
 import django
+import inflection
 from django.conf import settings
 from django.db.models import Manager
 from django.utils import encoding, six
 from django.utils.module_loading import import_string as import_class_from_dotted_path
 from django.utils.translation import ugettext_lazy as _
+from rest_framework import exceptions
+from rest_framework.exceptions import APIException
 
 try:
     from rest_framework.serializers import ManyRelatedField

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -1,21 +1,21 @@
 import django
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model
-from django.db.models.query import QuerySet
 from django.db.models.manager import Manager
+from django.db.models.query import QuerySet
 from rest_framework import generics, viewsets
+from rest_framework.exceptions import MethodNotAllowed, NotFound
 from rest_framework.response import Response
-from rest_framework.exceptions import NotFound, MethodNotAllowed
 from rest_framework.reverse import reverse
 from rest_framework.serializers import Serializer
 
 from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.serializers import ResourceIdentifierObjectSerializer
 from rest_framework_json_api.utils import (
-    get_resource_type_from_instance,
-    OrderedDict,
     Hyperlink,
+    OrderedDict,
     get_included_resources,
+    get_resource_type_from_instance
 )
 
 if django.VERSION >= (1, 10):

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,8 +10,11 @@ max-line-length = 100
 exclude = docs/conf.py,build,migrations
 
 [isort]
-known_standard_library = mock
-known_first_party = rest_framework_json_api
-multi_line_output = 3
-line_length = 100
 indent = 4
+known_first_party = rest_framework_json_api
+# This is to "trick" isort into putting example below DJA imports.
+known_localfolder = example
+known_standard_library = mock
+line_length = 100
+multi_line_output = 3
+skip_glob=*migrations*

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,10 +10,7 @@ max-line-length = 100
 exclude = docs/conf.py,build,migrations
 
 [isort]
-known_django = django
-sections = FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER
-default_section = THIRDPARTY
-known_standard_library = factory,mock,requests
+known_standard_library = mock
 known_first_party = rest_framework_json_api
 multi_line_output = 3
 line_length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -24,3 +24,12 @@ setenv =
 
 commands =
     python setup.py test {posargs}
+
+[testenv:isort]
+deps =
+    isort
+commands =
+    isort --check-only --verbose --recursive --diff rest_framework_json_api
+    # example has extra dependencies that are installed in a dev environment
+    # but are not installed in CI. Explicitly set those packages.
+    isort --check-only --verbose --recursive --diff --thirdparty pytest --thirdparty polymorphic --thirdparty pytest_factoryboy example


### PR DESCRIPTION
This branch adds `isort` to the CI process so that import ordering issues can be left to a tool. It also does an initial run through on the code so that everything respects the isort settings.

Fixes #344