### PR TITLE
Allow OPTIONS request to be used on RelationshipView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ any parts of the framework not mentioned in the documentation should generally b
 * Avoid exception when trying to include skipped relationship
 * Don't swallow `filter[]` params when there are several
 * Fix DeprecationWarning regarding collections.abc import in Python 3.7
+* Allow OPTIONS request to be used on RelationshipView.
 
 ## [2.7.0] - 2019-01-14
 

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -274,6 +274,39 @@ class TestRelationshipView(APITestCase):
 
         assert Comment.objects.filter(id=self.second_comment.id).exists()
 
+    def test_options_entry_relationship_blog(self):
+        url = reverse(
+            'entry-relationships', kwargs={'pk': self.first_entry.id, 'related_field': 'blog'}
+        )
+        response = self.client.options(url)
+        expected_data = {
+            "data": {
+                "name": "Entry Relationship",
+                "description": "",
+                "renders": [
+                    "application/vnd.api+json",
+                    "text/html"
+                ],
+                "parses": [
+                    "application/vnd.api+json",
+                    "application/x-www-form-urlencoded",
+                    "multipart/form-data"
+                ],
+                "allowed_methods": [
+                    "GET",
+                    "POST",
+                    "PATCH",
+                    "DELETE",
+                    "HEAD",
+                    "OPTIONS"
+                ],
+                "actions": {
+                    "POST": {}
+                }
+            }
+        }
+        assert response.json() == expected_data
+
 
 class TestRelatedMixin(APITestCase):
 

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -29,10 +29,6 @@ class ResourceIdentifierObjectSerializer(BaseSerializer):
 
     def __init__(self, *args, **kwargs):
         self.model_class = kwargs.pop('model_class', self.model_class)
-        if 'instance' not in kwargs and not self.model_class:
-            raise RuntimeError(
-                'ResourceIdentifierObjectsSerializer must be initialized with a model class.'
-            )
         super(ResourceIdentifierObjectSerializer, self).__init__(*args, **kwargs)
 
     def to_representation(self, instance):

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -29,6 +29,8 @@ class ResourceIdentifierObjectSerializer(BaseSerializer):
 
     def __init__(self, *args, **kwargs):
         self.model_class = kwargs.pop('model_class', self.model_class)
+        # this has no fields but assumptions are made elsewhere that self.fields exists.
+        self.fields = {}
         super(ResourceIdentifierObjectSerializer, self).__init__(*args, **kwargs)
 
     def to_representation(self, instance):


### PR DESCRIPTION
Fixes #315

## Description of the Change

Remove test for 'instance' from `__init__()` so that a call to get the RelationshipSerializer without an instance can be used by DRF's generateschema (3.10 milestone WIP). Missing values of `instance` (if there are ever any) will lead to an exception in `to_representation()`. There are no negative test cases that currently check for this.  The JSONAPI openapi schema generator (WIP; not yet submitted here) "knows" that the openapi schema for a[ Resource Identifier](https://jsonapi.org/format/#document-resource-object-identification) is just `type` and `id` strings so doesn't actually need to serialize it.
 
## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
