### PR TITLE
import missing six

### DIFF
--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -1,4 +1,5 @@
 import inflection
+import six
 from django.db.models.query import QuerySet
 from django.utils.translation import ugettext_lazy as _
 from rest_framework.exceptions import ParseError


### PR DESCRIPTION
Fixes #629 

## Description of the Change

`import six` since it's no longer in DRF as of 3.10.

## Checklist

- [x ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ x] author name in `AUTHORS`
