### PR TITLE
Pin django-debug-toolbar version to fix Python 2.7 tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(
         'pytest',
         'pytest-cov',
         'django-polymorphic>=2.0',
-        'django-debug-toolbar'
+        'django-debug-toolbar==1.11'
     ] + mock,
     zip_safe=False,
 )


### PR DESCRIPTION
## Description of the Change

Pin django debug toolbar to fix tests in master.

This is a quick fix and at a later point we should try to avoid having debug toolbar as dependency for tests. A bit more complicated to fix as example and tests are combined.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
