### PR TITLE
implement DjangoFilterBackend.get_schema_operation_parameters

### DIFF
--- a/example/tests/unit/test_openapi.py
+++ b/example/tests/unit/test_openapi.py
@@ -1,0 +1,60 @@
+from rest_framework import filters as drf_filters
+from rest_framework_json_api import filters as dja_filters
+from rest_framework_json_api.django_filters import backends
+from example.views import EntryViewSet
+
+
+class DummyEntryViewSet(EntryViewSet):
+    filter_backends = (dja_filters.QueryParameterValidationFilter, dja_filters.OrderingFilter,
+                       backends.DjangoFilterBackend, drf_filters.SearchFilter)
+    filterset_fields = {
+        'id': ('exact',),
+        'headline': ('exact',),
+    }
+
+def test_filters_get_schema_params():
+    """
+    test all my filters for `get_schema_operation_parameters()`
+    """
+    # list of tuples: (filter, expected result)
+    filters = [
+        (dja_filters.QueryParameterValidationFilter, []),
+        (backends.DjangoFilterBackend,
+         [
+             {
+                 'name': 'filter[id]', 'required': False, 'in': 'query',
+                 'description': 'id', 'schema': {'type': 'string'}
+             },
+             {
+                 'name': 'filter[headline]', 'required': False, 'in': 'query',
+                 'description': 'headline', 'schema': {'type': 'string'}
+             }
+          ]
+         ),
+        (dja_filters.OrderingFilter,
+         [
+             {
+                 'name': 'sort', 'required': False, 'in': 'query',
+                 'description': 'Which field to use when ordering the results.',
+                 'schema': {'type': 'string'}
+             }
+         ]
+        ),
+        (drf_filters.SearchFilter,
+         [
+             {
+                 'name': 'filter[search]', 'required': False, 'in': 'query',
+                 'description': 'A search term.',
+                 'schema': {'type': 'string'}
+             }
+         ]
+        ),
+    ]
+    view = DummyEntryViewSet()
+
+    for c, expected in filters:
+        f = c()
+        #  get_schema_operation_parameters is only available in DRF >= 3.10
+        if hasattr(f, 'get_schema_operation_parameters'):
+            result = f.get_schema_operation_parameters(view)
+            assert result == expected

--- a/example/tests/unit/test_openapi.py
+++ b/example/tests/unit/test_openapi.py
@@ -1,6 +1,8 @@
 from rest_framework import filters as drf_filters
+
 from rest_framework_json_api import filters as dja_filters
 from rest_framework_json_api.django_filters import backends
+
 from example.views import EntryViewSet
 
 
@@ -12,6 +14,7 @@ class DummyEntryViewSet(EntryViewSet):
         'headline': ('exact',),
     }
 
+
 def test_filters_get_schema_params():
     """
     test all my filters for `get_schema_operation_parameters()`
@@ -19,36 +22,30 @@ def test_filters_get_schema_params():
     # list of tuples: (filter, expected result)
     filters = [
         (dja_filters.QueryParameterValidationFilter, []),
-        (backends.DjangoFilterBackend,
-         [
-             {
-                 'name': 'filter[id]', 'required': False, 'in': 'query',
-                 'description': 'id', 'schema': {'type': 'string'}
-             },
-             {
-                 'name': 'filter[headline]', 'required': False, 'in': 'query',
-                 'description': 'headline', 'schema': {'type': 'string'}
-             }
-          ]
-         ),
-        (dja_filters.OrderingFilter,
-         [
-             {
-                 'name': 'sort', 'required': False, 'in': 'query',
-                 'description': 'Which field to use when ordering the results.',
-                 'schema': {'type': 'string'}
-             }
-         ]
-        ),
-        (drf_filters.SearchFilter,
-         [
-             {
-                 'name': 'filter[search]', 'required': False, 'in': 'query',
-                 'description': 'A search term.',
-                 'schema': {'type': 'string'}
-             }
-         ]
-        ),
+        (backends.DjangoFilterBackend, [
+            {
+                'name': 'filter[id]', 'required': False, 'in': 'query',
+                'description': 'id', 'schema': {'type': 'string'}
+            },
+            {
+                'name': 'filter[headline]', 'required': False, 'in': 'query',
+                'description': 'headline', 'schema': {'type': 'string'}
+            }
+        ]),
+        (dja_filters.OrderingFilter, [
+            {
+                'name': 'sort', 'required': False, 'in': 'query',
+                'description': 'Which field to use when ordering the results.',
+                'schema': {'type': 'string'}
+            }
+        ]),
+        (drf_filters.SearchFilter, [
+            {
+                'name': 'filter[search]', 'required': False, 'in': 'query',
+                'description': 'A search term.',
+                'schema': {'type': 'string'}
+            }
+        ]),
     ]
     view = DummyEntryViewSet()
 

--- a/rest_framework_json_api/django_filters/backends.py
+++ b/rest_framework_json_api/django_filters/backends.py
@@ -152,7 +152,8 @@ class DjangoFilterBackend(DjangoFilterBackend):
         # see https://github.com/carltongibson/django-filter/pull/1086
 
         try:
-            queryset = view.get_queryset()
+            #queryset = view.get_queryset()
+            queryset = view.queryset
         except Exception:
             queryset = None
             warnings.warn(

--- a/rest_framework_json_api/django_filters/backends.py
+++ b/rest_framework_json_api/django_filters/backends.py
@@ -148,11 +148,8 @@ class DjangoFilterBackend(DjangoFilterBackend):
         """
         Return Open API query parameter schema.
         """
-        # TODO: Update this to extend the upstream django-filter implemntation if and when that gets merged.
-        # see https://github.com/carltongibson/django-filter/pull/1086
-
         try:
-            #queryset = view.get_queryset()
+            # queryset = view.get_queryset()
             queryset = view.queryset
         except Exception:
             queryset = None


### PR DESCRIPTION
Fixes #644

## Description of the Change

Implements filter backend functionality required by DRF 3.9+ `generateschema` management command. Eventually this can extend django-filter's implementation, if and when https://github.com/carltongibson/django-filter/pull/1086 is merged, but it's small enough to stand on its own.

See #604 for more stuff still needed but it shouldn't hurt to merge this now. It will at least prevent an exception from being raised if someone tries to `generateschema` although the output will not be correct until the rest of #604 is done.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
