### PR TITLE
Remove obsolete packaging dependency

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,5 +1,4 @@
 # Requirements specifically for the example app
-packaging
 Django>=1.11
 django-debug-toolbar
 django-polymorphic>=2.0

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -1,8 +1,5 @@
 from datetime import datetime
 
-import rest_framework
-from packaging import version
-
 from rest_framework_json_api import relations, serializers
 
 from example.models import (
@@ -267,5 +264,4 @@ class CompanySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Company
-        if version.parse(rest_framework.VERSION) >= version.parse('3.3'):
-            fields = '__all__'
+        fields = '__all__'

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -5,7 +5,6 @@ factory-boy
 Faker
 isort
 mock
-packaging==16.8
 pytest
 pytest-django
 pytest-factoryboy

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,6 @@ setup(
         'pytest',
         'pytest-cov',
         'django-polymorphic>=2.0',
-        'packaging',
         'django-debug-toolbar'
     ] + mock,
     zip_safe=False,


### PR DESCRIPTION
## Description of the Change

DRF 3.3 is not supported anymore since DJA version 2.4.0

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS`

Deliberately left out CHANGELOG entry as this is only a internal change and not relevant to DJA user.