### PR TITLE
Adjust building of apidoc to new sphinx version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ django.setup()
 
 # Auto-generate API documentation.
 from sphinx.ext.apidoc import main
-main(['sphinx-apidoc', '-e',  '-T',  '-M',  '-f',  '-o', 'apidoc', '../rest_framework_json_api'])
+main(['-o', 'apidoc', '-f', '-e', '-T', '-M', '../rest_framework_json_api'])
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
Fixes #636 

## Description of the Change

This fixes failing readthedocs build

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
