### PR TITLE
add count to ResourceRelatedField

### DIFF
--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -150,7 +150,6 @@ class JSONRenderer(renderers.JSONRenderer):
                     }
                 )
                 data.update({field_name: relation_data})
-                data.update({field_name: relation_data})
                 continue
 
             if isinstance(

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -142,6 +142,14 @@ class JSONRenderer(renderers.JSONRenderer):
                     {'links': field_links}
                     if field_links else dict()
                 )
+                relation_data.update(
+                    {
+                        'meta': {
+                            'count': len(resource.get(field_name))
+                        }
+                    }
+                )
+                data.update({field_name: relation_data})
                 data.update({field_name: relation_data})
                 continue
 


### PR DESCRIPTION
This PR adds `meta` to count individual relations

```
"relationships": {
    "child": {
        "data": [ {...} ],
        "meta": {
            "count": 5
        }
    },
    ...
}
```

How do you feel I could put a hook for counter? In a case there is too many to display, `SerializerMethodResourceRelatedField` provides no source, like in:

```
    something = relations.SerializerMethodResourceRelatedField(
        source='get_something',
        model=models.Something,
        many=True,
        ...
    )

    def get_something(self, obj):
        # TODO: provide counter instead of relationship list
        # workaround https://github.com/django-json-api
        # /django-rest-framework-json-api/issues/178
        return ()
```

would new attribute `count_source` work?