### PR TITLE
removed duplicate requirement

### DIFF
--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -12,6 +12,5 @@ recommonmark
 Sphinx
 sphinx_rtd_theme
 tox
-mock
 django-debug-toolbar
 packaging==16.8


### PR DESCRIPTION
"mock" is included twice in the development requirements. This causes pip install to fail with 
```
Double requirement given: mock (from -r requirements-development.txt (line 15)) (already in mock (from -r requirements-development.txt (line 5)), name='mock')
```