### PR TITLE
Patch request with "meta" attribute fails

### DIFF
--- a/example/migrations/0001_initial.py
+++ b/example/migrations/0001_initial.py
@@ -61,6 +61,7 @@ class Migration(migrations.Migration):
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('body', models.TextField()),
                 ('author', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='example.Author')),
+                ('meta', models.CharField(max_length=50)),
             ],
             options={
                 'abstract': False,

--- a/example/models.py
+++ b/example/models.py
@@ -127,6 +127,7 @@ class Comment(BaseModel):
         on_delete=models.CASCADE,
         related_name='comments',
     )
+    meta = models.CharField(max_length=50)
 
     def __str__(self):
         return self.body

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -205,6 +205,21 @@ class TestRelationshipView(APITestCase):
         assert response.status_code == 200, response.content.decode()
         assert response.data['author'] is None
 
+    def test_patch_meta(self):
+        url = '/comments/{}'.format(self.second_comment.id)
+        request_data = {
+            'data': {
+                'type': 'comments',
+                'id': self.second_comment.id,
+                'attributes': {
+                    'meta': "test"
+                }
+            }
+        }
+        response = self.client.patch(url, data=request_data)
+        assert response.status_code == 200, response.content.decode()
+        assert response.data['meta'] == "test"
+
     def test_delete_to_many_relationship_with_no_change(self):
         url = '/entries/{}/relationships/comments'.format(self.first_entry.id)
         request_data = {


### PR DESCRIPTION
(This is actually more an issue instead of a PR, but since I have a failing test, I figured I'd post this as a PR anyway.)

When `meta` is used as attribute name, `PATCH` requests are failing because the attribute's value is used in a code path which is supposed to handle the top-level `meta` property.

Request body (taken from the test case):
```python
        request_data = {
            'data': {
                'type': 'comments',
                'id': self.second_comment.id,
                'attributes': {
                    'meta': "test"
                }
            }
        }
```

Exception:
```
Traceback (most recent call last):
  File "/home/christian/.pyenv/versions/3.6.7/envs/drf-json-api/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/home/christian/.pyenv/versions/3.6.7/envs/drf-json-api/lib/python3.6/site-packages/django/core/handlers/base.py", line 145, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/christian/.pyenv/versions/3.6.7/envs/drf-json-api/lib/python3.6/site-packages/django/core/handlers/base.py", line 143, in _get_response
    response = response.render()
  File "/home/christian/.pyenv/versions/3.6.7/envs/drf-json-api/lib/python3.6/site-packages/django/template/response.py", line 106, in render
    self.content = self.rendered_content
  File "/home/christian/.pyenv/versions/3.6.7/envs/drf-json-api/lib/python3.6/site-packages/rest_framework/response.py", line 72, in rendered_content
    ret = renderer.render(self.data, accepted_media_type, context)
  File "/home/christian/dev/django-rest-framework-json-api/rest_framework_json_api/renderers.py", line 572, in render
    json_api_meta.update(self.extract_root_meta(serializer, serializer_data))
AttributeError: 'str' object has no attribute 'update'
```

I didn't find any note that `meta` should not be used as attribute name. If that actually is advised, it would be great to check the models and throw an Error if a model/serializer with a `meta` property is found.