### PR TITLE
Allow HyperlinkedRelatedField to be used with related urls

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ santiavenda <santiavenda2@gmail.com>
 Tim Selman <timcbaoth@gmail.com>
 Yaniv Peer <yanivpeer@gmail.com>
 Mohammed Ali Zubair <mazg1493@gmail.com>
+Jason Housley <housleyjk@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ any parts of the framework not mentioned in the documentation should generally b
 * Avoid error with related urls when retrieving relationship which is referenced as `ForeignKey` on parent
 * Do not render `write_only` relations
 * Do not skip empty one-to-one relationships
-* Handle SkipField exception in RelateMixin
+* Allow `HyperlinkRelatedField` to be used with [related urls](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html?highlight=related%20links#related-urls)
 
 
 ## [2.6.0] - 2018-09-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ any parts of the framework not mentioned in the documentation should generally b
 * Avoid error with related urls when retrieving relationship which is referenced as `ForeignKey` on parent
 * Do not render `write_only` relations
 * Do not skip empty one-to-one relationships
+* Handle SkipField exception in RelateMixin
 
 
 ## [2.6.0] - 2018-09-20

--- a/example/models.py
+++ b/example/models.py
@@ -110,6 +110,7 @@ class Comment(BaseModel):
         null=True,
         blank=True,
         on_delete=models.CASCADE,
+        related_name='comments',
     )
 
     def __str__(self):

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -206,7 +206,7 @@ class AuthorSerializer(serializers.ModelSerializer):
         self_link_view_name='author-relationships',
         queryset=AuthorBio.objects,
     )
