### PR TITLE
Fix for resolving source when accessing sub-attr eg b.c

### DIFF
--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -3,6 +3,7 @@ Utils.
 """
 import copy
 import inspect
+import operator
 import warnings
 from collections import OrderedDict
 
@@ -339,7 +340,7 @@ def get_included_serializers(serializer):
 
 def get_relation_instance(resource_instance, source, serializer):
     try:
-        relation_instance = getattr(resource_instance, source)
+        relation_instance = operator.attrgetter(source)(resource_instance)
     except AttributeError:
         # if the field is not defined on the model then we check the serializer
         # and if no value is there we skip over the field completely


### PR DESCRIPTION
```
plan = PlanSerializer(source='subscription.plan')
```
 `plan` is a field of another serializer which needs to be resolved using `obj.subscription.plan` property. It works for standard DRF JSON response but fails in drf-json-api.

This PR fixes that issue by replacing `getattr` with `operator.attrgetter` which is able to resolve  the sub-attr access.