### PR TITLE
Issue 410

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,6 @@
 Adam Wróbel <https://adamwrobel.com>
 Adam Ziolkowski <adam@adsized.com>
+Alan Crosswell <alan@columbia.edu>
 Christian Zosel <https://zosel.ch>
 Greg Aker <greg@gregaker.net>
 Jamie Bliss <astronouth7303@gmail.com>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,7 +70,6 @@ From Source
 
     git clone https://github.com/django-json-api/django-rest-framework-json-api.git
     cd django-rest-framework-json-api
-    pip install -e .
     pip install -r example/requirements.txt
     django-admin.py runserver
 
@@ -78,5 +77,5 @@ Browse to http://localhost:8000
 
 ## Running Tests
 
-    python runtests.py
+    tox
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,6 +73,7 @@ From Source
     python -m venv env
     source env/bin/activate
     pip install -r example/requirements.txt
+	pip install -e .
     django-admin.py startproject example .
     python manage.py migrate
     python manage.py runserver

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,12 +70,17 @@ From Source
 
     git clone https://github.com/django-json-api/django-rest-framework-json-api.git
     cd django-rest-framework-json-api
+    python -m venv env
+    source env/bin/activate
     pip install -r example/requirements.txt
-    django-admin.py runserver
+    django-admin.py startproject example .
+    python manage.py migrate
+    python manage.py runserver
 
 Browse to http://localhost:8000
 
 ## Running Tests
 
+    pip install tox
     tox
 

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,2 +1,13 @@
 # Requirements specifically for the example app
 packaging
+Django>=1.11
+django-debug-toolbar
+django-polymorphic>=2.0
+djangorestframework
+inflection
+pluggy
+py
+pyparsing
+pytz
+six
+sqlparse

--- a/example/settings/dev.py
+++ b/example/settings/dev.py
@@ -63,6 +63,10 @@ MIDDLEWARE_CLASSES = (
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
 
+MIDDLEWARE = (
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+)
+
 INTERNAL_IPS = ('127.0.0.1', )
 
 JSON_API_FORMAT_KEYS = 'camelize'

--- a/example/settings/dev.py
+++ b/example/settings/dev.py
@@ -59,10 +59,6 @@ SECRET_KEY = 'abc123'
 
 PASSWORD_HASHERS = ('django.contrib.auth.hashers.UnsaltedMD5PasswordHasher', )
 
-MIDDLEWARE_CLASSES = (
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-)
-
 MIDDLEWARE = (
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 )

--- a/example/urls.py
+++ b/example/urls.py
@@ -8,7 +8,8 @@ from example.views import (
     CommentViewSet,
     CompanyViewset,
     EntryViewSet,
-    ProjectViewset
+    ProjectViewset,
+    EntryRelationshipView,
 )
 
 router = routers.DefaultRouter(trailing_slash=False)
@@ -22,6 +23,13 @@ router.register(r'projects', ProjectViewset)
 
 urlpatterns = [
     url(r'^', include(router.urls)),
+    url(r'^entries/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)',
+        EntryRelationshipView.as_view(),
+        name='entry-relationships'),
+    url(r'^entries/(?P<entry_pk>[^/.]+)/suggested/',
+        EntryViewSet.as_view({'get': 'list'}),
+        name='entry-suggested'
+        ),
 ]
 
 

--- a/example/urls.py
+++ b/example/urls.py
@@ -20,6 +20,7 @@ router = routers.DefaultRouter(trailing_slash=False)
 
 router.register(r'blogs', BlogViewSet)
 router.register(r'entries', EntryViewSet)
+router.register(r'nopage-entries', NonPaginatedEntryViewSet, 'nopage-entry')
 router.register(r'authors', AuthorViewSet)
 router.register(r'comments', CommentViewSet)
 router.register(r'companies', CompanyViewset)

--- a/example/urls.py
+++ b/example/urls.py
@@ -3,13 +3,17 @@ from django.conf.urls import include, url
 from rest_framework import routers
 
 from example.views import (
+    AuthorRelationshipView,
     AuthorViewSet,
+    BlogRelationshipView,
     BlogViewSet,
+    CommentRelationshipView,
     CommentViewSet,
     CompanyViewset,
-    EntryViewSet,
-    ProjectViewset,
     EntryRelationshipView,
+    EntryViewSet,
+    NonPaginatedEntryViewSet,
+    ProjectViewset
 )
 
 router = routers.DefaultRouter(trailing_slash=False)
@@ -23,13 +27,22 @@ router.register(r'projects', ProjectViewset)
 
 urlpatterns = [
     url(r'^', include(router.urls)),
-    url(r'^entries/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)',
-        EntryRelationshipView.as_view(),
-        name='entry-relationships'),
     url(r'^entries/(?P<entry_pk>[^/.]+)/suggested/',
         EntryViewSet.as_view({'get': 'list'}),
         name='entry-suggested'
         ),
+    url(r'^entries/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)',
+        EntryRelationshipView.as_view(),
+        name='entry-relationships'),
+    url(r'^blogs/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)',
+        BlogRelationshipView.as_view(),
+        name='blog-relationships'),
+    url(r'^comments/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)',
+        CommentRelationshipView.as_view(),
+        name='comment-relationships'),
+    url(r'^authors/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)',
+        AuthorRelationshipView.as_view(),
+        name='author-relationships'),
 ]
 
 


### PR DESCRIPTION
I was a bit confused by the various sources of urlpatterns, etc. and hopefully got it right. I ran both the example app with runserver and did a tox run too to make sure I didn't break that. 

For whatever reason, I was unable to get this to work by doing `export DJANGO_SETTINGS_MODULE=example.settings`  and various `django-admin.py` stuff as I got an error about module example not found. I'm not quite sure why that happened.

However, doing basically the same thing by creating `manage.py` works and, since `manage.py` is the usual documented approach, I think that's OK.

It's a little different from the usual pattern in that there's not a project directory with settings and then an example app directory; both are the same, but that's OK I think.

There's still one problem in here in that `http://127.0.0.1:8000/entries/2/relationships/suggested` returns a 404. I must have missed something. @mblayman Maybe you can find it quicker than I can.