### PR TITLE
Remove requested resources from included field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ any parts of the framework not mentioned in the documentation should generally b
 * Allow `HyperlinkRelatedField` to be used with [related urls](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html?highlight=related%20links#related-urls)
 * Fixed hardcoded year 2018 in tests ([#539](https://github.com/django-json-api/django-rest-framework-json-api/issues/539))
 * Avoid exception in `AutoPrefetchMixin` when including a reverse one to one relation ([#537](https://github.com/django-json-api/django-rest-framework-json-api/issues/537))
+* Exclude the requested resource(s) from the included field ([#524](https://github.com/django-json-api/django-rest-framework-json-api/issues/524))
 
 ## [2.6.0] - 2018-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ any parts of the framework not mentioned in the documentation should generally b
 * Allow `HyperlinkRelatedField` to be used with [related urls](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html?highlight=related%20links#related-urls)
 * Fixed hardcoded year 2018 in tests ([#539](https://github.com/django-json-api/django-rest-framework-json-api/issues/539))
 * Avoid exception in `AutoPrefetchMixin` when including a reverse one to one relation ([#537](https://github.com/django-json-api/django-rest-framework-json-api/issues/537))
-* Exclude the requested resource(s) from the included field ([#524](https://github.com/django-json-api/django-rest-framework-json-api/issues/524))
+* Avoid requested resource(s) to be added to included as well ([#524](https://github.com/django-json-api/django-rest-framework-json-api/issues/524))
 
 ## [2.6.0] - 2018-09-20
 

--- a/example/tests/conftest.py
+++ b/example/tests/conftest.py
@@ -51,6 +51,13 @@ def multiple_entries(blog_factory, author_factory, entry_factory, comment_factor
 
 
 @pytest.fixture
+def single_comment(blog, author, entry_factory, comment_factory):
+    entry = entry_factory(blog=blog, authors=(author,))
+    comment_factory(entry=entry)
+    return comment_factory(entry=entry)
+
+
+@pytest.fixture
 def single_company(art_project_factory, research_project_factory, company_factory):
     company = company_factory(future_projects=(research_project_factory(), art_project_factory()))
     return company

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -644,6 +644,21 @@ class JSONRenderer(renderers.JSONRenderer):
             render_data['data'] = json_api_data
 
         if included_cache:
+            if isinstance(json_api_data, list):
+                objects = json_api_data
+            else:
+                objects = [json_api_data]
+
+            for object in objects:
+                obj_type = object.get('type')
+                obj_id = object.get('id')
+                if obj_type in included_cache and \
+                   obj_id in included_cache[obj_type]:
+                    del included_cache[obj_type][obj_id]
+                if not included_cache[obj_type]:
+                    del included_cache[obj_type]
+
+        if included_cache:
             render_data['included'] = list()
             for included_type in sorted(included_cache.keys()):
                 for included_id in sorted(included_cache[included_type].keys()):


### PR DESCRIPTION
Fixes #524 

## Description of the Change

The resource(s) in the data field of the response are removed from the included_cache before building the included field for the response.

I added an integration test which checks whether this works on a single comment. If I request a comment and ask for all the comments of its associated blog entry with `?include=entry.comments` all comments except the one which I requested should turn up in the included field.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added (I added a integration test since I couldn't figure out how to unit test this.)
- [ ] documentation updated (couldn't find any relevant information on the documentation.
- [x] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS`
