### PR TITLE
Fix deprecation warnings regarding collections.abc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Avoid exception when trying to include skipped relationship
 * Don't swallow `filter[]` params when there are several
+* Fix DeprecationWarning regarding collections.abc import in Python 3.7
 
 ## [2.7.0] - 2019-01-14
 

--- a/rest_framework_json_api/compat.py
+++ b/rest_framework_json_api/compat.py
@@ -1,0 +1,4 @@
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc

--- a/rest_framework_json_api/compat.py
+++ b/rest_framework_json_api/compat.py
@@ -1,4 +1,4 @@
 try:
-    import collections.abc as collections_abc
+    import collections.abc as collections_abc  # noqa: F401
 except ImportError:
-    import collections as collections_abc
+    import collections as collections_abc  # noqa: F401

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -1,5 +1,8 @@
-import collections
 import json
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from collections import OrderedDict
 
 import inflection
@@ -388,7 +391,7 @@ class SerializerMethodResourceRelatedField(ResourceRelatedField):
         return super(SerializerMethodResourceRelatedField, self).get_attribute(instance)
 
     def to_representation(self, value):
-        if isinstance(value, collections.Iterable):
+        if isinstance(value, Iterable):
             base = super(SerializerMethodResourceRelatedField, self)
             return [base.to_representation(x) for x in value]
         return super(SerializerMethodResourceRelatedField, self).to_representation(value)

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -1,8 +1,4 @@
 import json
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
 from collections import OrderedDict
 
 import inflection
@@ -17,6 +13,7 @@ from rest_framework.relations import PrimaryKeyRelatedField, RelatedField
 from rest_framework.reverse import reverse
 from rest_framework.serializers import Serializer
 
+from rest_framework_json_api.compat import collections_abc
 from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.utils import (
     Hyperlink,
@@ -391,7 +388,7 @@ class SerializerMethodResourceRelatedField(ResourceRelatedField):
         return super(SerializerMethodResourceRelatedField, self).get_attribute(instance)
 
     def to_representation(self, value):
-        if isinstance(value, Iterable):
+        if isinstance(value, collections_abc.Iterable):
             base = super(SerializerMethodResourceRelatedField, self)
             return [base.to_representation(x) for x in value]
         return super(SerializerMethodResourceRelatedField, self).to_representation(value)

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -2,10 +2,6 @@
 Renderers
 """
 import copy
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
 from collections import OrderedDict, defaultdict
 
 import inflection
@@ -17,6 +13,7 @@ from rest_framework.settings import api_settings
 
 import rest_framework_json_api
 from rest_framework_json_api import utils
+from rest_framework_json_api.compat import collections_abc
 from rest_framework_json_api.relations import HyperlinkedMixin, ResourceRelatedField, SkipDataMixin
 
 
@@ -200,7 +197,7 @@ class JSONRenderer(renderers.JSONRenderer):
 
                 relation_data = {}
 
-                if isinstance(resource.get(field_name), Iterable):
+                if isinstance(resource.get(field_name), collections_abc.Iterable):
                     relation_data.update(
                         {
                             'meta': {'count': len(resource.get(field_name))}

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -2,7 +2,11 @@
 Renderers
 """
 import copy
-from collections import Iterable, OrderedDict, defaultdict
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+from collections import OrderedDict, defaultdict
 
 import inflection
 from django.db.models import Manager

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -1,4 +1,7 @@
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -1,7 +1,3 @@
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model
@@ -23,6 +19,7 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.serializers import Serializer, SkipField
 
+from rest_framework_json_api.compat import collections_abc
 from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.serializers import ResourceIdentifierObjectSerializer
 from rest_framework_json_api.utils import (
@@ -130,7 +127,7 @@ class RelatedMixin(object):
         if instance is None:
             return Response(data=None)
 
-        if isinstance(instance, Iterable):
+        if isinstance(instance, collections_abc.Iterable):
             serializer_kwargs['many'] = True
 
         serializer = self.get_serializer(instance, **serializer_kwargs)


### PR DESCRIPTION
Fixes #613 

## Description of the Change

* Fix `DeprecationWarning` over usage of `collections` instead of `collections.abc`

## Checklist

- [ ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`

The PR doesn't seem to have user impacting changes. Let me know if these need to be updated.

Thanks.