-    entries = relations.ResourceRelatedField(
+    entries = relations.HyperlinkedRelatedField(
         related_link_view_name='author-related',
         self_link_view_name='author-relationships',
         queryset=Entry.objects,

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -206,7 +206,7 @@ class AuthorSerializer(serializers.ModelSerializer):
         self_link_view_name='author-relationships',
         queryset=AuthorBio.objects,
     )
-    entries = relations.HyperlinkedRelatedField(
+    entries = relations.ResourceRelatedField(
         related_link_view_name='author-related',
         self_link_view_name='author-relationships',
         queryset=Entry.objects,
@@ -219,6 +219,12 @@ class AuthorSerializer(serializers.ModelSerializer):
         read_only=True,
         source='get_first_entry'
     )
+    comments = relations.HyperlinkedRelatedField(
+        related_link_view_name='author-related',
+        self_link_view_name='author-relationships',
+        queryset=Comment.objects,
+        many=True
+    )
     included_serializers = {
         'bio': AuthorBioSerializer,
         'type': AuthorTypeSerializer
@@ -226,13 +232,14 @@ class AuthorSerializer(serializers.ModelSerializer):
     related_serializers = {
         'bio': 'example.serializers.AuthorBioSerializer',
         'type': 'example.serializers.AuthorTypeSerializer',
+        'comments': 'example.serializers.CommentSerializer',
         'entries': 'example.serializers.EntrySerializer',
         'first_entry': 'example.serializers.EntrySerializer'
     }
 
     class Meta:
         model = Author
-        fields = ('name', 'email', 'bio', 'entries', 'first_entry', 'type')
+        fields = ('name', 'email', 'bio', 'entries', 'comments', 'first_entry', 'type')
 
     def get_first_entry(self, obj):
         return obj.entries.first()

--- a/example/settings/test.py
+++ b/example/settings/test.py
@@ -13,6 +13,6 @@ JSON_API_FORMAT_FIELD_NAMES = 'camelize'
 JSON_API_FORMAT_TYPES = 'camelize'
 JSON_API_PLURALIZE_TYPES = True
 
-REST_FRAMEWORK.update({
+REST_FRAMEWORK.update({  # noqa
     'PAGE_SIZE': 1,
 })

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -102,11 +102,11 @@ class TestRelationshipView(APITestCase):
         assert response.data == expected_data
 
     def test_get_to_many_relationship_self_link(self):
-        url = '/authors/{}/relationships/comment_set'.format(self.author.id)
+        url = '/authors/{}/relationships/comments'.format(self.author.id)
 
         response = self.client.get(url)
         expected_data = {
-            'links': {'self': 'http://testserver/authors/1/relationships/comment_set'},
+            'links': {'self': 'http://testserver/authors/1/relationships/comments'},
             'data': [{'id': str(self.second_comment.id), 'type': format_resource_type('Comment')}]
         }
         assert json.loads(response.content.decode('utf-8')) == expected_data
@@ -222,7 +222,7 @@ class TestRelationshipView(APITestCase):
         assert response.status_code == 409, response.content.decode()
 
     def test_delete_to_many_relationship_with_change(self):
-        url = '/authors/{}/relationships/comment_set'.format(self.author.id)
+        url = '/authors/{}/relationships/comments'.format(self.author.id)
         request_data = {
             'data': [{'type': format_resource_type('Comment'), 'id': str(self.second_comment.id)}, ]
         }
@@ -233,7 +233,7 @@ class TestRelationshipView(APITestCase):
         entry = EntryFactory(blog=self.blog, authors=(self.author,))
         comment = CommentFactory(entry=entry)
 
-        url = '/authors/{}/relationships/comment_set'.format(self.author.id)
+        url = '/authors/{}/relationships/comments'.format(self.author.id)
         request_data = {
             'data': [{'type': format_resource_type('Comment'), 'id': str(comment.id)}, ]
         }
@@ -244,7 +244,7 @@ class TestRelationshipView(APITestCase):
                  }
             ],
             'links': {
-                'self': 'http://testserver/authors/{}/relationships/comment_set'.format(
+                'self': 'http://testserver/authors/{}/relationships/comments'.format(
                     self.author.id
                 )
             }
@@ -261,7 +261,7 @@ class TestRelationshipView(APITestCase):
                  }
             ],
             'links': {
-                'self': 'http://testserver/authors/{}/relationships/comment_set'.format(
+                'self': 'http://testserver/authors/{}/relationships/comments'.format(
                     self.author.id
                 )
             }
@@ -368,6 +368,16 @@ class TestRelatedMixin(APITestCase):
         self.assertTrue(isinstance(resp.json()['data'], list))
         self.assertEqual(len(resp.json()['data']), 1)
         self.assertEqual(resp.json()['data'][0]['id'], str(entry.id))
+
+    def test_retrieve_related_many_hyperlinked(self):
+        comment = CommentFactory(author=self.author)
+        url = reverse('author-related', kwargs={'pk': self.author.pk, 'related_field': 'comments'})
+        resp = self.client.get(url)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(isinstance(resp.json()['data'], list))
+        self.assertEqual(len(resp.json()['data']), 1)
+        self.assertEqual(resp.json()['data'][0]['id'], str(comment.id))
 
     def test_retrieve_related_None(self):
         kwargs = {'pk': self.author.pk, 'related_field': 'first_entry'}

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -18,7 +18,7 @@ from rest_framework.fields import get_attribute
 from rest_framework.relations import PKOnlyObject
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
-from rest_framework.serializers import Serializer
+from rest_framework.serializers import Serializer, SkipField
 
 from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.serializers import ResourceIdentifierObjectSerializer
@@ -166,10 +166,14 @@ class RelatedMixin(object):
         field = parent_serializer.fields.get(field_name, None)
 
         if field is not None:
-            instance = field.get_attribute(parent_obj)
-            if isinstance(instance, PKOnlyObject):
-                # need whole object
+            try:
+                instance = field.get_attribute(parent_obj)
+            except SkipField:
                 instance = get_attribute(parent_obj, field.source_attrs)
+            else:
+                if isinstance(instance, PKOnlyObject):
+                    # need whole object
+                    instance = get_attribute(parent_obj, field.source_attrs)
             return instance
         else:
             try:


### PR DESCRIPTION
Fixes #521

## Description of the Change
The details in #521 are not clear, but I ran into a very similar `SkipField` issue when trying to use HyperlinkedRelatedFields and the RelatedMixin. The HyperlinkedRelatedField generates the correct url for the related link (e.g. /authors/1/entries), but visiting the url gives a 500 error because of an unhandled `SkipField` exception. In other words, without these changes, it is possible to give a related link in the payload, but that link won't actually work.

## Checklist

- [X] PR only contains one change (considered splitting up PR)
- [X] unit-test added (I couldn't get the unit tests to all work prior to making these changes, but I was able to trigger and fix this issue with the existing `test_retrieve_related_many()` test. So this code is covered by unit tests.)
- [X] NO documentation changes necessary, bug fix
- [X] changelog entry added to `CHANGELOG.md`
- [X] author name in `AUTHORS`
