### PR TITLE
Allow json api renderer to be used as test request renderer class

### DIFF
--- a/example/settings/dev.py
+++ b/example/settings/dev.py
@@ -88,4 +88,8 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.BrowsableAPIRenderer',
     ),
     'DEFAULT_METADATA_CLASS': 'rest_framework_json_api.metadata.JSONAPIMetadata',
+    'TEST_REQUEST_RENDERER_CLASSES': (
+        'rest_framework_json_api.renderers.JSONRenderer',
+    ),
+    'TEST_REQUEST_DEFAULT_FORMAT': 'vnd.api+json'
 }

--- a/example/tests/conftest.py
+++ b/example/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest_factoryboy import register
+from rest_framework.test import APIClient, APIRequestFactory
 
 from example.factories import (
     ArtProjectFactory,
@@ -56,3 +57,13 @@ def single_company(art_project_factory, research_project_factory, company_factor
 @pytest.fixture
 def single_art_project(art_project_factory):
     return art_project_factory()
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@pytest.fixture
+def rf():
+    return APIRequestFactory()

--- a/example/tests/conftest.py
+++ b/example/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from pytest_factoryboy import register
-from rest_framework.test import APIClient, APIRequestFactory
+from rest_framework.test import APIClient
 
 from example.factories import (
     ArtProjectFactory,
@@ -62,8 +62,3 @@ def single_art_project(art_project_factory):
 @pytest.fixture
 def client():
     return APIClient()
-
-
-@pytest.fixture
-def rf():
-    return APIRequestFactory()

--- a/example/tests/integration/test_meta.py
+++ b/example/tests/integration/test_meta.py
@@ -3,8 +3,6 @@ from datetime import datetime
 import pytest
 from django.core.urlresolvers import reverse
 
-from example.tests.utils import load_json
-
 pytestmark = pytest.mark.django_db
 
 
@@ -42,9 +40,8 @@ def test_top_level_meta_for_list_view(blog, client):
     }
 
     response = client.get(reverse("blog-list"))
-    parsed_content = load_json(response.content)
 
-    assert expected == parsed_content
+    assert expected == response.json()
 
 
 def test_top_level_meta_for_detail_view(blog, client):
@@ -74,6 +71,5 @@ def test_top_level_meta_for_detail_view(blog, client):
     }
 
     response = client.get(reverse("blog-detail", kwargs={'pk': blog.pk}))
-    parsed_content = load_json(response.content)
 
-    assert expected == parsed_content
+    assert expected == response.json()

--- a/example/tests/integration/test_non_paginated_responses.py
+++ b/example/tests/integration/test_non_paginated_responses.py
@@ -108,8 +108,7 @@ def test_multiple_entries_no_pagination(multiple_entries, rf):
     class NonPaginatedEntryViewSet(EntryViewSet):
         pagination_class = NoPagination
 
-    request = rf.get(
-        reverse("entry-list"))
+    request = rf.get(reverse("entry-list"))
     view = NonPaginatedEntryViewSet.as_view({'get': 'list'})
     response = view(request)
     response.render()

--- a/example/tests/integration/test_non_paginated_responses.py
+++ b/example/tests/integration/test_non_paginated_responses.py
@@ -1,11 +1,6 @@
 import pytest
 from django.core.urlresolvers import reverse
 
-from rest_framework_json_api.pagination import PageNumberPagination
-
-from example.tests.utils import load_json
-from example.views import EntryViewSet
-
 try:
     from unittest import mock
 except ImportError:
@@ -14,12 +9,11 @@ except ImportError:
 pytestmark = pytest.mark.django_db
 
 
-# rf == request_factory
 @mock.patch(
     'rest_framework_json_api.utils'
     '.get_default_included_resources_from_serializer',
     new=lambda s: [])
-def test_multiple_entries_no_pagination(multiple_entries, rf):
+def test_multiple_entries_no_pagination(multiple_entries, client):
 
     expected = {
         "data": [
@@ -102,17 +96,6 @@ def test_multiple_entries_no_pagination(multiple_entries, rf):
         ]
     }
 
-    class NoPagination(PageNumberPagination):
-        page_size = None
+    response = client.get(reverse("nopage-entry-list"))
 
-    class NonPaginatedEntryViewSet(EntryViewSet):
-        pagination_class = NoPagination
-
-    request = rf.get(reverse("entry-list"))
-    view = NonPaginatedEntryViewSet.as_view({'get': 'list'})
-    response = view(request)
-    response.render()
-
-    parsed_content = load_json(response.content)
-
-    assert expected == parsed_content
+    assert expected == response.json()

--- a/example/tests/integration/test_pagination.py
+++ b/example/tests/integration/test_pagination.py
@@ -1,8 +1,6 @@
 import pytest
 from django.core.urlresolvers import reverse
 
-from example.tests.utils import load_json
-
 try:
     from unittest import mock
 except ImportError:
@@ -81,6 +79,5 @@ def test_pagination_with_single_entry(single_entry, client):
     }
 
     response = client.get(reverse("entry-list"))
