### PR TITLE
Add support for related links using parent view and its permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add testing configuration to `REST_FRAMEWORK` configuration as described in [DRF](https://www.django-rest-framework.org/api-guide/testing/#configuration)
 * Add sorting configuration to `REST_FRAMEWORK` as defined in [json api spec](http://jsonapi.org/format/#fetching-sorting)
 * Add `HyperlinkedRelatedField` and `SerializerMethodHyperlinkedRelatedField`. See [usage docs](docs/usage.md#related-fields)
+* Add related urls support. See [usage docs](docs/usage.md#related-urls)
 
 
 v2.5.0 - Released July 11, 2018

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -443,6 +443,50 @@ class LineItemViewSet(viewsets.ModelViewSet):
 not render `data`. Use this in case you only need links of relationships and want to lower payload
 and increase performance.
 
+#### Related urls
+
+There is a nice way to handle "related" urls like `/orders/3/lineitems/` or `/orders/3/customer/`.
+All you need is just add to `urls.py`:
+```python
+url(r'^orders/(?P<pk>[^/.]+)/(?P<related_field>\w+)/$',
+        OrderViewSet.as_view({'get': 'retrieve_related'}),
+        name='order-related'),
+```
+Make sure that RelatedField declaration has `related_link_url_kwarg='pk'` or simply skipped (will be set by default):
+```python
+    line_items = ResourceRelatedField(
+        queryset=LineItem.objects,
+        many=True,
+        related_link_view_name='order-lineitems-list',
+        related_link_url_kwarg='pk',
+        self_link_view_name='order_relationships'
+    )
+
+    customer = ResourceRelatedField(
+        queryset=Customer.objects,
+        related_link_view_name='order-customer-detail',
+        self_link_view_name='order-relationships'
+    )
+```
+And, the most important part - declare serializer for each related entity:
+```python
+class OrderSerializer(serializers.HyperlinkedModelSerializer):
+    ...
+    related_serializers = {
+        'customer': 'example.serializers.CustomerSerializer',
+        'line_items': 'example.serializers.LineItemSerializer'
+    }
+```
+Or, if you already have `included_serializers` declared and your `related_serializers` look the same, just skip it:
+```python
+class OrderSerializer(serializers.HyperlinkedModelSerializer):
+    ...
+    included_serializers = {
+        'customer': 'example.serializers.CustomerSerializer',
+        'line_items': 'example.serializers.LineItemSerializer'
+    }
+```
+
 ### RelationshipView
 `rest_framework_json_api.views.RelationshipView` is used to build
 relationship views (see the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -448,6 +448,9 @@ and increase performance.
 There is a nice way to handle "related" urls like `/orders/3/lineitems/` or `/orders/3/customer/`.
 All you need is just add to `urls.py`:
 ```python
+url(r'^orders/(?P<pk>[^/.]+)/$',
+        OrderViewSet.as_view({'get': 'retrieve'}),
+        name='order-detail'),
 url(r'^orders/(?P<pk>[^/.]+)/(?P<related_field>\w+)/$',
         OrderViewSet.as_view({'get': 'retrieve_related'}),
         name='order-related'),
@@ -457,14 +460,14 @@ Make sure that RelatedField declaration has `related_link_url_kwarg='pk'` or sim
     line_items = ResourceRelatedField(
         queryset=LineItem.objects,
         many=True,
-        related_link_view_name='order-lineitems-list',
+        related_link_view_name='order-related',
         related_link_url_kwarg='pk',
-        self_link_view_name='order_relationships'
+        self_link_view_name='order-relationships'
     )
 
     customer = ResourceRelatedField(
         queryset=Customer.objects,
-        related_link_view_name='order-customer-detail',
+        related_link_view_name='order-related',
         self_link_view_name='order-relationships'
     )
 ```

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -166,6 +166,13 @@ class AuthorSerializer(serializers.ModelSerializer):
         queryset=Entry.objects,
         many=True
     )
+    first_entry = relations.SerializerMethodResourceRelatedField(
+        related_link_view_name='author-related',
+        self_link_view_name='author-relationships',
+        model=Entry,
+        read_only=True,
+        source='get_first_entry'
+    )
     included_serializers = {
         'bio': AuthorBioSerializer,
         'type': AuthorTypeSerializer
@@ -173,7 +180,10 @@ class AuthorSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Author
-        fields = ('name', 'email', 'bio', 'entries', 'type')
+        fields = ('name', 'email', 'bio', 'entries', 'first_entry', 'type')
+
+    def get_first_entry(self, obj):
+        return obj.entries.first()
 
 
 class WriterSerializer(serializers.ModelSerializer):

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -155,6 +155,17 @@ class AuthorBioSerializer(serializers.ModelSerializer):
 
 
 class AuthorSerializer(serializers.ModelSerializer):
+    bio = relations.ResourceRelatedField(
+        related_link_view_name='author-related',
+        self_link_view_name='author-relationships',
+        queryset=AuthorBio.objects,
+    )
+    entries = relations.ResourceRelatedField(
+        related_link_view_name='author-related',
+        self_link_view_name='author-relationships',
+        queryset=Entry.objects,
+        many=True
+    )
     included_serializers = {
         'bio': AuthorBioSerializer,
         'type': AuthorTypeSerializer

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -177,6 +177,11 @@ class AuthorSerializer(serializers.ModelSerializer):
         'bio': AuthorBioSerializer,
         'type': AuthorTypeSerializer
     }
+    related_serializers = {
+        'bio': 'example.serializers.AuthorBioSerializer',
+        'entries': 'example.serializers.EntrySerializer',
+        'first_entry': 'example.serializers.EntrySerializer'
+    }
 
     class Meta:
         model = Author

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -13,7 +13,7 @@ from . import TestBase
 from .. import views
 from example.factories import AuthorFactory, EntryFactory
 from example.models import Author, Blog, Comment, Entry
-from example.serializers import AuthorBioSerializer, EntrySerializer, AuthorTypeSerializer
+from example.serializers import AuthorBioSerializer, AuthorTypeSerializer, EntrySerializer
 from example.views import AuthorViewSet
 
 

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -13,7 +13,7 @@ from . import TestBase
 from .. import views
 from example.factories import AuthorFactory, EntryFactory
 from example.models import Author, Blog, Comment, Entry
-from example.serializers import AuthorBioSerializer, EntrySerializer
+from example.serializers import AuthorBioSerializer, EntrySerializer, AuthorTypeSerializer
 from example.views import AuthorViewSet
 
 
@@ -269,6 +269,16 @@ class TestRelatedMixin(APITestCase):
         view = self._get_view(kwargs)
         got = view.get_serializer_class()
         self.assertEqual(got, EntrySerializer)
+
+    def test_get_serializer_comes_from_included_serializers(self):
+        kwargs = {'pk': self.author.id, 'related_field': 'type'}
+        view = self._get_view(kwargs)
+        related_serializers = view.serializer_class.related_serializers
+        delattr(view.serializer_class, 'related_serializers')
+        got = view.get_serializer_class()
+        self.assertEqual(got, AuthorTypeSerializer)
+
+        view.serializer_class.related_serializers = related_serializers
 
     def test_get_serializer_class_raises_error(self):
         kwargs = {'pk': self.author.id, 'related_field': 'type'}

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -2,14 +2,19 @@ import json
 
 from django.test import RequestFactory
 from django.utils import timezone
+from rest_framework.exceptions import NotFound
+from rest_framework.request import Request
 from rest_framework.reverse import reverse
-from rest_framework.test import APITestCase, force_authenticate
+from rest_framework.test import APIRequestFactory, APITestCase, force_authenticate
 
 from rest_framework_json_api.utils import format_resource_type
 
 from . import TestBase
 from .. import views
+from example.factories import AuthorFactory, EntryFactory
 from example.models import Author, Blog, Comment, Entry
+from example.serializers import AuthorBioSerializer, EntrySerializer
+from example.views import AuthorViewSet
 
 
 class TestRelationshipView(APITestCase):
@@ -223,6 +228,86 @@ class TestRelationshipView(APITestCase):
         }
         response = self.client.delete(url, data=request_data)
         assert response.status_code == 200, response.content.decode()
+
+
+class TestRelatedMixin(APITestCase):
+
+    def setUp(self):
+        self.author = AuthorFactory()
+
+    def _get_view(self, kwargs):
+        factory = APIRequestFactory()
+        request = Request(factory.get('', content_type='application/vnd.api+json'))
+        return AuthorViewSet(request=request, kwargs=kwargs)
+
+    def test_get_related_field_name(self):
+        kwargs = {'pk': self.author.id, 'related_field': 'bio'}
+        view = self._get_view(kwargs)
+        got = view.get_related_field_name()
+        self.assertEqual(got, kwargs['related_field'])
+
+    def test_get_related_instance_serializer_field(self):
+        kwargs = {'pk': self.author.id, 'related_field': 'bio'}
+        view = self._get_view(kwargs)
+        got = view.get_related_instance()
+        self.assertEqual(got, self.author.bio)
+
+    def test_get_related_instance_model_field(self):
+        kwargs = {'pk': self.author.id, 'related_field': 'id'}
+        view = self._get_view(kwargs)
+        got = view.get_related_instance()
+        self.assertEqual(got, self.author.id)
+
+    def test_get_serializer_class(self):
+        kwargs = {'pk': self.author.id, 'related_field': 'bio'}
+        view = self._get_view(kwargs)
+        got = view.get_serializer_class()
+        self.assertEqual(got, AuthorBioSerializer)
+
+    def test_get_serializer_class_many(self):
+        kwargs = {'pk': self.author.id, 'related_field': 'entries'}
+        view = self._get_view(kwargs)
+        got = view.get_serializer_class()
+        self.assertEqual(got, EntrySerializer)
+
+    def test_get_serializer_class_raises_error(self):
+        kwargs = {'pk': self.author.id, 'related_field': 'type'}
+        view = self._get_view(kwargs)
+        self.assertRaises(NotFound, view.get_serializer_class)
+
+    def test_retrieve_related_single(self):
+        url = reverse('author-related', kwargs={'pk': self.author.pk, 'related_field': 'bio'})
+        resp = self.client.get(url)
+        expected = {
+            'data': {
+                'type': 'authorBios', 'id': str(self.author.bio.id),
+                'relationships': {
+                    'author': {'data': {'type': 'authors', 'id': str(self.author.id)}}},
+                'attributes': {
+                    'body': str(self.author.bio.body)
+                },
+            }
+        }
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), expected)
+
+    def test_retrieve_related_many(self):
+        entry = EntryFactory(authors=self.author)
+        url = reverse('author-related', kwargs={'pk': self.author.pk, 'related_field': 'entries'})
+        resp = self.client.get(url)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(isinstance(resp.json()['data'], list))
+        self.assertEqual(len(resp.json()['data']), 1)
+        self.assertEqual(resp.json()['data'][0]['id'], str(entry.id))
+
+    def test_retrieve_related_None(self):
+        kwargs = {'pk': self.author.pk, 'related_field': 'first_entry'}
+        url = reverse('author-related', kwargs=kwargs)
+        resp = self.client.get(url)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {'data': None})
 
 
 class TestValidationErrorResponses(TestBase):

--- a/example/urls.py
+++ b/example/urls.py
@@ -45,6 +45,10 @@ urlpatterns = [
         EntryViewSet.as_view({'get': 'retrieve'}),
         name='entry-featured'),
 
+    url(r'^authors/(?P<pk>[^/.]+)/(?P<related_field>\w+)/$',
+        AuthorViewSet.as_view({'get': 'retrieve_related'}),
+        name='author-related'),
+
     url(r'^entries/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)',
         EntryRelationshipView.as_view(),
         name='entry-relationships'),

--- a/example/urls_test.py
+++ b/example/urls_test.py
@@ -56,6 +56,10 @@ urlpatterns = [
         EntryViewSet.as_view({'get': 'retrieve'}),
         name='entry-featured'),
 
+    url(r'^authors/(?P<pk>[^/.]+)/(?P<related_field>\w+)/$',
+        AuthorViewSet.as_view({'get': 'retrieve_related'}),
+        name='author-related'),
+
     url(r'^entries/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)',
         EntryRelationshipView.as_view(),
         name='entry-relationships'),

--- a/example/views.py
+++ b/example/views.py
@@ -7,11 +7,10 @@ import rest_framework_json_api.parsers
 import rest_framework_json_api.renderers
 from rest_framework_json_api.pagination import PageNumberPagination
 from rest_framework_json_api.utils import format_drf_errors
-from rest_framework_json_api.views import ModelViewSet, RelatedMixin, RelationshipView
+from rest_framework_json_api.views import ModelViewSet, RelationshipView
 
 from example.models import Author, Blog, Comment, Company, Entry, Project
 from example.serializers import (
-    AuthorBioSerializer,
     AuthorSerializer,
     BlogSerializer,
     CommentSerializer,
@@ -93,12 +92,12 @@ class NonPaginatedEntryViewSet(EntryViewSet):
     pagination_class = NoPagination
 
 
-class AuthorViewSet(RelatedMixin, ModelViewSet):
+class AuthorViewSet(ModelViewSet):
     queryset = Author.objects.all()
     serializer_class = AuthorSerializer
     related_serializers = {
-        'bio': AuthorBioSerializer,
-        'entries': EntrySerializer
+        'bio': 'example.serializers.AuthorBioSerializer',
+        'entries': 'example.serializers.EntrySerializer'
     }
 
 

--- a/example/views.py
+++ b/example/views.py
@@ -95,11 +95,6 @@ class NonPaginatedEntryViewSet(EntryViewSet):
 class AuthorViewSet(ModelViewSet):
     queryset = Author.objects.all()
     serializer_class = AuthorSerializer
-    related_serializers = {
-        'bio': 'example.serializers.AuthorBioSerializer',
-        'entries': 'example.serializers.EntrySerializer',
-        'first_entry': 'example.serializers.EntrySerializer'
-    }
 
 
 class CommentViewSet(ModelViewSet):

--- a/example/views.py
+++ b/example/views.py
@@ -97,7 +97,8 @@ class AuthorViewSet(ModelViewSet):
     serializer_class = AuthorSerializer
     related_serializers = {
         'bio': 'example.serializers.AuthorBioSerializer',
-        'entries': 'example.serializers.EntrySerializer'
+        'entries': 'example.serializers.EntrySerializer',
+        'first_entry': 'example.serializers.EntrySerializer'
     }
 
 

--- a/example/views.py
+++ b/example/views.py
@@ -7,10 +7,11 @@ import rest_framework_json_api.parsers
 import rest_framework_json_api.renderers
 from rest_framework_json_api.pagination import PageNumberPagination
 from rest_framework_json_api.utils import format_drf_errors
-from rest_framework_json_api.views import ModelViewSet, RelationshipView
+from rest_framework_json_api.views import ModelViewSet, RelatedMixin, RelationshipView
 
 from example.models import Author, Blog, Comment, Company, Entry, Project
 from example.serializers import (
+    AuthorBioSerializer,
     AuthorSerializer,
     BlogSerializer,
     CommentSerializer,
@@ -92,9 +93,13 @@ class NonPaginatedEntryViewSet(EntryViewSet):
     pagination_class = NoPagination
 
 
-class AuthorViewSet(ModelViewSet):
+class AuthorViewSet(RelatedMixin, ModelViewSet):
     queryset = Author.objects.all()
     serializer_class = AuthorSerializer
+    related_serializers = {
+        'bio': AuthorBioSerializer,
+        'entries': EntrySerializer
+    }
 
 
 class CommentViewSet(ModelViewSet):

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -116,7 +116,11 @@ class HyperlinkedMixin(object):
         })
         self_link = self.get_url('self', self.self_link_view_name, self_kwargs, request)
 
-        related_kwargs = {self.related_link_url_kwarg: kwargs[self.related_link_lookup_field]}
+        if self.related_link_url_kwarg == 'pk':
+            related_kwargs = self_kwargs
+        else:
+            related_kwargs = {self.related_link_url_kwarg: kwargs[self.related_link_lookup_field]}
+
         related_link = self.get_url('related', self.related_link_view_name, related_kwargs, request)
 
         if self_link:

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -118,9 +118,11 @@ class HyperlinkedMixin(object):
 
         """
         Assuming RelatedField will be declared in two ways:
-        1. url(r'^authors/(?P<pk>[^/.]+)/(?P<related_field>\w+)/$', AuthorViewSet.as_view({'get': 'retrieve_related'}))
-        2. url(r'^authors/(?P<author_pk>[^/.]+)/bio/$', AuthorBioViewSet.as_view({'get': 'retrieve'}))
-        In other words if related_link_url_kwarg == 'pk' it will add 'related_field' parameter to reverse()
+        1. url(r'^authors/(?P<pk>[^/.]+)/(?P<related_field>\w+)/$',
+                AuthorViewSet.as_view({'get': 'retrieve_related'}))
+        2. url(r'^authors/(?P<author_pk>[^/.]+)/bio/$',
+                AuthorBioViewSet.as_view({'get': 'retrieve'}))
+        So, if related_link_url_kwarg == 'pk' it will add 'related_field' parameter to reverse()
         """
         if self.related_link_url_kwarg == 'pk':
             related_kwargs = self_kwargs

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -116,6 +116,12 @@ class HyperlinkedMixin(object):
         })
         self_link = self.get_url('self', self.self_link_view_name, self_kwargs, request)
 
