### PR TITLE
Improve REST_FRAMEWORK settings recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+[unreleased]
+
+* Add testing configuration to `REST_FRAMEWORK` configuration as described in [DRF](http://www.django-rest-framework.org/api-guide/testing/#configuration)
+* Add sorting configuration to `REST_FRAMEWORK` as defined in [json api spec](http://jsonapi.org/format/#fetching-sorting)
+
+
 v2.5.0 - Released July 11, 2018
 
 * Add new pagination classes based on JSON:API query parameter *recommendations*:

--- a/README.rst
+++ b/README.rst
@@ -140,7 +140,7 @@ override ``settings.REST_FRAMEWORK``
         'PAGE_SIZE': 10,
         'EXCEPTION_HANDLER': 'rest_framework_json_api.exceptions.exception_handler',
         'DEFAULT_PAGINATION_CLASS':
-            'rest_framework_json_api.pagination.PageNumberPagination',
+            'rest_framework_json_api.pagination.JsonApiPageNumberPagination',
         'DEFAULT_PARSER_CLASSES': (
             'rest_framework_json_api.parsers.JSONParser',
             'rest_framework.parsers.FormParser',
@@ -151,10 +151,14 @@ override ``settings.REST_FRAMEWORK``
             'rest_framework.renderers.BrowsableAPIRenderer',
         ),
         'DEFAULT_METADATA_CLASS': 'rest_framework_json_api.metadata.JSONAPIMetadata',
+        'DEFAULT_FILTER_BACKENDS': (
+            'rest_framework.filters.OrderingFilter',
+        ),
+        'ORDERING_PARAM': 'sort',
+        'TEST_REQUEST_RENDERER_CLASSES': (
+            'rest_framework_json_api.renderers.JSONRenderer',
+        ),
+        'TEST_REQUEST_DEFAULT_FORMAT': 'vnd.api+json'
     }
-
-If ``PAGINATE_BY`` is set the renderer will return a ``meta`` object with
-record count and a ``links`` object with the next and previous links. Pages
-can be specified with the ``page`` GET parameter.
 
 This package provides much more including automatic inflection of JSON keys, extra top level data (using nested serializers), relationships, links, and handy shortcuts like MultipleIDMixin. Read more at http://django-rest-framework-json-api.readthedocs.org/

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,6 +31,14 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.BrowsableAPIRenderer'
     ),
     'DEFAULT_METADATA_CLASS': 'rest_framework_json_api.metadata.JSONAPIMetadata',
+    'DEFAULT_FILTER_BACKENDS': (
+        'rest_framework.filters.OrderingFilter',
+    ),
+    'ORDERING_PARAM': 'sort',
+    'TEST_REQUEST_RENDERER_CLASSES': (
+        'rest_framework_json_api.renderers.JSONRenderer',
+    ),
+    'TEST_REQUEST_DEFAULT_FORMAT': 'vnd.api+json'
 }
 ```
 

--- a/example/settings/dev.py
+++ b/example/settings/dev.py
@@ -88,6 +88,10 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.BrowsableAPIRenderer',
     ),
     'DEFAULT_METADATA_CLASS': 'rest_framework_json_api.metadata.JSONAPIMetadata',
+    'DEFAULT_FILTER_BACKENDS': (
+        'rest_framework.filters.OrderingFilter',
+    ),
+    'ORDERING_PARAM': 'sort',
     'TEST_REQUEST_RENDERER_CLASSES': (
         'rest_framework_json_api.renderers.JSONRenderer',
     ),


### PR DESCRIPTION
Partially addresses #432

## Description of the Change

Improve `REST_FRAMEWORK` settings recommendation including:
* Testing configuration as explained [here](http://www.django-rest-framework.org/api-guide/testing/#configuration)
* Sorting configuration according to [json api spec](http://jsonapi.org/format/#fetching-sorting)

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS`