### PR TITLE
Avoid deprecation warnings during tests

### DIFF
--- a/example/api/resources/identity.py
+++ b/example/api/resources/identity.py
@@ -11,19 +11,8 @@ from ..serializers.post import PostSerializer
 
 
 class Identity(mixins.MultipleIDMixin, viewsets.ModelViewSet):
-    queryset = auth_models.User.objects.all()
+    queryset = auth_models.User.objects.all().order_by('pk')
     serializer_class = IdentitySerializer
-
-    @list_route()
-    def empty_list(self, request):
-        """
-        This is a hack/workaround to return an empty result on a list
-        endpoint because the delete operation in the test_empty_pluralization
-        test doesn't prevent the /identities endpoint from still returning
-        records when called in the same test. Suggestions welcome.
-        """
-        self.queryset = self.queryset.filter(pk=None)
-        return super(Identity, self).list(request)
 
     # demonstrate sideloading data for use at app boot time
     @list_route()

--- a/example/settings/dev.py
+++ b/example/settings/dev.py
@@ -72,7 +72,7 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 5,
     'EXCEPTION_HANDLER': 'rest_framework_json_api.exceptions.exception_handler',
     'DEFAULT_PAGINATION_CLASS':
-        'rest_framework_json_api.pagination.PageNumberPagination',
+        'rest_framework_json_api.pagination.JsonApiPageNumberPagination',
     'DEFAULT_PARSER_CLASSES': (
         'rest_framework_json_api.parsers.JSONParser',
         'rest_framework.parsers.FormParser',

--- a/example/tests/integration/test_includes.py
+++ b/example/tests/integration/test_includes.py
@@ -4,14 +4,8 @@ from django.urls import reverse
 pytestmark = pytest.mark.django_db
 
 
-def test_default_included_data_on_list(multiple_entries, client):
-    return test_included_data_on_list(
-        multiple_entries=multiple_entries, client=client, query='?page_size=5'
-    )
-
-
-def test_included_data_on_list(multiple_entries, client, query='?include=comments&page_size=5'):
-    response = client.get(reverse("entry-list") + query)
+def test_included_data_on_list(multiple_entries, client):
+    response = client.get(reverse("entry-list"), data={'include': 'comments', 'page[size]': 5})
     included = response.json().get('included')
 
     assert len(response.json()['data']) == len(multiple_entries), (
@@ -79,7 +73,7 @@ def test_missing_field_not_included(author_bio_factory, author_factory, client):
 
 def test_deep_included_data_on_list(multiple_entries, client):
     response = client.get(reverse("entry-list") + '?include=comments,comments.author,'
-                          'comments.author.bio,comments.writer&page_size=5')
+                          'comments.author.bio,comments.writer&page[size]=5')
     included = response.json().get('included')
 
     assert len(response.json()['data']) == len(multiple_entries), (
@@ -113,7 +107,7 @@ def test_deep_included_data_on_list(multiple_entries, client):
 
     # Also include entry authors
     response = client.get(reverse("entry-list") + '?include=authors,comments,comments.author,'
-                          'comments.author.bio&page_size=5')
+                          'comments.author.bio&page[size]=5')
     included = response.json().get('included')
 
     assert len(response.json()['data']) == len(multiple_entries), (

--- a/example/tests/integration/test_meta.py
+++ b/example/tests/integration/test_meta.py
@@ -28,8 +28,8 @@ def test_top_level_meta_for_list_view(blog, client):
             },
         }],
         'links': {
-            'first': 'http://testserver/blogs?page=1',
-            'last': 'http://testserver/blogs?page=1',
+            'first': 'http://testserver/blogs?page%5Bnumber%5D=1',
+            'last': 'http://testserver/blogs?page%5Bnumber%5D=1',
             'next': None,
             'prev': None
         },

