### PR TITLE
Improve performance of extract_related()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,5 +23,6 @@ Mohammed Ali Zubair <mazg1493@gmail.com>
 Jason Housley <housleyjk@gmail.com>
 Beni Keller <beni@matraxi.ch>
 Stas S. <stas@nerd.ro>
+Juha Yrjölä <juha.yrjola@iki.fi>
 Nathanael Gordon <nathanael.l.gordon@gmail.com>
 Charlie Allatson <charles.allatson@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ This is the last release supporting Python 2.7, Python 3.4, Django Filter 1.1, D
 * Allow `HyperlinkRelatedField` to be used with [related urls](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html?highlight=related%20links#related-urls)
 * Avoid exception in `AutoPrefetchMixin` when including a reverse one to one relation ([#537](https://github.com/django-json-api/django-rest-framework-json-api/issues/537))
 * Avoid requested resource(s) to be added to included as well ([#524](https://github.com/django-json-api/django-rest-framework-json-api/issues/524))
+* Performance improvement when rendering included data
 
 ## [2.6.0] - 2018-09-20
 

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -397,6 +397,10 @@ class JSONRenderer(renderers.JSONRenderer):
                             relation_type or
                             utils.get_resource_type_from_instance(nested_resource_instance)
                         )
+                        resource_id = encoding.force_text(nested_resource_instance.pk)
+                        if included_cache.get(resource_type, {}).get(resource_id):
+                            # Do not serialize if already included in the response
+                            continue
                         serializer_fields = utils.get_serializer_fields(
                             serializer.__class__(
                                 nested_resource_instance, context=serializer.context
@@ -421,7 +425,10 @@ class JSONRenderer(renderers.JSONRenderer):
 
             if isinstance(field, Serializer):
                 relation_type = utils.get_resource_type_from_serializer(field)
-
+                resource_id = encoding.force_text(relation_instance.pk)
+                if included_cache.get(relation_type, {}).get(resource_id):
+                    # Do not serialize if already included in the response
+                    continue
                 # Get the serializer fields
                 serializer_fields = utils.get_serializer_fields(field)
                 if serializer_data:


### PR DESCRIPTION
Check more thoroughly if the related resource is already included in the response, and skip serialization if it is. For my workload with a lot of included resources, this optimization decreased the list endpoint processing time by around 50 %, because `extract_related()` was repeating serialization for many of the resources that were already included in the response.