### PR TITLE
Adjust to new flake8 3.6.0 version

### DIFF
--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -4,7 +4,7 @@ django-filter>=2.0
 django-polymorphic>=2.0
 factory-boy
 Faker
-flake8
+flake8==3.6.0
 flake8-isort
 isort
 mock

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -116,14 +116,12 @@ class HyperlinkedMixin(object):
         })
         self_link = self.get_url('self', self.self_link_view_name, self_kwargs, request)
 
-        """
-        Assuming RelatedField will be declared in two ways:
-        1. url(r'^authors/(?P<pk>[^/.]+)/(?P<related_field>\w+)/$',
-                AuthorViewSet.as_view({'get': 'retrieve_related'}))
-        2. url(r'^authors/(?P<author_pk>[^/.]+)/bio/$',
-                AuthorBioViewSet.as_view({'get': 'retrieve'}))
-        So, if related_link_url_kwarg == 'pk' it will add 'related_field' parameter to reverse()
-        """
+        # Assuming RelatedField will be declared in two ways:
+        # 1. url(r'^authors/(?P<pk>[^/.]+)/(?P<related_field>\w+)/$',
+        #         AuthorViewSet.as_view({'get': 'retrieve_related'}))
+        # 2. url(r'^authors/(?P<author_pk>[^/.]+)/bio/$',
+        #         AuthorBioViewSet.as_view({'get': 'retrieve'}))
+        # So, if related_link_url_kwarg == 'pk' it will add 'related_field' parameter to reverse()
         if self.related_link_url_kwarg == 'pk':
             related_kwargs = self_kwargs
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,12 +5,13 @@ test = pytest
 universal = 1
 
 [flake8]
-ignore = F405
+ignore = F405,W504
 max-line-length = 100
 exclude =
-    docs/conf.py,
     build,
+    docs/conf.py,
     migrations,
+    .eggs
     .tox,
 
 [isort]
@@ -21,7 +22,12 @@ known_localfolder = example
 known_standard_library = mock
 line_length = 100
 multi_line_output = 3
-skip=migrations,.tox,docs/conf.py
+skip=
+    build,
+    docs/conf.py,
+    migrations,
+    .eggs
+    .tox,
 
 [coverage:report]
 omit=


### PR DESCRIPTION
## Description of the Change

As we do not have pinned dependencies linting broke as of automatic update to 3.6.0.

Pinned flake8 version and fixed linting.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS`
