### PR TITLE
Don't render empty objects on relationships

### DIFF
--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -143,7 +143,7 @@ class JSONRenderer(renderers.JSONRenderer):
             if isinstance(field, HyperlinkedMixin):
                 field_links = field.get_links(resource_instance, field.related_link_lookup_field)
                 relation_data.update({'links': field_links} if field_links else dict())
-                data.update({field_name: relation_data})
+                data.update({field_name: relation_data} if relation_data else dict())
 
             if isinstance(field, (ResourceRelatedField, )):
                 relation_instance_id = getattr(resource_instance, source + "_id", None)


### PR DESCRIPTION
## Description of the Change

REGRESION (version 2.6)

In previous versions, OneToOneFields without Hyperlink settings in its Serializer doesn't render anything.

In version 2.6, an empty JSON object is rendered.

## Checklist

- [X] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] changelog entry added to `CHANGELOG.md`
- [ ] author name in `AUTHORS`