+        """
+        Assuming RelatedField will be declared in two ways:
+        1. url(r'^authors/(?P<pk>[^/.]+)/(?P<related_field>\w+)/$', AuthorViewSet.as_view({'get': 'retrieve_related'}))
+        2. url(r'^authors/(?P<author_pk>[^/.]+)/bio/$', AuthorBioViewSet.as_view({'get': 'retrieve'}))
+        In other words if related_link_url_kwarg == 'pk' it will add 'related_field' parameter to reverse()
+        """
         if self.related_link_url_kwarg == 'pk':
             related_kwargs = self_kwargs
         else:

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -156,10 +156,18 @@ class RelatedMixin(object):
         return field_name
 
     def get_related_instance(self):
-        try:
-            return getattr(self.get_object(), self.get_related_field_name())
-        except AttributeError:
-            raise NotFound
+        parent_obj = self.get_object()
+        parent_serializer = self.serializer_class(parent_obj)
+        field_name = self.get_related_field_name()
+        field = parent_serializer.fields.get(field_name, None)
+
+        if field is not None:
+            return field.get_attribute(parent_obj)
+        else:
+            try:
+                return getattr(parent_obj, field_name)
+            except AttributeError:
+                raise NotFound
 
 
 class ModelViewSet(AutoPrefetchMixin,

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -133,20 +133,22 @@ class RelatedMixin(object):
 
             # Try get the class from related_serializers
             if hasattr(parent_serializer_class, 'related_serializers'):
-                class_str = parent_serializer_class.related_serializers.get(field_name, None)
-                if class_str is None:
+                _class = parent_serializer_class.related_serializers.get(field_name, None)
+                if _class is None:
                     raise NotFound
 
             elif hasattr(parent_serializer_class, 'included_serializers'):
-                class_str = parent_serializer_class.included_serializers.get(field_name, None)
-                if class_str is None:
+                _class = parent_serializer_class.included_serializers.get(field_name, None)
+                if _class is None:
                     raise NotFound
 
             else:
                 assert False, \
                     'Either "included_serializers" or "related_serializers" should be configured'
 
-            return import_class_from_dotted_path(class_str)
+            if not isinstance(_class, type):
+                return import_class_from_dotted_path(_class)
+            return _class
 
         return parent_serializer_class
 

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -106,6 +106,7 @@ class RelatedMixin(object):
     This mixin handles all related entities, whose Serializers are declared in "related_serializers"
     """
     related_serializers = {}
+    related_field_mapping = {}
 
     def retrieve_related(self, request, *args, **kwargs):
         serializer_kwargs = {}
@@ -137,12 +138,8 @@ class RelatedMixin(object):
 
     def get_related_field_name(self):
         field_name = self.kwargs['related_field']
-        # Making sure we're getting correct model field/property/method name
-        try:
-            return super(RelatedMixin, self).get_serializer_class()().fields[field_name].source
-        except KeyError:
-            # Looks like the field was not declared on the serializer
-            pass
+        if field_name in self.related_field_mapping:
+            return self.related_field_mapping[field_name]
         return field_name
 
     def get_related_instance(self):

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -133,8 +133,10 @@ class RelatedMixin(object):
         if 'related_field' in self.kwargs:
             field_name = self.kwargs['related_field']
 
-            assert hasattr(parent_serializer_class, 'included_serializers') or self.related_serializers,\
-                'Either "included_serializers" or "related_serializers" should be configured'
+            assert hasattr(parent_serializer_class, 'included_serializers')\
+                or self.related_serializers,\
+                'Either "included_serializers" or ' \
+                '"related_serializers" should be configured'
 
             # Try get the class from related_serializers
             class_str = self.related_serializers.get(field_name, None)

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -148,12 +148,16 @@ class RelatedMixin(object):
             raise NotFound
 
 
-class ModelViewSet(AutoPrefetchMixin, PrefetchForIncludesHelperMixin, viewsets.ModelViewSet):
+class ModelViewSet(AutoPrefetchMixin,
+                   PrefetchForIncludesHelperMixin,
+                   RelatedMixin,
+                   viewsets.ModelViewSet):
     pass
 
 
 class ReadOnlyModelViewSet(AutoPrefetchMixin,
                            PrefetchForIncludesHelperMixin,
+                           RelatedMixin,
                            viewsets.ReadOnlyModelViewSet):
     pass
 

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -11,6 +11,7 @@ from django.db.models.fields.related_descriptors import (
 from django.db.models.manager import Manager
 from django.db.models.query import QuerySet
 from django.urls import NoReverseMatch
+from django.utils.module_loading import import_string as import_class_from_dotted_path
 from rest_framework import generics, viewsets
 from rest_framework.exceptions import MethodNotAllowed, NotFound
 from rest_framework.response import Response
@@ -129,10 +130,10 @@ class RelatedMixin(object):
     def get_serializer_class(self):
         if 'related_field' in self.kwargs:
             field_name = self.get_related_field_name()
-            _class = self.related_serializers.get(field_name, None)
-            if _class is None:
+            class_str = self.related_serializers.get(field_name, None)
+            if class_str is None:
                 raise NotFound
-            return _class
+            return import_class_from_dotted_path(class_str)
         return super(RelatedMixin, self).get_serializer_class()
 
     def get_related_field_name(self):


### PR DESCRIPTION
Fixes #450 
Fixes #426

## Description of the Change

Add `RelatedMixin`. This introduces new approach in handling related urls/entities. `RelatedMixin` will handle all related entities, configured in `related_serializers` dict with no related views required. Also it will check permissions for parent object for any related entity.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS`
