### PR TITLE
Respect serializer's `id` field.

### DIFF
--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -487,9 +487,16 @@ class JSONRenderer(renderers.JSONRenderer):
         # Determine type from the instance if the underlying model is polymorphic
         if force_type_resolution:
             resource_name = utils.get_resource_type_from_instance(resource_instance)
+
+        # Allow serializer `id` field to override model pk
+        if 'id' in resource:
+            resource_id = encoding.force_text(resource['id'])
+        else:
+            resource_id = encoding.force_text(resource_instance.pk) if resource_instance else None
+
         resource_data = [
             ('type', resource_name),
-            ('id', encoding.force_text(resource_instance.pk) if resource_instance else None),
+            ('id', resource_id),
             ('attributes', cls.extract_attributes(fields, resource)),
         ]
         relationships = cls.extract_relationships(fields, resource, resource_instance)


### PR DESCRIPTION
## Description of the Change
Until now the renderer ignored `id` field provided by the serializer. This prevented API author from using separate values for internal database key (`pk`) and for user facing resource ID. One reason for using separate values like this is if the pk has to be small for use by foreign keys and external id can be longer, for example a human readable string.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
