### PR TITLE
Fix factory boy dependency

### DIFF
--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -5,6 +5,7 @@ isort
 mock
 pytest>=2.9.0,<3.0
 pytest-django
+# factory_boy is currently broken at 2.9 and above. See: https://github.com/pytest-dev/pytest-factoryboy/issues/47
 factory-boy<2.9.0
 pytest-factoryboy
 recommonmark

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -5,7 +5,7 @@ isort
 mock
 pytest>=2.9.0,<3.0
 pytest-django
-factory-boy==2.8.1
+factory-boy<2.9.0
 pytest-factoryboy
 recommonmark
 Sphinx

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -5,6 +5,7 @@ isort
 mock
 pytest>=2.9.0,<3.0
 pytest-django
+factory-boy==2.8.1
 pytest-factoryboy
 recommonmark
 Sphinx

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     setup_requires=pytest_runner + sphinx + wheel,
     tests_require=[
         'pytest-factoryboy',
-        'factory-boy<2.9.0'
+        'factory-boy<2.9.0',
         'pytest-django',
         'pytest>=2.8,<3',
         'django-polymorphic',

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
     setup_requires=pytest_runner + sphinx + wheel,
     tests_require=[
         'pytest-factoryboy',
+        'factory-boy<2.9.0'
         'pytest-django',
         'pytest>=2.8,<3',
         'django-polymorphic',


### PR DESCRIPTION
Factoy Boy 2.9.+ versions are raising this problem when we run the test suite using py.test

ConftestImportFailure: (local('/home/santiago/develop/invgate-django-rest-framework-json-api/example/tests/conftest.py'), (<type 'exceptions.AttributeError'>, AttributeError("'DjangoOptions' object has no attribute 'postgen_declarations'",), <traceback object at 0x7fb1c6b123b0>))

Related issue https://github.com/pytest-dev/pytest-factoryboy/issues/47

To fix this problem temporally  we can switch to FactoryBoy 2.8.1.