### PR TITLE
Use pytest instead of py.test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,7 +142,7 @@ installed and activated:
 
     $ pip install -r requirements-development.txt
     $ flake8
-    $ DJANGO_SETTINGS_MODULE=example.settings.test py.test
+    $ pytest
 
 -----
 Usage


### PR DESCRIPTION
py.test is the old way of running pytest.

Also remove DJANGO_SETTINGS_MODULE env when running tests. This is already defined in pytest.ini and py.test will take it from as it should also take parameters we might add in pytest.ini in the future.

I have overlooked this change in #498 

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] changelog entry added to `CHANGELOG.md`
- [ ] author name in `AUTHORS`
