### PR TITLE
Removed hardcoded year 2018 from tests (#539)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@ Tim Selman <timcbaoth@gmail.com>
 Yaniv Peer <yanivpeer@gmail.com>
 Mohammed Ali Zubair <mazg1493@gmail.com>
 Jason Housley <housleyjk@gmail.com>
+Beni Keller <beni@matraxi.ch>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ any parts of the framework not mentioned in the documentation should generally b
 * Do not render `write_only` relations
 * Do not skip empty one-to-one relationships
 * Allow `HyperlinkRelatedField` to be used with [related urls](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html?highlight=related%20links#related-urls)
-
+* Fixed hardcoded year 2018 in tests ([#539](https://github.com/django-json-api/django-rest-framework-json-api/issues/539))
 
 ## [2.6.0] - 2018-09-20
 

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -1,5 +1,6 @@
 import json
 
+from datetime import datetime
 from django.test import RequestFactory
 from django.utils import timezone
 from rest_framework.exceptions import NotFound
@@ -466,7 +467,7 @@ class TestBlogViewSet(APITestCase):
                 'attributes': {'name': self.blog.name},
                 'id': '{}'.format(self.blog.id),
                 'links': {'self': 'http://testserver/blogs/{}'.format(self.blog.id)},
-                'meta': {'copyright': 2018},
+                'meta': {'copyright': datetime.now().year},
                 'relationships': {'tags': {'data': []}},
                 'type': 'blogs'
             },

--- a/example/tests/unit/test_default_drf_serializers.py
+++ b/example/tests/unit/test_default_drf_serializers.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from datetime import datetime
 from django.urls import reverse
 from rest_framework import viewsets
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
@@ -108,7 +109,7 @@ def test_blog_create(client):
             'attributes': {'name': blog.name},
             'id': '{}'.format(blog.id),
             'links': {'self': 'http://testserver/blogs/{}'.format(blog.id)},
-            'meta': {'copyright': 2018},
+            'meta': {'copyright': datetime.now().year},
             'relationships': {'tags': {'data': []}},
             'type': 'blogs'
         },
@@ -129,7 +130,7 @@ def test_get_object_gives_correct_blog(client, blog, entry):
             'attributes': {'name': blog.name},
             'id': '{}'.format(blog.id),
             'links': {'self': 'http://testserver/blogs/{}'.format(blog.id)},
-            'meta': {'copyright': 2018},
+            'meta': {'copyright': datetime.now().year},
             'relationships': {'tags': {'data': []}},
             'type': 'blogs'
         },
@@ -151,7 +152,7 @@ def test_get_object_patches_correct_blog(client, blog, entry):
             'attributes': {'name': new_name},
             'id': '{}'.format(blog.id),
             'links': {'self': 'http://testserver/blogs/{}'.format(blog.id)},
-            'meta': {'copyright': 2018},
+            'meta': {'copyright': datetime.now().year},
             'relationships': {'tags': {'data': []}},
             'type': 'blogs'
         },
@@ -167,7 +168,7 @@ def test_get_object_patches_correct_blog(client, blog, entry):
             'attributes': {'name': new_name},
             'id': '{}'.format(blog.id),
             'links': {'self': 'http://testserver/blogs/{}'.format(blog.id)},
-            'meta': {'copyright': 2018},
+            'meta': {'copyright': datetime.now().year},
             'relationships': {'tags': {'data': []}},
             'type': 'blogs'
         },


### PR DESCRIPTION
Fixes #539 

## Description of the Change

Replaced the hardcoded year 2018 with `datetime.now().year` in all four tests which failed.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] changelog entry added to `CHANGELOG.md`
- [x] author name in `AUTHORS` (Already included in another pull request.)
