### PR TITLE
Adjust warning to state to move to JSON_API_FORMAT_FIELD_NAMES

### DIFF
--- a/example/settings/test.py
+++ b/example/settings/test.py
@@ -9,7 +9,7 @@ DATABASES = {
 
 ROOT_URLCONF = 'example.urls_test'
 
-JSON_API_FIELD_NAMES = 'camelize'
+JSON_API_FORMAT_FIELD_NAMES = 'camelize'
 JSON_API_FORMAT_TYPES = 'camelize'
 JSON_API_PLURALIZE_TYPES = True
 

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -133,7 +133,7 @@ def format_keys(obj, format_type=None):
 
         `format_keys` function and `JSON_API_FORMAT_KEYS` setting are deprecated and will be
         removed in the future.
-        Use `format_field_names` and `JSON_API_FIELD_NAMES` instead. Be aware that
+        Use `format_field_names` and `JSON_API_FORMAT_FIELD_NAMES` instead. Be aware that
         `format_field_names` only formats keys and preserves value.
 
     Takes either a dict or list and returns it with camelized keys only if
@@ -144,7 +144,7 @@ def format_keys(obj, format_type=None):
     warnings.warn(
         "`format_keys` function and `JSON_API_FORMAT_KEYS` setting are deprecated and will be "
         "removed in the future. "
-        "Use `format_field_names` and `JSON_API_FIELD_NAMES` instead. Be aware that "
+        "Use `format_field_names` and `JSON_API_FORMAT_FIELD_NAMES` instead. Be aware that "
         "`format_field_names` only formats keys and preserves value.",
         DeprecationWarning
     )


### PR DESCRIPTION
## Description of the Change

Changelog entry was correct so not adding a new one which would only add noise.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS`
