### PR TITLE
Document goals of Django REST Framework JSON API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,20 @@ like the following::
     }
 
 
+-----
+Goals
+-----
+
+As a Django REST Framework JSON API (short DJA) we are trying to address following goals:
+
+1. Support the [JSON API](http://jsonapi.org/) spec to compliance
+2. Be as compatible with Django REST Framework as possible
+   e.g. issues in Django REST Framework should be fixed upstream and not worked around in DJA
+3. Have sane defaults to be as easy to pick up as possible
+4. Be solid and tested with good coverage
+5. Be performant
+
+
 ------------
 Requirements
 ------------


### PR DESCRIPTION
Add goals of Django RESTFramework JSON API which we can reference to and use as basis in discussions of issues and pull requests.

This goals are extracted from following [comment](https://github.com/django-json-api/django-rest-framework-json-api/issues/155#issuecomment-301172555) made by @mblayman. I can fully agree to those points and think it is important to document those goals in a easy to find place.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS`