-    parsed_content = load_json(response.content)
 
-    assert expected == parsed_content
+    assert expected == response.json()

--- a/example/tests/test_format_keys.py
+++ b/example/tests/test_format_keys.py
@@ -3,7 +3,6 @@ from django.core.urlresolvers import reverse
 from django.utils import encoding
 
 from example.tests import TestBase
-from example.tests.utils import load_json
 
 
 class FormatKeysSetTests(TestBase):
@@ -51,6 +50,4 @@ class FormatKeysSetTests(TestBase):
             }
         }
 
-        parsed_content = load_json(response.content)
-
-        assert expected == parsed_content
+        assert expected == response.json()

--- a/example/tests/test_generic_validation.py
+++ b/example/tests/test_generic_validation.py
@@ -1,7 +1,6 @@
 from django.core.urlresolvers import reverse
 
 from example.tests import TestBase
-from example.tests.utils import load_json
 
 
 class GenericValidationTest(TestBase):
@@ -30,6 +29,4 @@ class GenericValidationTest(TestBase):
             }]
         }
 
-        parsed_content = load_json(response.content)
-
-        assert expected == parsed_content
+        assert expected == response.json()

--- a/example/tests/test_generic_viewset.py
+++ b/example/tests/test_generic_viewset.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from example.tests import TestBase
-from example.tests.utils import load_json
 
 
 class GenericViewSet(TestBase):
@@ -36,9 +35,7 @@ class GenericViewSet(TestBase):
             'email': 'miles@example.com'
         }
 
-        parsed_content = load_json(response.content)
-
-        assert expected == parsed_content
+        assert expected == response.json()
 
     def test_ember_expected_renderer(self):
         """
@@ -62,9 +59,7 @@ class GenericViewSet(TestBase):
             }
         }
 
-        parsed_content = load_json(response.content)
-
-        assert expected == parsed_content
+        assert expected == response.json()
 
     def test_default_validation_exceptions(self):
         """
@@ -89,11 +84,15 @@ class GenericViewSet(TestBase):
             ]
         }
         response = self.client.post('/identities', {
-            'email': 'bar', 'first_name': 'alajflajaljalajlfjafljalj'})
+            'data': {
+                'type': 'users',
+                'attributes': {
+                    'email': 'bar', 'first_name': 'alajflajaljalajlfjafljalj'
+                }
+            }
+        })
 
-        parsed_content = load_json(response.content)
-
-        assert expected == parsed_content
+        assert expected == response.json()
 
     def test_custom_validation_exceptions(self):
         """
@@ -116,8 +115,12 @@ class GenericViewSet(TestBase):
             ]
         }
         response = self.client.post('/identities', {
-            'email': 'bar', 'last_name': 'alajflajaljalajlfjafljalj'})
+            'data': {
+                'type': 'users',
+                'attributes': {
+                    'email': 'bar', 'last_name': 'alajflajaljalajlfjafljalj'
+                }
+            }
+        })
 
-        parsed_content = load_json(response.content)
-
-        assert expected == parsed_content
+        assert expected == response.json()

--- a/example/tests/test_model_viewsets.py
+++ b/example/tests/test_model_viewsets.py
@@ -5,7 +5,6 @@ from django.core.urlresolvers import reverse
 from django.utils import encoding
 
 from example.tests import TestBase
-from example.tests.utils import dump_json, load_json
 
 
 class ModelViewSetTests(TestBase):
@@ -63,9 +62,7 @@ class ModelViewSetTests(TestBase):
             }
         }
 
-        parsed_content = load_json(response.content)
-
-        assert expected == parsed_content
+        assert expected == response.json()
 
     def test_page_two_in_list_result(self):
         """
