### PR TITLE
Speed up JSONRenderer.extract_included

### DIFF
--- a/rest_framework_json_api/exceptions.py
+++ b/rest_framework_json_api/exceptions.py
@@ -2,12 +2,13 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import exceptions, status
 
-from rest_framework_json_api import renderers, utils
+from rest_framework_json_api import utils
 
 
 def rendered_with_json_api(view):
+    from rest_framework_json_api.renderers import JSONRenderer
     for renderer_class in getattr(view, 'renderer_classes', []):
-        if issubclass(renderer_class, renderers.JSONRenderer):
+        if issubclass(renderer_class, JSONRenderer):
             return True
     return False
 


### PR DESCRIPTION
I've hit a nasty performance issue with one of my index-type API endpoints. It returns only about 600 elements each with 3 additional resources included (one of them nested under another). The included resources are widely shared (loaded with `prefetch_related`). All database queries for this request taken together execute for less than 10ms, but the entire request takes over 2 seconds to complete. That's not reasonable at all.

Turns out main view code was taking *"only"* about 500ms (still a lot for this amount of data) while `JSONRenderer.render` was taking almost 2 seconds.

In this PR I am introducing some optimizations to `JSONRenderer.extract_included` – instead of serializing all related resources and then deduplicating them near the end, I pass a cache of serialized resources and skip processing when encountering the same resource.

Here are some measurements I've put around the `render` method. Before my changes:
```
Successfully completed rendering in 1.807s
Successfully completed rendering in 1.790s
Successfully completed rendering in 1.788s
Successfully completed rendering in 1.809s
```

After my changes:
```
Successfully completed rendering in 0.465s
Successfully completed rendering in 0.460s
Successfully completed rendering in 0.463s
Successfully completed rendering in 0.463s
```

Just to give the idea of how much time `extract_included` takes for my request and what is the ceiling for our optimizations I've ran another test with `extract_included` short-circuited to return immediately without extracting anything:
```
Successfully completed rendering in 0.054s
Successfully completed rendering in 0.056s
Successfully completed rendering in 0.054s
Successfully completed rendering in 0.054s
```

## Warning

Optimization in this PR is aggressive and there is a theoretical scenario where it could fail to extract some resources. It is related to nested included resources, e.g. `["contributors", "author.opinions"]`. If `author` happened to be first extracted via a different path (like `contributors`) then their related `opinions` would never get extracted.

I do not run this risk, because I don't include the same resource type via multiple paths in a single endpoint. I think this risk is acceptable for this library overall. Including one resource type via multiple paths in a single endpoint is already unsafe operation today – if you were to use different `Serializer` classes for these different paths then only one serialization would be kept for `included` key at the end of rendering. The versions of the same serialized resource would be discarded as long as they have the same `type` and `id` values.

## Caveat

I have focused on optimizing extraction via a simple `ResourceRelatedField`. There are more optimizations that can be made for `ListSerializer` and the `included_cache` dictionary that I have introduced paves the way for others to implement them.