### PR TITLE
Don't output key for write only relations

### DIFF
--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -86,6 +86,10 @@ class JSONRenderer(renderers.JSONRenderer):
             if field_name == api_settings.URL_FIELD_NAME:
                 continue
 
+            # don't output a key for write only fields
+            if fields[field_name].write_only:
+                continue
+
             # Skip fields without relations
             if not isinstance(
                 field, (relations.RelatedField, relations.ManyRelatedField, BaseSerializer)


### PR DESCRIPTION
If the `write_only` key is `True` on a relationship, its key is still included in the response body with an empty resource object (`{'data': null}`).

This was fixed in #230 for normal fields but not for relations.