### PR TITLE
Allow defining of `select_related` per include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ any parts of the framework not mentioned in the documentation should generally b
 
 ### Fixed
 
+* Added `select_for_includes` handling. [PR](https://github.com/django-json-api/django-rest-framework-json-api/pull/600). [Docs](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html#performance-improvements).
 * Avoid exception when trying to include skipped relationship
 * Don't swallow `filter[]` params when there are several
 * Fix DeprecationWarning regarding collections.abc import in Python 3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,22 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Add support for Django 2.2
 
+### Changed
+
+* Allow to define `select_related` per include using [select_for_includes](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html#performance-improvements)
+* Reduce number of queries to calculate includes by using `select_related` when possible
+
 ### Fixed
 
-* Added `select_for_includes` handling. [PR](https://github.com/django-json-api/django-rest-framework-json-api/pull/600). [Docs](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html#performance-improvements).
 * Avoid exception when trying to include skipped relationship
 * Don't swallow `filter[]` params when there are several
 * Fix DeprecationWarning regarding collections.abc import in Python 3.7
-* Allow OPTIONS request to be used on RelationshipView.
+* Allow OPTIONS request to be used on RelationshipView
+
+### Deprecated
+
+* Deprecate `PrefetchForIncludesHelperMixin` use `PreloadIncludesMixin` instead
+* Deprecate `AutoPrefetchMixin` use `AutoPreloadMixin` instead
 
 ## [2.7.0] - 2019-01-14
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -823,7 +823,9 @@ class QuestSerializer(serializers.ModelSerializer):
 
 Be aware that using included resources without any form of prefetching **WILL HURT PERFORMANCE** as it will introduce m\*(n+1) queries.
 
-A viewset helper was designed to allow for greater flexibility and it is automatically available when subclassing
+A viewset helper was designed to allow for greater flexibility and it is automatically available when subclassing.
+You can also define your custom queryset for `select` or `prefetch` related for each `include` that comes from the url.
+It has a priority over automatically added preloads.
 `rest_framework_json_api.views.ModelViewSet`:
 ```python
 from rest_framework_json_api import views
@@ -831,9 +833,12 @@ from rest_framework_json_api import views
 # When MyViewSet is called with ?include=author it will dynamically prefetch author and author.bio
 class MyViewSet(views.ModelViewSet):
     queryset = Book.objects.all()
+    select_for_includes = {
+        'author': ['author__bio'],
+    }
     prefetch_for_includes = {
         '__all__': [],
-        'author': ['author', 'author__bio'],
+        'all_authors': [Prefetch('all_authors', queryset=Author.objects.select_related('bio'))],
         'category.section': ['category']
     }
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -823,9 +823,10 @@ class QuestSerializer(serializers.ModelSerializer):
 
 Be aware that using included resources without any form of prefetching **WILL HURT PERFORMANCE** as it will introduce m\*(n+1) queries.
 
-A viewset helper was designed to allow for greater flexibility and it is automatically available when subclassing.
-You can also define your custom queryset for `select` or `prefetch` related for each `include` that comes from the url.
-It has a priority over automatically added preloads.
+A viewset helper was therefore designed to automatically preload data when possible. Such is automatically available when subclassing `ModelViewSet`.
+
+It also allows to define custom `select_related` and `prefetch_related` for each requested `include` when needed in special cases:
+
 `rest_framework_json_api.views.ModelViewSet`:
 ```python
 from rest_framework_json_api import views
@@ -853,7 +854,7 @@ class MyReadOnlyViewSet(views.ReadOnlyModelViewSet):
 
 The special keyword `__all__` can be used to specify a prefetch which should be done regardless of the include, similar to making the prefetch yourself on the QuerySet.
 
-Using the helper to prefetch, rather than attempting to minimise queries via select_related might give you better performance depending on the characteristics of your data and database.
+Using the helper to prefetch, rather than attempting to minimise queries via `select_related` might give you better performance depending on the characteristics of your data and database.
 
 For example:
 
@@ -866,11 +867,11 @@ a) 1 query via selected_related, e.g. SELECT * FROM books LEFT JOIN author LEFT 
 b) 4 small queries via prefetch_related.
 
 If you have 1M books, 50k authors, 10k categories, 10k copyrightholders
-in the select_related scenario, you've just created a in-memory table
+in the `select_related` scenario, you've just created a in-memory table
 with 1e18 rows which will likely exhaust any available memory and
 slow your database to crawl.
 
-The prefetch_related case will issue 4 queries, but they will be small and fast queries.
+The `prefetch_related` case will issue 4 queries, but they will be small and fast queries.
 <!--
 ### Relationships
 ### Errors

--- a/example/tests/test_performance.py
+++ b/example/tests/test_performance.py
@@ -58,7 +58,7 @@ class PerformanceTestCase(APITestCase):
             self.assertEqual(len(response.data['results']), 25)
 
     def test_query_select_related_entry(self):
-        """ We expect a list view with an include have three queries:
+        """ We expect a list view with an include have two queries:
 
         1. Primary resource COUNT query
         2. Primary resource SELECT + SELECT RELATED writer(author) and bio

--- a/example/tests/test_performance.py
+++ b/example/tests/test_performance.py
@@ -56,3 +56,13 @@ class PerformanceTestCase(APITestCase):
         with self.assertNumQueries(5):
             response = self.client.get('/comments?include=author&page[size]=25')
             self.assertEqual(len(response.data['results']), 25)
+
+    def test_query_select_related_entry(self):
+        """ We expect a list view with an include have three queries:
+
+        1. Primary resource COUNT query
+        2. Primary resource SELECT + SELECT RELATED writer(author) and bio
+        """
+        with self.assertNumQueries(2):
+            response = self.client.get('/comments?include=writer&page[size]=25')
+            self.assertEqual(len(response.data['results']), 25)

--- a/example/tests/test_performance.py
+++ b/example/tests/test_performance.py
@@ -53,7 +53,7 @@ class PerformanceTestCase(APITestCase):
         4. Author types prefetched
         5. Entries prefetched
         """
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             response = self.client.get('/comments?include=author&page[size]=25')
             self.assertEqual(len(response.data['results']), 25)
 

--- a/example/views.py
+++ b/example/views.py
@@ -203,6 +203,9 @@ class CommentViewSet(ModelViewSet):
 class CompanyViewset(ModelViewSet):
     queryset = Company.objects.all()
     serializer_class = CompanySerializer
+    prefetch_for_includes = {
+        'current_project': ['current_project'],
+    }
 
 
 class ProjectViewset(ModelViewSet):

--- a/example/views.py
+++ b/example/views.py
@@ -184,6 +184,9 @@ class AuthorViewSet(ModelViewSet):
 class CommentViewSet(ModelViewSet):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
+    select_for_includes = {
+        'writer': ['author__bio']
+    }
     prefetch_for_includes = {
         '__all__': [],
         'author': ['author__bio', 'author__entries'],

--- a/example/views.py
+++ b/example/views.py
@@ -12,7 +12,7 @@ from rest_framework_json_api.django_filters import DjangoFilterBackend
 from rest_framework_json_api.filters import OrderingFilter, QueryParameterValidationFilter
 from rest_framework_json_api.pagination import JsonApiPageNumberPagination
 from rest_framework_json_api.utils import format_drf_errors
-from rest_framework_json_api.views import ModelViewSet, RelationshipView
+from rest_framework_json_api.views import ModelViewSet, RelationshipView, PreloadIncludesMixin
 
 from example.models import Author, Blog, Comment, Company, Entry, Project, ProjectType
 from example.serializers import (
@@ -200,7 +200,7 @@ class CommentViewSet(ModelViewSet):
         return super(CommentViewSet, self).get_queryset()
 
 
-class CompanyViewset(ModelViewSet):
+class CompanyViewset(PreloadIncludesMixin, viewsets.ModelViewSet):
     queryset = Company.objects.all()
     serializer_class = CompanySerializer
     prefetch_for_includes = {

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -70,7 +70,7 @@ class PrefetchForIncludesHelperMixin(object):
         return qs
 
 
-class SelectAndPrefetchForIncludesMixin(object):
+class PreloadIncludesMixin(object):
     """
     This mixin provides a helper attributes to select or prefetch related models
     based on the include specified in the URL.
@@ -92,7 +92,7 @@ class SelectAndPrefetchForIncludesMixin(object):
         }
     """
     def get_queryset(self):
-        qs = super(SelectAndPrefetchForIncludesMixin, self).get_queryset()
+        qs = super(PreloadIncludesMixin, self).get_queryset()
 
         includes = self.request.GET.get('include', '').split(',') + ['__all__']
 
@@ -237,14 +237,14 @@ class RelatedMixin(object):
 
 
 class ModelViewSet(AutoPrefetchMixin,
-                   SelectAndPrefetchForIncludesMixin,
+                   PreloadIncludesMixin,
                    RelatedMixin,
                    viewsets.ModelViewSet):
     pass
 
 
 class ReadOnlyModelViewSet(AutoPrefetchMixin,
-                           SelectAndPrefetchForIncludesMixin,
+                           PreloadIncludesMixin,
                            RelatedMixin,
                            viewsets.ReadOnlyModelViewSet):
     pass

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -111,11 +111,6 @@ class AutoPrefetchMixin(object):
     def get_queryset(self, *args, **kwargs):
         """ This mixin adds automatic prefetching for OneToOne and ManyToMany fields. """
         qs = super(AutoPrefetchMixin, self).get_queryset(*args, **kwargs)
-
-        # Prefetch includes handled by another mixin, let's do not mix them
-        if hasattr(self, 'prefetch_for_includes'):
-            return qs
-
         included_resources = get_included_resources(self.request)
 
         for included in included_resources:

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -35,7 +35,7 @@ class PrefetchForIncludesHelperMixin(object):
 
     def __init__(self, *args, **kwargs):
         warnings.warn("PrefetchForIncludesHelperMixin is deprecated. "
-                      "Use AutoPreloadMixin instead",
+                      "Use PreloadIncludesMixin instead",
                       DeprecationWarning)
         super(PrefetchForIncludesHelperMixin, self).__init__(*args, **kwargs)
 
@@ -70,7 +70,7 @@ class PrefetchForIncludesHelperMixin(object):
         return qs
 
 
-class AutoPreloadMixin(object):
+class PreloadIncludesMixin(object):
     """
     This mixin provides a helper attributes to select or prefetch related models
     based on the include specified in the URL.
