### PR TITLE
Remove factory-boy version constraint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ matrix:
 before_install:
   # Force an upgrade of py & pytest to avoid VersionConflict
   - pip install --upgrade py
-  - pip install pytest
+  # Faker requires a newer pytest
+  - pip install "pytest>3.3"
   - pip install codecov flake8 isort
 install:
   - pip install Django${DJANGO} djangorestframework${DRF}

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
 before_install:
   # Force an upgrade of py & pytest to avoid VersionConflict
   - pip install --upgrade py
-  - pip install "pytest>=2.8,<3"
+  - pip install pytest
   - pip install codecov flake8 isort
 install:
   - pip install Django${DJANGO} djangorestframework${DRF}

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -3,7 +3,7 @@ django-polymorphic>=2.0
 Faker
 isort
 mock
-pytest>=2.9.0,<3.0
+pytest
 pytest-django
 factory-boy
 pytest-factoryboy

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -5,8 +5,7 @@ isort
 mock
 pytest>=2.9.0,<3.0
 pytest-django
-# factory_boy is currently broken at 2.9 and above. See: https://github.com/pytest-dev/pytest-factoryboy/issues/47
-factory-boy<2.9.0
+factory-boy
 pytest-factoryboy
 recommonmark
 Sphinx

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
         'pytest-factoryboy',
         'factory-boy',
         'pytest-django',
-        'pytest>=2.8,<3',
+        'pytest',
         'django-polymorphic>=2.0',
         'packaging',
         'django-debug-toolbar'

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     setup_requires=pytest_runner + sphinx + wheel,
     tests_require=[
         'pytest-factoryboy',
-        'factory-boy<2.9.0',
+        'factory-boy',
         'pytest-django',
         'pytest>=2.8,<3',
         'django-polymorphic>=2.0',


### PR DESCRIPTION
PR #407 is failing CI currently because of a package version issue and the PR is only changing a typo in the usage file. Some dependency requirement must have changed recently.

I'm trying this PR to see if it's now possible to have factory-boy working on a newer version.