### PR TITLE
Add missing envlist for Django 2.2 support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py{34,35,36}-df20-django20-drf{37,38,39,master},
     py37-df20-django20-drf{39,master},
     py{35,36,37}-df20-django21-drf{39,master},
+    py{35,36,37}-df20-django22-drf{39,master},
 
 [testenv]
 deps =


### PR DESCRIPTION
Missing change in #640 