### PR TITLE
Add six as a dependency.

### DIFF
--- a/rest_framework_json_api/__init__.py
+++ b/rest_framework_json_api/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 __title__ = 'djangorestframework-jsonapi'
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 __author__ = ''
 __license__ = 'MIT'
 __copyright__ = ''

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
         'inflection>=0.3.0',
         'djangorestframework>=3.1.0',
         'django',
+        'six',
     ],
     setup_requires=pytest_runner + sphinx + wheel,
     tests_require=[


### PR DESCRIPTION
The `six` library is required, but it was not included in the packaging.

Fixes #389