### PR TITLE
Allow overwriting of get_queryset() of related field

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -373,7 +373,7 @@ class LineItemViewSet(viewsets.ModelViewSet):
     serializer_class = LineItemSerializer
 
     def get_queryset(self):
-        queryset = self.queryset
+        queryset = super(LineItemViewSet, self).get_queryset()
 
         # if this viewset is accessed via the 'order-lineitems-list' route,
         # it wll have been passed the `order_pk` kwarg and the queryset

--- a/example/tests/test_relations.py
+++ b/example/tests/test_relations.py
@@ -129,8 +129,13 @@ class TestResourceRelatedField(TestBase):
         }
 
 
+class BlogResourceRelatedField(ResourceRelatedField):
+    def get_queryset(self):
+        return Blog.objects
+
+
 class BlogFKSerializer(serializers.Serializer):
-    blog = ResourceRelatedField(queryset=Blog.objects)
+    blog = BlogResourceRelatedField()
 
 
 class EntryFKSerializer(serializers.Serializer):

--- a/rest_framework_json_api/mixins.py
+++ b/rest_framework_json_api/mixins.py
@@ -12,10 +12,11 @@ class MultipleIDMixin(object):
         """
         Override :meth:``get_queryset``
         """
+        queryset = super(MultipleIDMixin, self).get_queryset()
         if hasattr(self.request, 'query_params'):
             ids = dict(self.request.query_params).get('ids[]')
         else:
             ids = dict(self.request.QUERY_PARAMS).get('ids[]')
         if ids:
-            self.queryset = self.queryset.filter(id__in=ids)
-        return self.queryset
+            queryset = queryset.filter(id__in=ids)
+        return queryset

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -150,7 +150,7 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         if not isinstance(data, dict):
             self.fail('incorrect_type', data_type=type(data).__name__)
 
-        expected_relation_type = get_resource_type_from_queryset(self.queryset)
+        expected_relation_type = get_resource_type_from_queryset(self.get_queryset())
         serializer_resource_type = self.get_resource_type_from_included_serializer()
 
         if serializer_resource_type is not None:


### PR DESCRIPTION
As documented in http://www.django-rest-framework.org/api-guide/relations/#custom-relational-fields this allows to implement custom `ResourceRelatedField` where queryset is depended on context.