### PR TITLE
Avoid exception when trying to include skipped relationship

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Yaniv Peer <yanivpeer@gmail.com>
 Mohammed Ali Zubair <mazg1493@gmail.com>
 Jason Housley <housleyjk@gmail.com>
 Beni Keller <beni@matraxi.ch>
+Stas S. <stas@nerd.ro>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ any parts of the framework not mentioned in the documentation should generally b
 
 ### Fixed
 
-* Resource related fields can be blank, serializer/renderer should skip these.
+* Avoid exception when trying to include skipped relationship
 
 ## [2.7.0] - 2019-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST Framework policy](http://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
+## [Unreleased]
+
+### Fixed
+
+* Resource related fields can be blank, serializer/renderer should skip these.
 
 ## [2.7.0] - 2019-01-14
 

--- a/example/tests/integration/test_polymorphism.py
+++ b/example/tests/integration/test_polymorphism.py
@@ -25,10 +25,13 @@ def test_polymorphism_on_detail_relations(single_company, client):
 
 
 def test_polymorphism_on_included_relations(single_company, client):
-    response = client.get(reverse("company-detail", kwargs={'pk': single_company.pk}) +
-                          '?include=current_project,future_projects')
+    response = client.get(
+        reverse("company-detail", kwargs={'pk': single_company.pk}) +
+        '?include=current_project,future_projects,current_art_project,current_research_project')
     content = response.json()
     assert content["data"]["relationships"]["currentProject"]["data"]["type"] == "artProjects"
+    assert content["data"]["relationships"]["currentArtProject"]["data"]["type"] == "artProjects"
+    assert content["data"]["relationships"]["currentResearchProject"]["data"] is None
     assert (
         set([rel["type"] for rel in content["data"]["relationships"]["futureProjects"]["data"]]) ==
         set(["researchProjects", "artProjects"])

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -375,7 +375,7 @@ class JSONRenderer(renderers.JSONRenderer):
                 serializer_data = field.data
 
             if isinstance(field, relations.RelatedField):
-                if relation_instance is None:
+                if relation_instance is None or not serializer_data:
                     continue
 
                 many = field._kwargs.get('child_relation', None) is not None


### PR DESCRIPTION
# Fixes

It is a very weird error I hit. We are using the DRF-JSONAPI to build 
https://github.com/occrp/id-backend

One of the packages we use is [django-simple-activity](https://github.com/richardARPANET/django-simple-activity). Where this package provides a model with a polymorphic relationship which we renamed in our project based on the relationship type:
https://github.com/occrp/id-backend/blob/master/api_v3/serializers/action.py#L55-L62

I get a strange error [when I try to include dynamically](https://github.com/occrp/id-backend/blob/master/api_v3/tests/views/test_activities.py#L55-L78) in the payload the renamed relationships.

## Description of the Change

I tracked down the error here:
https://github.com/django-json-api/django-rest-framework-json-api/blob/master/rest_framework_json_api/renderers.py#L356

I was not able to reproduce it as part of the DRF-JSONAPI test suite, unfortunately (the most related changes set is #412). I'll be more than happy to provide some tests if you could direct me or just explain a bit the purpose of the `extract_included()` arguments... Maybe I'm doing something wrong.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS`

Thanks in advance for any help or for reviewing this!!!