### PR TITLE
Avoid printing invalid pointer when api returns 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ any parts of the framework not mentioned in the documentation should generally b
 * Removed support for Django REST Framework <=3.8.
 * Removed support for Django 2.0.
 
+### Fixed
+
+* Avoid printing invalid pointer when api returns 404
+
+
 ## [2.8.0] - 2019-06-13
 
 This is the last release supporting Python 2.7, Python 3.4, Django Filter 1.1, Django REST Framework <=3.8 and Django 2.0.

--- a/example/tests/test_model_viewsets.py
+++ b/example/tests/test_model_viewsets.py
@@ -212,6 +212,24 @@ class ModelViewSetTests(TestBase):
             get_user_model().objects.get(pk=self.miles.pk).email,
             'miles@trumpet.org')
 
+    def test_404_error_pointer(self):
+        """
+        Ensure 404 uses '/data' pointer
+        """
+        self.client.login(username='miles', password='pw')
+        not_found_url = reverse('user-detail', kwargs={'pk': 12345})
+        errors = {
+            'errors': [
+                {'detail': 'Not found.', 'status': '404'}
+            ]
+        }
+
+        with override_settings(JSON_API_FORMAT_FIELD_NAMES='dasherize'):
+            response = self.client.get(not_found_url)
+
+        assert 404 == response.status_code
+        assert errors == response.json()
+
 
 @pytest.mark.django_db
 def test_patch_allow_field_type(author, author_type_factory, client):

--- a/example/tests/test_model_viewsets.py
+++ b/example/tests/test_model_viewsets.py
@@ -213,9 +213,6 @@ class ModelViewSetTests(TestBase):
             'miles@trumpet.org')
 
     def test_404_error_pointer(self):
-        """
-        Ensure 404 uses '/data' pointer
-        """
         self.client.login(username='miles', password='pw')
         not_found_url = reverse('user-detail', kwargs={'pk': 12345})
         errors = {
@@ -224,9 +221,7 @@ class ModelViewSetTests(TestBase):
             ]
         }
 
-        with override_settings(JSON_API_FORMAT_FIELD_NAMES='dasherize'):
-            response = self.client.get(not_found_url)
-
+        response = self.client.get(not_found_url)
         assert 404 == response.status_code
         assert errors == response.json()
 

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -11,6 +11,7 @@ from django.db.models.fields.related_descriptors import (
     ManyToManyDescriptor,
     ReverseManyToOneDescriptor
 )
+from django.http import Http404
 from django.utils import encoding
 from django.utils.module_loading import import_string as import_class_from_dotted_path
 from django.utils.translation import ugettext_lazy as _
@@ -405,6 +406,12 @@ def format_drf_errors(response, context, exc):
             # see if they passed a dictionary to ValidationError manually
             if isinstance(error, dict):
                 errors.append(error)
+            elif isinstance(exc, Http404) and isinstance(error, str):
+                # 404 errors don't have a pointer
+                errors.append({
+                    'detail': error,
+                    'status': encoding.force_text(response.status_code),
+                })
             elif isinstance(error, str):
                 classes = inspect.getmembers(exceptions, inspect.isclass)
                 # DRF sets the `field` to 'detail' for its own exceptions


### PR DESCRIPTION
Fixes the pointer for 404 results.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
