### PR TITLE
"Data" key optional in relationships

### DIFF
--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -134,10 +134,12 @@ class JSONRenderer(renderers.JSONRenderer):
                     if not resolved:
                         continue
 
+                relation_data = {}
                 # special case for ResourceRelatedField
-                relation_data = {
-                    'data': resource.get(field_name)
-                }
+                if field_name in resource:
+                    relation_data.update({
+                        'data': resource.get(field_name)
+                    })
 
                 field_links = field.get_links(
                     resource_instance, field.related_link_lookup_field)
@@ -188,9 +190,15 @@ class JSONRenderer(renderers.JSONRenderer):
 
                 if isinstance(field.child_relation, ResourceRelatedField):
                     # special case for ResourceRelatedField
-                    relation_data = {
-                        'data': resource.get(field_name)
-                    }
+                    relation_data = {}
+
+                    if field_name in resource:
+                        relation_data.update({
+                            'data': resource.get(field_name),
+                            'meta': {
+                                'count': len(resource.get(field_name))
+                            }
+                        })
 
                     field_links = field.child_relation.get_links(
                         resource_instance,
@@ -200,13 +208,7 @@ class JSONRenderer(renderers.JSONRenderer):
                         {'links': field_links}
                         if field_links else dict()
                     )
-                    relation_data.update(
-                        {
-                            'meta': {
-                                'count': len(resource.get(field_name))
-                            }
-                        }
-                    )
+
                     data.update({field_name: relation_data})
                     continue
 


### PR DESCRIPTION
Fixes #

## Description of the Change
This PR adds a flag `render_data` on ResourceRelatedField. Passing `render_data=False` will skip rendering "data" in responce, thus saving sql queries and improveing performance.

Json api docs says:
>A “relationship object” MUST contain at least one of the following: 
links, data, meta

Before:
```
"relationships": {
    "comments": {
        "data": [
             {
                 "type": "comments",
                  "id": "874"
             },
             {
                  "type": "comments",
                   "id": "877"
              },
              {
                  "type": "comments",
                  "id": "2273"
              }
       ],
       "links": {
           "self": "http://127.0.0.1:9000/drf/users/1/relationships/comments/",
           "related": "http://127.0.0.1:9000/drf/users/1/comments/",
           "first": "http://127.0.0.1:9000/drf/users/1/comments/?page=1",
            "last": "http://127.0.0.1:9000/drf/users/1/comments/?page=1",
            "next": null,
            "prev": null
       }
},
```

Using `comments=ResourceRelatedField(render_data=False, ...):

```
"relationships": {
    "comments": {
       "links": {
           "self": "http://127.0.0.1:9000/drf/users/1/relationships/comments/",
           "related": "http://127.0.0.1:9000/drf/users/1/comments/",
           "first": "http://127.0.0.1:9000/drf/users/1/comments/?page=1",
            "last": "http://127.0.0.1:9000/drf/users/1/comments/?page=1",
            "next": null,
            "prev": null
       }
},
```

## Checklist

- [ ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] changelog entry added to `CHANGELOG.md`
- [ ] author name in `AUTHORS`