@@ -99,22 +99,30 @@ class AutoPreloadMixin(object):
         return getattr(self, 'prefetch_for_includes', {}).get(include, None)
 
     def get_queryset(self, *args, **kwargs):
+        qs = super(PreloadIncludesMixin, self).get_queryset(*args, **kwargs)
+
+        included_resources = get_included_resources(self.request)
+        for included in included_resources + ['__all__']:
+
+            select_related = self.get_select_related(included)
+            if select_related is not None:
+                qs = qs.select_related(*select_related)
+
+            prefetch_related = self.get_prefetch_related(included)
+            if prefetch_related is not None:
+                qs = qs.prefetch_related(*prefetch_related)
+
+        return qs
+
+
+class AutoPreloadMixin(object):
+
+    def get_queryset(self, *args, **kwargs):
         """ This mixin adds automatic prefetching for OneToOne and ManyToMany fields. """
         qs = super(AutoPreloadMixin, self).get_queryset(*args, **kwargs)
         included_resources = get_included_resources(self.request)
 
         for included in included_resources + ['__all__']:
-            # Custom defined "select_related" and "prefetch_related" is a priority
-            select_related = self.get_select_related(included)
-            if select_related is not None:
-                qs = qs.select_related(*select_related)
-                continue
-
-            prefetch_related = self.get_prefetch_related(included)
-            if prefetch_related is not None:
-                qs = qs.prefetch_related(*prefetch_related)
-                continue
-
             # If include was not defined, trying to resolve it automatically
             included_model = None
             levels = included.split('.')
