### PR TITLE
Fixed import of NoReverseMatch exception

### DIFF
--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -4,8 +4,8 @@ from collections import OrderedDict
 
 import inflection
 import six
+import django
 from django.core.exceptions import ImproperlyConfigured
-from django.urls import NoReverseMatch
 from django.utils.translation import ugettext_lazy as _
 from rest_framework.fields import MISSING_ERROR_MESSAGE
 from rest_framework.relations import MANY_RELATION_KWARGS, PrimaryKeyRelatedField
@@ -20,6 +20,11 @@ from rest_framework_json_api.utils import (
     get_resource_type_from_queryset,
     get_resource_type_from_serializer
 )
+
+if django.VERSION >= (1, 10):
+    from django.urls import NoReverseMatch
+else:
+    from django.core.urlresolvers import NoReverseMatch
 
 LINKS_PARAMS = [
     'self_link_view_name',

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -2,9 +2,9 @@ import collections
 import json
 from collections import OrderedDict
 
+import django
 import inflection
 import six
-import django
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
 from rest_framework.fields import MISSING_ERROR_MESSAGE


### PR DESCRIPTION
In relations.py the NoReverseMatch exception isn't correctly imported for Django versions >= 1.10.