### PR TITLE
deprecate MultipleIDMixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ any parts of the framework not mentioned in the documentation should generally b
 * Add related urls support. See [usage docs](docs/usage.md#related-urls)
 * Add optional [jsonapi-style](http://jsonapi.org/format/) filter backends. See [usage docs](docs/usage.md#filter-backends)
 
+### Deprecated
+
+* Deprecate `MultipleIDMixin` because it doesn't comply with the JSON:API 1.0 spec. Replace it with
+  `DjangoFilterBackend` and **change clients** to use `filter[id.in]` query parameter instead of `ids[]`.
+  See [usage docs](docs/usage.md#djangofilterbackend).
+
 ### Changed
 
 * Replaced binary `drf_example` sqlite3 db with a [fixture](example/fixtures/drf_example.json). See [getting started](docs/getting-started.md#running-the-example-app).

--- a/README.rst
+++ b/README.rst
@@ -184,4 +184,6 @@ override ``settings.REST_FRAMEWORK``
         'TEST_REQUEST_DEFAULT_FORMAT': 'vnd.api+json'
     }
 
-This package provides much more including automatic inflection of JSON keys, extra top level data (using nested serializers), relationships, links, and handy shortcuts like MultipleIDMixin. Read more at http://django-rest-framework-json-api.readthedocs.org/
+This package provides much more including automatic inflection of JSON keys, extra top level data (using nested
+serializers), relationships, links, paginators, filters, and handy shortcuts.
+Read more at http://django-rest-framework-json-api.readthedocs.org/

--- a/rest_framework_json_api/mixins.py
+++ b/rest_framework_json_api/mixins.py
@@ -1,12 +1,28 @@
 """
 Class Mixins.
 """
+import warnings
 
 
 class MultipleIDMixin(object):
     """
     Override get_queryset for multiple id support
+
+    .. warning::
+
+        MultipleIDMixin is deprecated because it does not comply with http://jsonapi.org/format.
+        Instead add :py:class:`django_filters.DjangoFilterBackend` to your
+        list of `filter_backends` and change client usage from:
+        ``?ids[]=id1,id2,...,idN`` to ``'?filter[id.in]=id1,id2,...,idN``
+
     """
+    def __init__(self, *args, **kwargs):
+        warnings.warn("MultipleIDMixin is deprecated. "
+                      "Instead add django_filters.DjangoFilterBackend to your "
+                      "list of 'filter_backends' and change client usage from: "
+                      "'?ids[]=id1,id2,...,idN' to '?filter[id.in]=id1,id2,...,idN'",
+                      DeprecationWarning)
+        super(MultipleIDMixin, self).__init__(*args, **kwargs)
 
     def get_queryset(self):
         """


### PR DESCRIPTION
Fixes #480 

## Description of the Change

Deprecates `MultipleIDMixin` now that there's a JSON:API spec-compliant version (#466) using
`filter[id.in]=` instead of `ids[]=`. This will require **client changes** to change the query param.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS`

