### PR TITLE
Move to keep a changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,6 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Replaced binary `drf_example` sqlite3 db with a [fixture](example/fixtures/drf_example.json). See [getting started](docs/getting-started.md#running-the-example-app).
 
-### Deprecated
-
-* For naming consistency, renamed new `JsonApi`-prefix pagination classes to `JSONAPI`-prefix.
-  * Deprecates `JsonApiPageNumberPagination` and `JsonApiLimitOffsetPagination`
-
 ### Fixed
 
 * Performance improvement when rendering relationships with `ModelSerializer`


### PR DESCRIPTION
Fixes #470

Includes documentation of versioning and deprecation policy.

This change will also help to better document deprecation changes like currently proposed in https://github.com/django-json-api/django-rest-framework-json-api/pull/469