### PR TITLE
tox flake8-isort exclude env and .venv

### DIFF
--- a/example/serializers.py
+++ b/example/serializers.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
-from rest_framework import serializers as drf_serilazers, fields as drf_fields
+from rest_framework import fields as drf_fields
+from rest_framework import serializers as drf_serilazers
 
 from rest_framework_json_api import relations, serializers
 

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -10,8 +10,8 @@ from rest_framework.test import APIRequestFactory, APITestCase, force_authentica
 
 from rest_framework_json_api.utils import format_resource_type
 
-from . import TestBase
 from .. import views
+from . import TestBase
 from example.factories import AuthorFactory, CommentFactory, EntryFactory
 from example.models import Author, Blog, Comment, Entry
 from example.serializers import AuthorBioSerializer, AuthorTypeSerializer, EntrySerializer

--- a/example/views.py
+++ b/example/views.py
@@ -12,7 +12,7 @@ from rest_framework_json_api.django_filters import DjangoFilterBackend
 from rest_framework_json_api.filters import OrderingFilter, QueryParameterValidationFilter
 from rest_framework_json_api.pagination import JsonApiPageNumberPagination
 from rest_framework_json_api.utils import format_drf_errors
-from rest_framework_json_api.views import ModelViewSet, RelationshipView, PreloadIncludesMixin
+from rest_framework_json_api.views import ModelViewSet, PreloadIncludesMixin, RelationshipView
 
 from example.models import Author, Blog, Comment, Company, Entry, Project, ProjectType
 from example.serializers import (

--- a/rest_framework_json_api/django_filters/backends.py
+++ b/rest_framework_json_api/django_filters/backends.py
@@ -4,6 +4,7 @@ from django_filters import VERSION
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.exceptions import ValidationError
 from rest_framework.settings import api_settings
+
 from rest_framework_json_api.utils import format_value
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,8 @@ exclude =
     migrations,
     .eggs
     .tox,
+    env
+    .venv
 
 [isort]
 indent = 4
@@ -28,6 +30,8 @@ skip=
     migrations,
     .eggs
     .tox,
+    env
+    .venv
 
 [coverage:run]
 source =


### PR DESCRIPTION
## Description of the Change

Updates setup.cfg to ignore the `.venv/` or `env/` directories as was already the case in `.gitconfig`.
This allows having a local virtualenv that `tox -e flake8` doesn't scan.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