@@ -252,6 +260,7 @@ class RelatedMixin(object):
 
 
 class ModelViewSet(AutoPreloadMixin,
+                   PreloadIncludesMixin,
                    RelatedMixin,
                    viewsets.ModelViewSet):
     pass

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -35,7 +35,7 @@ class PrefetchForIncludesHelperMixin(object):
 
     def __init__(self, *args, **kwargs):
         warnings.warn("PrefetchForIncludesHelperMixin is deprecated. "
-                      "Use SelectAndPrefetchForIncludesMixin instead",
+                      "Use PreloadIncludesMixin instead",
                       DeprecationWarning)
         super(PrefetchForIncludesHelperMixin, self).__init__(*args, **kwargs)
 
@@ -107,10 +107,10 @@ class PreloadIncludesMixin(object):
         return qs
 
 
-class AutoPrefetchMixin(object):
+class AutoPreloadMixin(object):
     def get_queryset(self, *args, **kwargs):
         """ This mixin adds automatic prefetching for OneToOne and ManyToMany fields. """
-        qs = super(AutoPrefetchMixin, self).get_queryset(*args, **kwargs)
+        qs = super(AutoPreloadMixin, self).get_queryset(*args, **kwargs)
         included_resources = get_included_resources(self.request)
 
         for included in included_resources:
@@ -152,6 +152,15 @@ class AutoPrefetchMixin(object):
                 qs = qs.prefetch_related(included.replace('.', '__'))
 
         return qs
+
+
+class AutoPrefetchMixin(AutoPreloadMixin):
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn("AutoPrefetchMixin is deprecated. "
+                      "Use AutoPreloadMixin instead",
+                      DeprecationWarning)
+        super(AutoPrefetchMixin, self).__init__(*args, **kwargs)
 
 
 class RelatedMixin(object):
@@ -231,14 +240,14 @@ class RelatedMixin(object):
                 raise NotFound
 
 
-class ModelViewSet(AutoPrefetchMixin,
+class ModelViewSet(AutoPreloadMixin,
                    PreloadIncludesMixin,
                    RelatedMixin,
                    viewsets.ModelViewSet):
     pass
 
 
-class ReadOnlyModelViewSet(AutoPrefetchMixin,
+class ReadOnlyModelViewSet(AutoPreloadMixin,
                            PreloadIncludesMixin,
                            RelatedMixin,
                            viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
Fixes #591

## Description of the Change

This PR adds  `SelectAndPrefetchForIncludesMixin` which handles `include` GET parameter and adds `select_related` and/or `prefetch_related` calls to queryset in order to save some sql queries.

This also deprecates `PrefetchForIncludesHelperMixin`.

`AutoPrefetchMixin` is modified so if developer declared `prefetch_for_includes` that means that it's handled "manually" and no need to auto prefetch related entities. 

Let's say we have a code like below:
```python
class Product(models.Model):
    name = CharField()
    tags = M2MField()
    variant = FKField()


class ProductSerializer():
    tags = ResourceRelatedField()
    

class VariantSerializer():
    product = ResourceRelatedField()


class VariantViewset():
    serializer_class = VariantSerializer
    prefetch_for_include = {
    'product': 'product__tags'
}
    
```
Line `'product': 'product__tags'`   will save one query per included product, because it will prefetch tags.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
