### PR TITLE
Allow `format` through GET validation filtering

### DIFF
--- a/rest_framework_json_api/filters.py
+++ b/rest_framework_json_api/filters.py
@@ -69,7 +69,7 @@ class QueryParameterValidationFilter(BaseFilterBackend):
     the rules at http://jsonapi.org/format/#query-parameters.
     """
     #: compiled regex that matches the allowed http://jsonapi.org/format/#query-parameters:
-    #: `sort` and `include` stand alone; `filter`, `fields`, and `page` have []'s
+    #: `sort`, `include` and `format` stand alone; `filter`, `fields`, and `page` have []'s
     query_regex = re.compile(r'^(sort|include|format)$|^(filter|fields|page)(\[[\w\.\-]+\])?$')
 
     def validate_query_params(self, request):

--- a/rest_framework_json_api/filters.py
+++ b/rest_framework_json_api/filters.py
@@ -70,7 +70,7 @@ class QueryParameterValidationFilter(BaseFilterBackend):
     """
     #: compiled regex that matches the allowed http://jsonapi.org/format/#query-parameters:
     #: `sort` and `include` stand alone; `filter`, `fields`, and `page` have []'s
-    query_regex = re.compile(r'^(sort|include)$|^(filter|fields|page)(\[[\w\.\-]+\])?$')
+    query_regex = re.compile(r'^(sort|include|format)$|^(filter|fields|page)(\[[\w\.\-]+\])?$')
 
     def validate_query_params(self, request):
         """


### PR DESCRIPTION
## Issue

The guides on https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html#configuration recommend including the `rest_framework_json_api.filters.QueryParameterValidationFilter` in initial configuration which is good advice, but by default, the Django REST Framework UI provides a dropdown which allows you to pick `format=api` or `format=vnd.api+json`

![screenshot at 2018-12-28 15-10-51](https://user-images.githubusercontent.com/41655/50499977-cbbb0a80-0ab2-11e9-9585-d50dfa3fa63c.png)

Without allowing the `format` parameter through you get the following error:

```
HTTP 400 Bad Request
Allow: GET, POST, HEAD, OPTIONS
Content-Type: application/vnd.api+json
Vary: Accept

{
    "errors": [
        {
            "detail": "invalid query parameter: format",
            "source": {
                "pointer": "/data"
            },
            "status": "400"
        }
    ]
}
```
## Description of the Change

This change adds `format` to `query_regex`

## Checklist

- [ ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] changelog entry added to `CHANGELOG.md`
- [ ] author name in `AUTHORS`
