### PR TITLE
Allow example app and tests to be run with Django 2.2

### DIFF
--- a/example/fixtures/blogentry.json
+++ b/example/fixtures/blogentry.json
@@ -83,9 +83,7 @@
     "n_comments": 0,
     "n_pingbacks": 0,
     "rating": 0,
-    "authors": [
-      1
-    ]
+    "authors": []
   }
 },
 {
@@ -102,9 +100,7 @@
     "n_comments": 0,
     "n_pingbacks": 0,
     "rating": 0,
-    "authors": [
-      2
-    ]
+    "authors": []
   }
 },
 {

--- a/example/settings/dev.py
+++ b/example/settings/dev.py
@@ -21,7 +21,6 @@ INSTALLED_APPS = [
     'django.contrib.sites',
     'django.contrib.sessions',
     'django.contrib.auth',
-    'django.contrib.admin',
     'rest_framework',
     'polymorphic',
     'example',


### PR DESCRIPTION
## Description of the Change

* admin app would need several middlewares and other apps configured, hence removed for example app
* Remove invalid authors references in blogentry.json

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
