### PR TITLE
Defer to lookup_field/custom id fields

### DIFF
--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -112,7 +112,7 @@ class JSONRenderer(renderers.JSONRenderer):
                         OrderedDict([
                             ('type', relation_type),
                             ('id', encoding.force_text(getattr(
-                                related_object.pk, field.lookup_field)))
+                                related_object, field.lookup_field)))
                         ])
                     )
 
@@ -223,14 +223,14 @@ class JSONRenderer(renderers.JSONRenderer):
                     )
 
                     if hasattr(field.child_relation, 'lookup_field'):
-                        _id = getattr(nested_resource_instance,
-                                      field.child_relation.lookup_field)
+                        pk = getattr(nested_resource_instance,
+                                     field.child_relation.lookup_field)
                     else:
-                        _id = nested_resource_instance.pk
+                        pk = nested_resource_instance.pk
 
                     relation_data.append(OrderedDict([
                         ('type', nested_resource_instance_type),
-                        ('id', encoding.force_text(_id))
+                        ('id', encoding.force_text(pk))
                     ]))
                 data.update({
                     field_name: {

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -154,7 +154,8 @@ class JSONRenderer(renderers.JSONRenderer):
                 lookup_field = getattr(field, 'lookup_field', None)
                 if lookup_field:
                     relation_id = getattr(
-                        getattr(resource_instance, source), lookup_field)
+                        getattr(resource_instance, source),
+                        lookup_field, None)
                 else:
                     resolved, relation = utils.get_relation_instance(
                         resource_instance, '%s_id' % source, field.parent

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -168,7 +168,7 @@ class JSONRenderer(renderers.JSONRenderer):
                         OrderedDict([
                             ('type', relation_type), ('id', encoding.force_text(relation_id))
                         ])
-                        if relation_id is not None else None)
+                        if relation_id is not None else {'data': None})
                 }
 
                 if (


### PR DESCRIPTION
Thsi PR allow support for custom pk https://github.com/django-json-api/django-rest-framework-json-api/issues/155

There are so many places where PK is assumed in
djangorestframework-jsonapi and so many places/ways to change IDs/URLs
in DRF itself, that getting coverage on all the edge cases will be quite
a lot of work.  Some of that work may be better spent re-factoring
things to make the code easier to understand and reduce the number of
edge cases in the first place.