### PR TITLE
Issue 431: return all exceptions as JSON:API error objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,11 +31,15 @@ pip-delete-this-directory.txt
 
 # PyTest cache
 .cache/
+.pytest_cache/
+
 
 # Tox
 .tox/
 .cache/
 .python-version
+.coverage
+htmlcov/
 
 # VirtualEnv
 .venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 v2.5.0 - [unreleased]
+
 * Add new pagination classes based on JSON:API query parameter *recommendations*:
   * JsonApiPageNumberPagination and JsonApiLimitOffsetPagination. See [usage docs](docs/usage.md#pagination).
   * Deprecates PageNumberPagination and LimitOffsetPagination.
+* Add exception handling improvements:
+  * Document JSON_API_UNIFORM_EXCEPTIONS setting.
+  * Catch all exceptions not caught by DRF and format as JSON API error objects instead of returning HTML error pages.
+  * handle missing fields exception
 
 v2.4.0 - Released January 25, 2018
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,6 +82,14 @@ class MyLimitPagination(JsonApiLimitOffsetPagination):
     max_limit = None
 ```
 
+### Exception handling
+
+For the `exception_handler` class, if the optional `JSON_API_UNIFORM_EXCEPTIONS` is set to True,
+all exceptions will respond with the JSON API [error format](http://jsonapi.org/format/#error-objects).
+
+When `JSON_API_UNIFORM_EXCEPTIONS` is False (the default), non-JSON API views will respond
+with the normal DRF error format.
+
 ### Performance Testing
 
 If you are trying to see if your viewsets are configured properly to optimize performance,

--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,16 @@ deps =
     django111: Django>=1.11,<1.12
     drf36: djangorestframework>=3.6.3,<3.7
     drf37: djangorestframework>=3.7.0,<3.8
+    coverage
 
 setenv =
     PYTHONPATH = {toxinidir}
     DJANGO_SETTINGS_MODULE=example.settings.test
 
 commands =
-    python setup.py test {posargs}
+    coverage erase
+    coverage run setup.py test {posargs}
+    coverage html --include=rest_framework_json_api/*
 
 [testenv:isort]
 deps =


### PR DESCRIPTION
Fixes #431 
Fixes #326

## Description of the Change

Improve exception handling to return JSON:API [error](http://jsonapi.org/format/#errors) objects in all cases.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS`
