### PR TITLE
Remove not always supported auto `select_related`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Changed
 
 * Allow to define `select_related` per include using [select_for_includes](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html#performance-improvements)
-* Reduce number of queries to calculate includes by using `select_related` when possible
 * Use REST framework serializer functionality to extract includes. This adds support like using
   dotted notations in source attribute in `ResourceRelatedField`.
 
@@ -31,7 +30,6 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Deprecated
 
 * Deprecate `PrefetchForIncludesHelperMixin` use `PreloadIncludesMixin` instead
-* Deprecate `AutoPrefetchMixin` use `AutoPreloadMixin` instead
 
 ## [2.7.0] - 2019-01-14
 

--- a/example/tests/test_performance.py
+++ b/example/tests/test_performance.py
@@ -53,7 +53,7 @@ class PerformanceTestCase(APITestCase):
         4. Author types prefetched
         5. Entries prefetched
         """
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             response = self.client.get('/comments?include=author&page[size]=25')
             self.assertEqual(len(response.data['results']), 25)
 

--- a/example/views.py
+++ b/example/views.py
@@ -12,7 +12,7 @@ from rest_framework_json_api.django_filters import DjangoFilterBackend
 from rest_framework_json_api.filters import OrderingFilter, QueryParameterValidationFilter
 from rest_framework_json_api.pagination import JsonApiPageNumberPagination
 from rest_framework_json_api.utils import format_drf_errors
-from rest_framework_json_api.views import ModelViewSet, PreloadIncludesMixin, RelationshipView
+from rest_framework_json_api.views import ModelViewSet, RelationshipView
 
 from example.models import Author, Blog, Comment, Company, Entry, Project, ProjectType
 from example.serializers import (
@@ -200,12 +200,9 @@ class CommentViewSet(ModelViewSet):
         return super(CommentViewSet, self).get_queryset()
 
 
-class CompanyViewset(PreloadIncludesMixin, viewsets.ModelViewSet):
+class CompanyViewset(ModelViewSet):
     queryset = Company.objects.all()
     serializer_class = CompanySerializer
-    prefetch_for_includes = {
-        'current_project': ['current_project'],
-    }
 
 
 class ProjectViewset(ModelViewSet):


### PR DESCRIPTION
Addresses testing issue in https://github.com/django-json-api/django-rest-framework-json-api/pull/643 

## Description of the Change

Polymorphic models do not always support [select_related](https://django-polymorphic.readthedocs.io/en/stable/advanced.html?highlight=select_related#about-queryset-methods) and might actually be [slower](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html?highlight=usage#performance-improvements).

Hence reverting change of `AutoPreloadMixin` as it has not been released yet.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
