### PR TITLE
renamed JSONAPIOrderingFilter to OrderingFilter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,7 @@ override ``settings.REST_FRAMEWORK``
         ),
         'DEFAULT_METADATA_CLASS': 'rest_framework_json_api.metadata.JSONAPIMetadata',
         'DEFAULT_FILTER_BACKENDS': (
-            'rest_framework_json_api.filters.JSONAPIOrderingFilter',
+            'rest_framework_json_api.filters.OrderingFilter',
             'rest_framework_json_api.django_filters.DjangoFilterBackend',
         ),
         'TEST_REQUEST_RENDERER_CLASSES': (

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,7 +33,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_METADATA_CLASS': 'rest_framework_json_api.metadata.JSONAPIMetadata',
     'DEFAULT_FILTER_BACKENDS': (
-        'rest_framework_json_api.filters.JSONAPIOrderingFilter',
+        'rest_framework_json_api.filters.OrderingFilter',
         'rest_framework_json_api.django_filters.DjangoFilterBackend',
     ),
     'TEST_REQUEST_RENDERER_CLASSES': (
@@ -104,8 +104,8 @@ class MyLimitPagination(JsonApiLimitOffsetPagination):
 
 _There are several anticipated JSON:API-specific filter backends in development. The first two are described below._
 
-#### `JSONAPIOrderingFilter`
-`JSONAPIOrderingFilter` implements the [JSON:API `sort`](http://jsonapi.org/format/#fetching-sorting) and uses
+#### `OrderingFilter`
+`OrderingFilter` implements the [JSON:API `sort`](http://jsonapi.org/format/#fetching-sorting) and uses
 DRF's [ordering filter](http://django-rest-framework.readthedocs.io/en/latest/api-guide/filtering/#orderingfilter).
 
 Per the JSON:API specification, "If the server does not support sorting as specified in the query parameter `sort`,
@@ -186,7 +186,7 @@ from rest_framework_json_api import django_filters
 class MyViewset(ModelViewSet):
     queryset = MyModel.objects.all()
     serializer_class = MyModelSerializer
-    filter_backends = (filters.JSONAPIOrderingFilter, django_filters.DjangoFilterBackend,)
+    filter_backends = (filters.OrderingFilter, django_filters.DjangoFilterBackend,)
 ```
 
 

--- a/example/settings/dev.py
+++ b/example/settings/dev.py
@@ -90,7 +90,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_METADATA_CLASS': 'rest_framework_json_api.metadata.JSONAPIMetadata',
     'DEFAULT_FILTER_BACKENDS': (
-        'rest_framework_json_api.filters.JSONAPIOrderingFilter',
+        'rest_framework_json_api.filters.OrderingFilter',
         'rest_framework_json_api.django_filters.DjangoFilterBackend',
     ),
     'TEST_REQUEST_RENDERER_CLASSES': (

--- a/rest_framework_json_api/filters/__init__.py
+++ b/rest_framework_json_api/filters/__init__.py
@@ -1,1 +1,1 @@
-from .sort import JSONAPIOrderingFilter  # noqa: F401
+from .sort import OrderingFilter  # noqa: F401

--- a/rest_framework_json_api/filters/sort.py
+++ b/rest_framework_json_api/filters/sort.py
@@ -4,7 +4,7 @@ from rest_framework.filters import OrderingFilter
 from rest_framework_json_api.utils import format_value
 
 
-class JSONAPIOrderingFilter(OrderingFilter):
+class OrderingFilter(OrderingFilter):
     """
     This implements http://jsonapi.org/format/#fetching-sorting and raises 400
     if any sort field is invalid. If you prefer *not* to report 400 errors for
@@ -40,5 +40,5 @@ class JSONAPIOrderingFilter(OrderingFilter):
             else:
                 underscore_fields.append(format_value(item_rewritten, "underscore"))
 
-        return super(JSONAPIOrderingFilter, self).remove_invalid_fields(
+        return super(OrderingFilter, self).remove_invalid_fields(
             queryset, underscore_fields, view, request)


### PR DESCRIPTION
Fixes #471

## Description of the Change
Remove "JSONAPI" prefix from `OrderingFilter` before it is released.

No CHANGELOG.md changes needed as it's covered by "Add optional [jsonapi-style](http://jsonapi.org/format/) filter backends. See [usage docs](docs/usage.md#filter-backends)"

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] documentation updated
- [x] author name in `AUTHORS`