@@ -102,9 +99,7 @@ class ModelViewSetTests(TestBase):
             }
         }
 
-        parsed_content = load_json(response.content)
-
-        assert expected == parsed_content
+        assert expected == response.json()
 
     def test_page_range_in_list_result(self):
         """
@@ -152,9 +147,7 @@ class ModelViewSetTests(TestBase):
             }
         }
 
-        parsed_content = load_json(response.content)
-
-        assert expected == parsed_content
+        assert expected == response.json()
 
     def test_key_in_detail_result(self):
         """
@@ -175,9 +168,7 @@ class ModelViewSetTests(TestBase):
             }
         }
 
-        parsed_content = load_json(response.content)
-
-        assert expected == parsed_content
+        assert expected == response.json()
 
     def test_patch_requires_id(self):
         """
@@ -192,9 +183,7 @@ class ModelViewSetTests(TestBase):
             }
         }
 
-        response = self.client.patch(self.detail_url,
-                                     content_type='application/vnd.api+json',
-                                     data=dump_json(data))
+        response = self.client.patch(self.detail_url, data=data)
 
         self.assertEqual(response.status_code, 400)
 
@@ -215,13 +204,9 @@ class ModelViewSetTests(TestBase):
             }
         }
 
-        response = self.client.put(self.detail_url,
-                                   content_type='application/vnd.api+json',
-                                   data=dump_json(data))
+        response = self.client.put(self.detail_url, data=data)
 
-        parsed_content = load_json(response.content)
-
-        assert data == parsed_content
+        assert data == response.json()
 
         # is it updated?
         self.assertEqual(
@@ -250,8 +235,6 @@ def test_patch_allow_field_type(author, author_type_factory, client):
         }
     }
 
-    response = client.patch(url,
-                            content_type='application/vnd.api+json',
-                            data=dump_json(data))
+    response = client.patch(url, data=data)
 
     assert response.status_code == 200

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -7,7 +7,6 @@ from rest_framework_json_api.serializers import ResourceIdentifierObjectSerializ
 from rest_framework_json_api.utils import format_resource_type
 
 from example.models import Author, Blog, Entry
-from example.tests.utils import load_json
 
 pytestmark = pytest.mark.django_db
 
@@ -114,7 +113,4 @@ class TestModelSerializer(object):
         response = client.get(reverse("comment-detail", kwargs={'pk': comment.pk}))
 
         assert response.status_code == 200
-
-        parsed_content = load_json(response.content)
-
-        assert expected == parsed_content
+        assert expected == response.json()

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -76,16 +76,12 @@ class TestRelationshipView(APITestCase):
 
     def test_patch_invalid_entry_relationship_blog_returns_400(self):
         url = '/entries/{}/relationships/blog'.format(self.first_entry.id)
-        response = self.client.patch(url,
-                                     data=json.dumps({'data': {'invalid': ''}}),
-                                     content_type='application/vnd.api+json')
+        response = self.client.patch(url, data={'data': {'invalid': ''}})
         assert response.status_code == 400
 
     def test_relationship_view_errors_format(self):
         url = '/entries/{}/relationships/blog'.format(self.first_entry.id)
-        response = self.client.patch(url,
-                                     data=json.dumps({'data': {'invalid': ''}}),
-                                     content_type='application/vnd.api+json')
+        response = self.client.patch(url, data={'data': {'invalid': ''}})
         assert response.status_code == 400
 
         result = json.loads(response.content.decode('utf-8'))
@@ -115,9 +111,7 @@ class TestRelationshipView(APITestCase):
         request_data = {
             'data': {'type': format_resource_type('Blog'), 'id': str(self.other_blog.id)}
         }
-        response = self.client.patch(
-            url, data=json.dumps(request_data), content_type='application/vnd.api+json'
-        )
+        response = self.client.patch(url, data=request_data)
         assert response.status_code == 200, response.content.decode()
         assert response.data == request_data['data']
 
@@ -129,9 +123,7 @@ class TestRelationshipView(APITestCase):
         request_data = {
             'data': [{'type': format_resource_type('Entry'), 'id': str(self.first_entry.id)}, ]
         }
-        response = self.client.patch(
-            url, data=json.dumps(request_data), content_type='application/vnd.api+json'
-        )
+        response = self.client.patch(url, data=request_data)
         assert response.status_code == 200, response.content.decode()
         assert response.data == request_data['data']
 
@@ -148,9 +140,7 @@ class TestRelationshipView(APITestCase):
                 },
             ]
         }
-        response = self.client.patch(url,
-                                     data=json.dumps(request_data),
-                                     content_type='application/vnd.api+json')
+        response = self.client.patch(url, data=request_data)
         assert response.status_code == 200, response.content.decode()
         assert response.data == request_data['data']
 
@@ -162,9 +152,7 @@ class TestRelationshipView(APITestCase):
         request_data = {
             'data': {'type': format_resource_type('Blog'), 'id': str(self.other_blog.id)}
         }
-        response = self.client.post(
-            url, data=json.dumps(request_data), content_type='application/vnd.api+json'
-        )
+        response = self.client.post(url, data=request_data)
         assert response.status_code == 405, response.content.decode()
 
     def test_post_to_many_relationship_with_no_change(self):
@@ -172,9 +160,7 @@ class TestRelationshipView(APITestCase):
         request_data = {
             'data': [{'type': format_resource_type('Comment'), 'id': str(self.first_comment.id)}, ]
         }
-        response = self.client.post(
-            url, data=json.dumps(request_data), content_type='application/vnd.api+json'
-        )
+        response = self.client.post(url, data=request_data)
         assert response.status_code == 204, response.content.decode()
         assert len(response.rendered_content) == 0, response.rendered_content.decode()
 
@@ -183,9 +169,7 @@ class TestRelationshipView(APITestCase):
         request_data = {
             'data': [{'type': format_resource_type('Comment'), 'id': str(self.second_comment.id)}, ]
         }
-        response = self.client.post(
-            url, data=json.dumps(request_data), content_type='application/vnd.api+json'
-        )
+        response = self.client.post(url, data=request_data)
         assert response.status_code == 200, response.content.decode()
 
         assert request_data['data'][0] in response.data
@@ -195,9 +179,7 @@ class TestRelationshipView(APITestCase):
         request_data = {
             'data': {'type': format_resource_type('Blog'), 'id': str(self.other_blog.id)}
         }
-        response = self.client.delete(
-            url, data=json.dumps(request_data), content_type='application/vnd.api+json'
-        )
+        response = self.client.delete(url, data=request_data)
         assert response.status_code == 405, response.content.decode()
 
     def test_delete_relationship_overriding_with_none(self):
@@ -213,9 +195,7 @@ class TestRelationshipView(APITestCase):
                 }
             }
         }
-        response = self.client.patch(
-            url, data=json.dumps(request_data), content_type='application/vnd.api+json'
-        )
+        response = self.client.patch(url, data=request_data)
         assert response.status_code == 200, response.content.decode()
         assert response.data['author'] is None
 
@@ -224,9 +204,7 @@ class TestRelationshipView(APITestCase):
         request_data = {
             'data': [{'type': format_resource_type('Comment'), 'id': str(self.second_comment.id)}, ]
         }
-        response = self.client.delete(
-            url, data=json.dumps(request_data), content_type='application/vnd.api+json'
-        )
+        response = self.client.delete(url, data=request_data)
         assert response.status_code == 204, response.content.decode()
         assert len(response.rendered_content) == 0, response.rendered_content.decode()
 
@@ -235,9 +213,7 @@ class TestRelationshipView(APITestCase):
         request_data = {
             'data': [{'type': format_resource_type('Comment'), 'id': str(self.first_comment.id)}, ]
         }
-        response = self.client.delete(
-            url, data=json.dumps(request_data), content_type='application/vnd.api+json'
-        )
+        response = self.client.delete(url, data=request_data)
         assert response.status_code == 409, response.content.decode()
 
     def test_delete_to_many_relationship_with_change(self):
@@ -245,9 +221,7 @@ class TestRelationshipView(APITestCase):
         request_data = {
             'data': [{'type': format_resource_type('Comment'), 'id': str(self.second_comment.id)}, ]
         }
-        response = self.client.delete(
-            url, data=json.dumps(request_data), content_type='application/vnd.api+json'
-        )
+        response = self.client.delete(url, data=request_data)
         assert response.status_code == 200, response.content.decode()
 
 

--- a/example/tests/utils.py
+++ b/example/tests/utils.py
@@ -1,21 +1,7 @@
 import json
 
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_text
 
 
 def load_json(data):
     return json.loads(force_text(data))
-
-
-def dump_json(data):
-    '''
-    Converts a Python object to a JSON formatted string.
-    '''
-
-    json_kwargs = {
-        'sort_keys': True,
-        'indent': 4,
-        'separators': (', ', ': ')
-    }
-
-    return force_bytes(json.dumps(data, **json_kwargs))

--- a/example/tests/utils.py
+++ b/example/tests/utils.py
@@ -1,7 +1,0 @@
-import json
-
-from django.utils.encoding import force_text
-
-
-def load_json(data):
-    return json.loads(force_text(data))

--- a/example/urls_test.py
+++ b/example/urls_test.py
@@ -12,6 +12,7 @@ from example.views import (
     CompanyViewset,
     EntryRelationshipView,
     EntryViewSet,
+    NonPaginatedEntryViewSet,
     ProjectViewset
 )
 
@@ -19,6 +20,7 @@ router = routers.DefaultRouter(trailing_slash=False)
 
 router.register(r'blogs', BlogViewSet)
 router.register(r'entries', EntryViewSet)
+router.register(r'nopage-entries', NonPaginatedEntryViewSet, 'nopage-entry')
 router.register(r'authors', AuthorViewSet)
 router.register(r'comments', CommentViewSet)
 router.register(r'companies', CompanyViewset)

--- a/example/views.py
+++ b/example/views.py
@@ -5,6 +5,7 @@ from rest_framework import exceptions
 import rest_framework_json_api.metadata
 import rest_framework_json_api.parsers
 import rest_framework_json_api.renderers
+from rest_framework_json_api.pagination import PageNumberPagination
 from rest_framework_json_api.utils import format_drf_errors
 from rest_framework_json_api.views import ModelViewSet, RelationshipView
 
@@ -66,6 +67,14 @@ class EntryViewSet(ModelViewSet):
 
     def get_serializer_class(self):
         return EntrySerializer
+
+
+class NoPagination(PageNumberPagination):
+    page_size = None
+
+
+class NonPaginatedEntryViewSet(EntryViewSet):
+    pagination_class = NoPagination
 
 
 class AuthorViewSet(ModelViewSet):

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -496,6 +496,8 @@ class JSONRenderer(renderers.JSONRenderer):
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
 
+        renderer_context = renderer_context or {}
+
         view = renderer_context.get("view", None)
         request = renderer_context.get("request", None)
 

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -40,7 +40,7 @@ def get_resource_name(context, expand_polymorphic_types=False):
 
     # Sanity check to make sure we have a view.
     if not view:
-        raise APIException(_('Could not find view.'))
+        return None
 
     # Check to see if there is a status code and return early
     # with the resource_name value of `errors`.


### PR DESCRIPTION
This allows to define json api format as default in tests. Following needs to be configured:

```python
REST_FRAMEWORK {
   ...
    'TEST_REQUEST_RENDERER_CLASSES': (
        'rest_framework_json_api.renderers.JSONRenderer',
    ),
    'TEST_REQUEST_DEFAULT_FORMAT': 'vnd.api+json'
   ...
}
```

With this change tests can be simplified and there is no need to specifically assign json api content type and dump resp. load data as json. This PR changes tests accordingly.

More detail documentation on this rest framework feature can be found [here](http://www.django-rest-framework.org/api-guide/testing/#configuration)