### PR TITLE
Don't render write only relations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@ Adam Ziolkowski <adam@adsized.com>
 Alan Crosswell <alan@columbia.edu>
 Anton Shutik <shutikanton@gmail.com>
 Christian Zosel <https://zosel.ch>
+David Vogt <david.vogt@adfinis-sygroup.ch>
 Greg Aker <greg@gregaker.net>
 Jamie Bliss <astronouth7303@gmail.com>
 Jerel Unruh <mail@unruhdesigns.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ any parts of the framework not mentioned in the documentation should generally b
 * Pass context from `PolymorphicModelSerializer` to child serializers to support fields which require a `request` context such as `url`.
 * Avoid patch on `RelationshipView` deleting relationship instance when constraint would allow null ([#242](https://github.com/django-json-api/django-rest-framework-json-api/issues/242))
 * Avoid error with related urls when retrieving relationship which is referenced as `ForeignKey` on parent
-* No longer show `write_only` relation fields
+* Do not render `write_only` relations
 
 
 ## [2.6.0] - 2018-09-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ any parts of the framework not mentioned in the documentation should generally b
 * Pass context from `PolymorphicModelSerializer` to child serializers to support fields which require a `request` context such as `url`.
 * Avoid patch on `RelationshipView` deleting relationship instance when constraint would allow null ([#242](https://github.com/django-json-api/django-rest-framework-json-api/issues/242))
 * Avoid error with related urls when retrieving relationship which is referenced as `ForeignKey` on parent
+* No longer show `write_only` relation fields
 
 
 ## [2.6.0] - 2018-09-20

--- a/example/tests/unit/test_renderers.py
+++ b/example/tests/unit/test_renderers.py
@@ -46,7 +46,7 @@ class ReadOnlyDummyTestViewSet(views.ReadOnlyModelViewSet):
 
 
 def render_dummy_test_serialized_view(view_class):
-    serializer = DummyTestSerializer(instance=Entry())
+    serializer = view_class.serializer_class(instance=Entry())
     renderer = JSONRenderer()
     return renderer.render(
         serializer.data,

--- a/example/tests/unit/test_renderers.py
+++ b/example/tests/unit/test_renderers.py
@@ -112,9 +112,7 @@ def test_writeonly_not_in_response(settings):
         queryset = Entry.objects.all()
         serializer_class = WriteonlyTestSerializer
 
-
     rendered = render_dummy_test_serialized_view(WriteOnlyDummyTestViewSet)
-
     result = json.loads(rendered.decode())
 
     assert 'rating' not in result['data']['attributes']

--- a/example/tests/unit/test_renderers.py
+++ b/example/tests/unit/test_renderers.py
@@ -87,3 +87,35 @@ def test_render_format_keys(settings):
 
     result = json.loads(rendered.decode())
     assert result['data']['attributes']['json-field'] == {'json-key': 'JsonValue'}
+
+
+def test_writeonly_not_in_response(settings):
+    """Test that writeonly fields are not shown in list response"""
+
+    settings.JSON_API_FORMAT_FIELD_NAMES = 'dasherize'
+
+    class WriteonlyTestSerializer(serializers.ModelSerializer):
+        '''Serializer for testing the absence of write_only fields'''
+        comments = serializers.ResourceRelatedField(
+            many=True,
+            write_only=True,
+            queryset=Comment.objects.all()
+        )
+
+        rating = serializers.IntegerField(write_only=True)
+
+        class Meta:
+            model = Entry
+            fields = ('comments', 'rating')
+
+    class WriteOnlyDummyTestViewSet(views.ReadOnlyModelViewSet):
+        queryset = Entry.objects.all()
+        serializer_class = WriteonlyTestSerializer
+
+
+    rendered = render_dummy_test_serialized_view(WriteOnlyDummyTestViewSet)
+
+    result = json.loads(rendered.decode())
+
+    assert 'rating' not in result['data']['attributes']
+    assert 'relationships' not in result['data']

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -99,6 +99,10 @@ class JSONRenderer(renderers.JSONRenderer):
             if field_name == api_settings.URL_FIELD_NAME:
                 continue
 
+            # don't output a key for write only fields
+            if fields[field_name].write_only:
+                continue
+
             # Skip fields without relations
             if not isinstance(
                 field, (relations.RelatedField, relations.ManyRelatedField, BaseSerializer)


### PR DESCRIPTION
Fixes #421 

## Description of the Change

Don't output key for write only relations.

This builds on top of #421 and adds the requested test cases.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS`

