### PR TITLE
replace DRF @list_route and @detail_route with @action

### DIFF
--- a/example/api/resources/identity.py
+++ b/example/api/resources/identity.py
@@ -1,13 +1,24 @@
 from django.contrib.auth import models as auth_models
 from django.utils import encoding
 from rest_framework import generics, parsers, renderers, serializers, viewsets
-from rest_framework.decorators import detail_route, list_route
 from rest_framework.response import Response
 
 from rest_framework_json_api import mixins, utils
 
 from ..serializers.identity import IdentitySerializer
 from ..serializers.post import PostSerializer
+
+try:
+    from rest_framework.decorators import action
+
+    def detail_route(**kwargs):
+        return action(detail=True, **kwargs)
+
+    def list_route(**kwargs):
+        return action(detail=False, **kwargs)
+
+except ImportError:
+    from rest_framework.decorators import detail_route, list_route
 
 
 class Identity(mixins.MultipleIDMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
Fixes #657

## Description of the Change

DRF 3.10 milestone has dropped the `@list_route` and `@detail_route` decorators and replaced them with `@action(detail=False)` or `@action(detail=True)` which was added in DRF 3.8.

This fix handles both `DRF<=3.7` and `>=3.8` cases.
 
## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
