### PR TITLE
Extend ReadOnlyModelViewSet with prefetch mixins

### DIFF
--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -102,6 +102,12 @@ class ModelViewSet(AutoPrefetchMixin, PrefetchForIncludesHelperMixin, viewsets.M
     pass
 
 
+class ReadOnlyModelViewSet(AutoPrefetchMixin,
+                           PrefetchForIncludesHelperMixin,
+                           viewsets.ReadOnlyModelViewSet):
+    pass
+
+
 class RelationshipView(generics.GenericAPIView):
     serializer_class = ResourceIdentifierObjectSerializer
     self_link_view_name = None


### PR DESCRIPTION
This change creates a ReadOnlyModelViewSet with the required prefetch mixins.

## Description of the Change

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] changelog entry added to `CHANGELOG.md`
- [ ] author name in `AUTHORS`
