### PR TITLE
WIP Disable Travis cache for proper flaking checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-sudo: required
-cache: pip
 # Favor explicit over implicit and use an explicit build matrix.
 matrix:
   allow_failures:


### PR DESCRIPTION
Trying to reproduce why flake8-isort didn't fail even though sorting is invalid.