### PR TITLE
Do not skip empty one-to-one relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ any parts of the framework not mentioned in the documentation should generally b
 * Avoid patch on `RelationshipView` deleting relationship instance when constraint would allow null ([#242](https://github.com/django-json-api/django-rest-framework-json-api/issues/242))
 * Avoid error with related urls when retrieving relationship which is referenced as `ForeignKey` on parent
 * Do not render `write_only` relations
+* Do not skip empty one-to-one relationships
 
 
 ## [2.6.0] - 2018-09-20

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -150,13 +150,6 @@ class JSONRenderer(renderers.JSONRenderer):
                 data.update({field_name: relation_data})
 
             if isinstance(field, (ResourceRelatedField, )):
-                relation_instance_id = getattr(resource_instance, source + "_id", None)
-                if not relation_instance_id:
-                    resolved, relation_instance = utils.get_relation_instance(resource_instance,
-                                                                              source, field.parent)
-                    if not resolved:
-                        continue
-
                 if not isinstance(field, SkipDataMixin):
                     relation_data.update({'data': resource.get(field_name)})
 


### PR DESCRIPTION
Fixes #488

## Description of the Change

In case of a reverse one-to-one relationships `get_relation_instance` would swallow `DoesNotExist` exception leading renderer to skip field. Such field instead should be rendered as `null` and never be skipped.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS`