--- a/example/tests/integration/test_pagination.py
+++ b/example/tests/integration/test_pagination.py
@@ -87,8 +87,8 @@ def test_pagination_with_single_entry(single_entry, client):
                 }
             }],
         "links": {
-            "first": "http://testserver/entries?page=1",
-            "last": "http://testserver/entries?page=1",
+            'first': 'http://testserver/entries?page%5Bnumber%5D=1',
+            'last': 'http://testserver/entries?page%5Bnumber%5D=1',
             "next": None,
             "prev": None,
         },

--- a/example/tests/integration/test_polymorphism.py
+++ b/example/tests/integration/test_polymorphism.py
@@ -105,8 +105,8 @@ def test_polymorphism_on_polymorphic_model_w_included_serializers(client):
 def test_polymorphic_model_without_any_instance(client):
     expected = {
         "links": {
-            "first": "http://testserver/projects?page=1",
-            "last": "http://testserver/projects?page=1",
+            'first': 'http://testserver/projects?page%5Bnumber%5D=1',
+            'last': 'http://testserver/projects?page%5Bnumber%5D=1',
             "next": None,
             "prev": None
         },

--- a/example/tests/test_format_keys.py
+++ b/example/tests/test_format_keys.py
@@ -36,9 +36,9 @@ class FormatKeysSetTests(TestBase):
                 }
             ],
             'links': {
-                'first': 'http://testserver/identities?page=1',
-                'last': 'http://testserver/identities?page=2',
-                'next': 'http://testserver/identities?page=2',
+                'first': 'http://testserver/identities?page%5Bnumber%5D=1',
+                'last': 'http://testserver/identities?page%5Bnumber%5D=2',
+                'next': 'http://testserver/identities?page%5Bnumber%5D=2',
                 'prev': None
             },
             'meta': {

--- a/example/tests/test_model_viewsets.py
+++ b/example/tests/test_model_viewsets.py
@@ -43,9 +43,9 @@ class ModelViewSetTests(TestBase):
                 }
             ],
             'links': {
-                'first': 'http://testserver/identities?page=1',
-                'last': 'http://testserver/identities?page=2',
-                'next': 'http://testserver/identities?page=2',
+                'first': 'http://testserver/identities?page%5Bnumber%5D=1',
+                'last': 'http://testserver/identities?page%5Bnumber%5D=2',
+                'next': 'http://testserver/identities?page%5Bnumber%5D=2',
                 'prev': None
             },
             'meta': {
@@ -63,7 +63,7 @@ class ModelViewSetTests(TestBase):
         """
         Ensure that the second page is reachable and is the correct data.
         """
-        response = self.client.get(self.list_url, {'page': 2})
+        response = self.client.get(self.list_url, {'page[number]': 2})
         self.assertEqual(response.status_code, 200)
 
         user = get_user_model().objects.all()[1]
@@ -80,10 +80,10 @@ class ModelViewSetTests(TestBase):
                 }
             ],
             'links': {
-                'first': 'http://testserver/identities?page=1',
-                'last': 'http://testserver/identities?page=2',
+                'first': 'http://testserver/identities?page%5Bnumber%5D=1',
+                'last': 'http://testserver/identities?page%5Bnumber%5D=2',
                 'next': None,
-                'prev': 'http://testserver/identities?page=1',
+                'prev': 'http://testserver/identities?page%5Bnumber%5D=1'
             },
             'meta': {
                 'pagination': {
@@ -102,7 +102,7 @@ class ModelViewSetTests(TestBase):
         tests pluralization as two objects means it converts ``user`` to
         ``users``.
         """
-        response = self.client.get(self.list_url, {'page_size': 2})
+        response = self.client.get(self.list_url, {'page[size]': 2})
         self.assertEqual(response.status_code, 200)
 
         users = get_user_model().objects.all()
@@ -128,8 +128,8 @@ class ModelViewSetTests(TestBase):
                 }
             ],
             'links': {
-                'first': 'http://testserver/identities?page=1&page_size=2',
-                'last': 'http://testserver/identities?page=1&page_size=2',
+                'first': 'http://testserver/identities?page%5Bnumber%5D=1&page%5Bsize%5D=2',
+                'last': 'http://testserver/identities?page%5Bnumber%5D=1&page%5Bsize%5D=2',
                 'next': None,
                 'prev': None
             },

--- a/example/tests/test_multiple_id_mixin.py
+++ b/example/tests/test_multiple_id_mixin.py
@@ -39,9 +39,9 @@ class MultipleIDMixin(TestBase):
         links = json_content.get("links")
         meta = json_content.get("meta").get('pagination')
 
-        self.assertEquals(expected.get('user'), json_content.get('user'))
-        self.assertEquals(meta.get('count', 0), 1)
-        self.assertEquals(links.get("next"), None)
+        self.assertEqual(expected.get('user'), json_content.get('user'))
+        self.assertEqual(meta.get('count', 0), 1)
+        self.assertEqual(links.get("next"), None)
         self.assertEqual(meta.get("page"), 1)
 
     def test_multiple_ids_in_query_params(self):
@@ -69,11 +69,11 @@ class MultipleIDMixin(TestBase):
         links = json_content.get("links")
         meta = json_content.get("meta").get('pagination')
 
-        self.assertEquals(expected.get('user'), json_content.get('user'))
-        self.assertEquals(meta.get('count', 0), 2)
+        self.assertEqual(expected.get('user'), json_content.get('user'))
+        self.assertEqual(meta.get('count', 0), 2)
         self.assertEqual(
             sorted(
-                'http://testserver/identities?ids%5B%5D=2&ids%5B%5D=1&page=2'
+                'http://testserver/identities?ids%5B%5D=2&ids%5B%5D=1&page%5Bnumber%5D=2'
                 .split('?')[1].split('&')
             ),
             sorted(

--- a/example/tests/test_parsers.py
+++ b/example/tests/test_parsers.py
@@ -1,6 +1,7 @@
 import json
 from io import BytesIO
 
+import pytest
 from django.test import TestCase, override_settings
 from rest_framework.exceptions import ParseError
 
@@ -34,6 +35,7 @@ class TestJSONParser(TestCase):
 
         self.string = json.dumps(data)
 
+    @pytest.mark.filterwarnings("ignore:`format_keys` function and `JSON_API_FORMAT_KEYS`")
     @override_settings(JSON_API_FORMAT_KEYS='camelize')
     def test_parse_include_metadata_format_keys(self):
         parser = JSONParser()

--- a/example/tests/test_performance.py
+++ b/example/tests/test_performance.py
@@ -41,7 +41,7 @@ class PerformanceTestCase(APITestCase):
         2. The SELECT query for the set
         """
         with self.assertNumQueries(2):
-            response = self.client.get('/comments?page_size=25')
+            response = self.client.get('/comments?page[size]=25')
             self.assertEqual(len(response.data['results']), 25)
 
     def test_query_count_include_author(self):
@@ -54,5 +54,5 @@ class PerformanceTestCase(APITestCase):
         5. Entries prefetched
         """
         with self.assertNumQueries(5):
-            response = self.client.get('/comments?include=author&page_size=25')
+            response = self.client.get('/comments?include=author&page[size]=25')
             self.assertEqual(len(response.data['results']), 25)

--- a/example/tests/unit/test_default_drf_serializers.py
+++ b/example/tests/unit/test_default_drf_serializers.py
@@ -68,6 +68,7 @@ def test_render_format_field_names(settings):
     assert result['data']['attributes']['json-field'] == {'JsonKey': 'JsonValue'}
 
 
+@pytest.mark.filterwarnings("ignore:`format_keys` function and `JSON_API_FORMAT_KEYS`")
 def test_render_format_keys(settings):
     """Test that json field value keys are formated."""
     delattr(settings, 'JSON_API_FORMAT_FILED_NAMES')
@@ -195,8 +196,8 @@ def test_get_entry_list_with_blogs(client, entry):
 
     expected = {
         'links': {
-            'first': 'http://testserver/drf-entries/1/suggested/?page=1',
-            'last': 'http://testserver/drf-entries/1/suggested/?page=1',
+            'first': 'http://testserver/drf-entries/1/suggested/?page%5Bnumber%5D=1',
+            'last': 'http://testserver/drf-entries/1/suggested/?page%5Bnumber%5D=1',
             'next': None,
             'prev': None
         },

--- a/example/tests/unit/test_renderers.py
+++ b/example/tests/unit/test_renderers.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from rest_framework_json_api import serializers, views
 from rest_framework_json_api.renderers import JSONRenderer
 
@@ -79,6 +81,7 @@ def test_render_format_field_names(settings):
     assert result['data']['attributes']['json-field'] == {'JsonKey': 'JsonValue'}
 
 
+@pytest.mark.filterwarnings("ignore:`format_keys` function and `JSON_API_FORMAT_KEYS`")
 def test_render_format_keys(settings):
     """Test that json field value keys are formated."""
     delattr(settings, 'JSON_API_FORMAT_FILED_NAMES')

--- a/example/tests/unit/test_utils.py
+++ b/example/tests/unit/test_utils.py
@@ -62,6 +62,7 @@ def test_get_resource_name():
     assert 'users' == utils.get_resource_name(context), 'derived from non-model serializer'
 
 
+@pytest.mark.filterwarnings("ignore:`format_keys` function and `JSON_API_FORMAT_KEYS`")
 def test_format_keys():
     underscored = {
         'first_name': 'a',

--- a/example/views.py
+++ b/example/views.py
@@ -10,7 +10,7 @@ import rest_framework_json_api.parsers
 import rest_framework_json_api.renderers
 from rest_framework_json_api.django_filters import DjangoFilterBackend
 from rest_framework_json_api.filters import OrderingFilter, QueryParameterValidationFilter
-from rest_framework_json_api.pagination import PageNumberPagination
+from rest_framework_json_api.pagination import JsonApiPageNumberPagination
 from rest_framework_json_api.utils import format_drf_errors
 from rest_framework_json_api.views import ModelViewSet, RelationshipView
 
@@ -119,7 +119,7 @@ class DRFEntryViewSet(viewsets.ModelViewSet):
         return super(DRFEntryViewSet, self).get_object()
 
 
-class NoPagination(PageNumberPagination):
+class NoPagination(JsonApiPageNumberPagination):
     page_size = None
 
 
@@ -203,7 +203,7 @@ class CompanyViewset(ModelViewSet):
 
 
 class ProjectViewset(ModelViewSet):
-    queryset = Project.objects.all()
+    queryset = Project.objects.all().order_by('pk')
     serializer_class = ProjectSerializer
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,17 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=example.settings.test
+filterwarnings =
+    error::DeprecationWarning
+    error::PendingDeprecationWarning
+    # TODO: restructure tests so this can be ignored on a test level
+    ignore:MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly.
+    ignore:use of getfuncargvalue is deprecated, use getfixturevalue
+    ignore:`list_route`
+    ignore:`detail_route`
+    ignore:`FiltersetEntryViewSet.filter_fields` attribute should be renamed
+    ignore:`NoFiltersetEntryViewSet.filter_fields` attribute should be renamed
+    ignore:`NoFiltersetEntryViewSet.filter_class` attribute should be renamed `filterset_class`
+    ignore:MultipleIDMixin is deprecated
+    # can be removed once following DRF PR is released
+    # https://github.com/encode/django-rest-framework/pull/6268
+    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated


### PR DESCRIPTION
## Description of the Change

* Change to non deprecation pagination class per default
* filterwarnings per test level where a warning is actually tested
* Add some global filterwarnings for warnings which happen during import
  time. (those can be removed resp. moved to specific test when tests are being restructured)

All in all this change helps output not being bloated with warnings when running tests.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS`
