### PR TITLE
DjangoFilterBackend.get_filterset_kwargs doesn't modify data dict while iterating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Fixed
 
 * Avoid exception when trying to include skipped relationship
+* Don't ignore `filter[]` params when there are many query params
 
 ## [2.7.0] - 2019-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Fixed
 
 * Avoid exception when trying to include skipped relationship
-* Don't ignore `filter[]` params when there are many query params
+* Don't swallow `filter[]` params when there are several
 
 ## [2.7.0] - 2019-01-14
 

--- a/example/tests/test_filters.py
+++ b/example/tests/test_filters.py
@@ -503,3 +503,18 @@ class DJATestFilters(APITestCase):
         dja_response = response.json()
         self.assertEqual(dja_response['errors'][0]['detail'],
                          "repeated query parameter not allowed: sort")
+
+    def test_many_params(self):
+        """
+        Test that filter params aren't ignored when many params are present
+        """
+        response = self.client.get(self.url,
+                                   data={'filter[headline.regex]': '^A',
+                                         'filter[body_text.regex]': '^IN',
+                                         'filter[blog.name]': 'ANTB',
+                                         'page[size]': 3})
+        self.assertEqual(response.status_code, 200,
+                         msg=response.content.decode("utf-8"))
+        dja_response = response.json()
+        self.assertEqual(len(dja_response['data']), 1)
+        self.assertEqual(dja_response['data'][0]['id'], '1')

--- a/rest_framework_json_api/django_filters/backends.py
+++ b/rest_framework_json_api/django_filters/backends.py
@@ -100,8 +100,8 @@ class DjangoFilterBackend(DjangoFilterBackend):
         """
         filter_keys = []
         # rewrite filter[field] query params to make DjangoFilterBackend work.
-        data = {}
-        for qp, val in request.query_params.copy().items():
+        data = request.query_params.copy()
+        for qp, val in request.query_params.items():
             m = self.filter_regex.match(qp)
             if m and (not m.groupdict()['assoc'] or
                       m.groupdict()['ldelim'] != '[' or m.groupdict()['rdelim'] != ']'):
@@ -115,6 +115,7 @@ class DjangoFilterBackend(DjangoFilterBackend):
                 key = format_value(key, 'underscore')
                 data[key] = val
                 filter_keys.append(key)
+                del data[qp]
         return {
             'data': data,
             'queryset': queryset,

--- a/rest_framework_json_api/django_filters/backends.py
+++ b/rest_framework_json_api/django_filters/backends.py
@@ -4,7 +4,6 @@ from django_filters import VERSION
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.exceptions import ValidationError
 from rest_framework.settings import api_settings
-
 from rest_framework_json_api.utils import format_value
 
 
@@ -101,8 +100,8 @@ class DjangoFilterBackend(DjangoFilterBackend):
         """
         filter_keys = []
         # rewrite filter[field] query params to make DjangoFilterBackend work.
-        data = request.query_params.copy()
-        for qp, val in data.items():
+        data = {}
+        for qp, val in request.query_params.copy().items():
             m = self.filter_regex.match(qp)
             if m and (not m.groupdict()['assoc'] or
                       m.groupdict()['ldelim'] != '[' or m.groupdict()['rdelim'] != ']'):
@@ -116,7 +115,6 @@ class DjangoFilterBackend(DjangoFilterBackend):
                 key = format_value(key, 'underscore')
                 data[key] = val
                 filter_keys.append(key)
-                del data[qp]
         return {
             'data': data,
             'queryset': queryset,


### PR DESCRIPTION
It looks like `DjangoFilterBackend.get_filterset_kwargs` reused the same dictionary for the original (`filter[something]`) keys, the converted (`something`) keys, and the extra params (`include` or `page`).  By calling `data[key] = val` in while iterating `data.items()`, the indexes can be incorrectly changed: https://stackoverflow.com/questions/6777485/modifying-a-python-dict-while-iterating-over-it

## Example
With the path: `/api/products?filter[organization]=44cbbad6-d418-4129-8093-731637d5013b&filter[archived]=False&filter[productType.key]=biomass&include=images,product_type`, different filter params were ignored based on their order in the param string.

- `filter[productType.key]=...&filter[organization]=...&filter[archived]=False&include=images,product_type` 
    - ignores `filter[archived]`
- `filter[productType.key]=...&filter[organization]=...&filter[archived]=False&include=images,product_type`
    - ignores `filter[organization]`
- `filter[archived]=False&filter[productType.key]=...&filter[organization]=...&include=images,product_type`
    - ignores `filter[organization]`
- `filter[archived]=False&filter[organization]=...&filter[productType.key]=...&include=images,product_type`
    - ignores `filter[productType.key]`
- `filter[organization]=...&filter[archived]=False&filter[productType.key]=...&include=images,product_type`
    - ignores `filter[productType.key]`
- `filter[organization]=...&filter[productType.key]=...&filter[archived]=False&include=images,product_type`
    - ignores `filter[archived]`
- `filter[organization]=...&filter[productType.key]=...&filter[archived]=False`
    - works perfectly

Fixes #

## Description of the Change

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
