### PR TITLE
Drop support for obsolete dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,119 +4,63 @@ cache: pip
 # Favor explicit over implicit and use an explicit build matrix.
 matrix:
   allow_failures:
-    - env: TOXENV=py34-df21-django20-drfmaster
-    - env: TOXENV=py35-df21-django20-drfmaster
-    - env: TOXENV=py36-df21-django20-drfmaster
-    - env: TOXENV=py37-df21-django20-drfmaster
-    - env: TOXENV=py35-df21-django21-drfmaster
-    - env: TOXENV=py36-df21-django21-drfmaster
-    - env: TOXENV=py37-df21-django21-drfmaster
-    - env: TOXENV=py35-df21-django22-drfmaster
-    - env: TOXENV=py36-df21-django22-drfmaster
-    - env: TOXENV=py37-df21-django22-drfmaster
+    - env: TOXENV=py35-django21-drfmaster
+    - env: TOXENV=py36-django21-drfmaster
+    - env: TOXENV=py37-django21-drfmaster
+    - env: TOXENV=py35-django22-drfmaster
+    - env: TOXENV=py36-django22-drfmaster
+    - env: TOXENV=py37-django22-drfmaster
 
   include:
     - python: 3.6
       env: TOXENV=flake8
 
-    - python: 2.7
-      env: TOXENV=py27-df11-django111-drf36
-    - python: 2.7
-      env: TOXENV=py27-df11-django111-drf37
-    - python: 2.7
-      env: TOXENV=py27-df11-django111-drf38
-    - python: 2.7
-      env: TOXENV=py27-df11-django111-drf39
-
-    - python: 3.4
-      env: TOXENV=py34-df21-django111-drf36
-    - python: 3.4
-      env: TOXENV=py34-df21-django111-drf37
-    - python: 3.4
-      env: TOXENV=py34-df21-django111-drf38
-    - python: 3.4
-      env: TOXENV=py34-df21-django20-drf37
-    - python: 3.4
-      env: TOXENV=py34-df21-django20-drf38
-    - python: 3.4
-      env: TOXENV=py34-df21-django20-drf39
-    - python: 3.4
-      env: TOXENV=py34-df21-django20-drfmaster
-
     - python: 3.5
-      env: TOXENV=py35-df21-django111-drf36
+      env: TOXENV=py35-django111-drf39
     - python: 3.5
-      env: TOXENV=py35-df21-django111-drf37
+      env: TOXENV=py35-django111-drfmaster
     - python: 3.5
-      env: TOXENV=py35-df21-django111-drf38
+      env: TOXENV=py35-django21-drf39
     - python: 3.5
-      env: TOXENV=py35-df21-django20-drf37
-    - python: 3.5
-      env: TOXENV=py35-df21-django20-drf38
-    - python: 3.5
-      env: TOXENV=py35-df21-django20-drf39
-    - python: 3.5
-      env: TOXENV=py35-df21-django20-drfmaster
-    - python: 3.5
-      env: TOXENV=py35-df21-django21-drf39
-    - python: 3.5
-      env: TOXENV=py35-df21-django21-drfmaster
+      env: TOXENV=py35-django21-drfmaster
     - python: 3.5
       dist: xenial
-      env: TOXENV=py35-df21-django22-drf39
+      env: TOXENV=py35-django22-drf39
     - python: 3.5
       dist: xenial
-      env: TOXENV=py35-df21-django22-drfmaster
+      env: TOXENV=py35-django22-drfmaster
 
     - python: 3.6
-      env: TOXENV=py36-df21-django111-drf36
+      env: TOXENV=py36-django111-drf39
     - python: 3.6
-      env: TOXENV=py36-df21-django111-drf37
+      env: TOXENV=py36-django111-drfmaster
     - python: 3.6
-      env: TOXENV=py36-df21-django111-drf38
+      env: TOXENV=py36-django21-drf39
     - python: 3.6
-      env: TOXENV=py36-df21-django20-drf37
-    - python: 3.6
-      env: TOXENV=py36-df21-django20-drf38
-    - python: 3.6
-      env: TOXENV=py36-df21-django20-drf39
-    - python: 3.6
-      env: TOXENV=py36-df21-django20-drfmaster
-    - python: 3.6
-      env: TOXENV=py36-df21-django21-drf39
-    - python: 3.6
-      env: TOXENV=py36-df21-django21-drfmaster
+      env: TOXENV=py36-django21-drfmaster
     - python: 3.6
       dist: xenial
-      env: TOXENV=py36-df21-django22-drf39
+      env: TOXENV=py36-django22-drf39
     - python: 3.6
       dist: xenial
-      env: TOXENV=py36-df21-django22-drfmaster
+      env: TOXENV=py36-django22-drfmaster
 
     - python: 3.7
       dist: xenial
       sudo: required
-      env: TOXENV=py37-df21-django20-drf39
+      env: TOXENV=py37-django21-drf39
     - python: 3.7
       dist: xenial
       sudo: required
-      env: TOXENV=py37-df21-django20-drfmaster
+      env: TOXENV=py37-django21-drfmaster
     - python: 3.7
       dist: xenial
       sudo: required
-      env: TOXENV=py37-df21-django21-drf39
+      env: TOXENV=py37-django22-drf39
     - python: 3.7
       dist: xenial
       sudo: required
-      env: TOXENV=py37-df21-django21-drfmaster
-    - python: 3.7
-      dist: xenial
-      sudo: required
-      env: TOXENV=py37-df21-django22-drf39
-    - python: 3.7
-      dist: xenial
-      sudo: required
-      env: TOXENV=py37-df21-django22-drfmaster
+      env: TOXENV=py37-django22-drfmaster
 install:
   - pip install tox
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST Framework policy](http://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
+## [Unreleased]
+
+### Removed
+
+* Removed support for Python 2.7 and 3.4.
+* Removed support for Django Filter 1.1.
+* Removed obsolete dependency six.
+* Removed support for Django REST Framework <=3.8.
+* Removed support for Django 2.0.
+
 ## [2.8.0] - 2019-06-13
 
 This is the last release supporting Python 2.7, Python 3.4, Django Filter 1.1, Django REST Framework <=3.8 and Django 2.0.

--- a/README.rst
+++ b/README.rst
@@ -87,9 +87,9 @@ As a Django REST Framework JSON API (short DJA) we are trying to address followi
 Requirements
 ------------
 
-1. Python (2.7, 3.4, 3.5, 3.6, 3.7)
-2. Django (1.11, 2.0, 2.1, 2.2)
-3. Django REST Framework (3.6, 3.7, 3.8, 3.9)
+1. Python (3.5, 3.6, 3.7)
+2. Django (1.11, 2.1, 2.2)
+3. Django REST Framework (3.9)
 
 ------------
 Installation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,9 +51,9 @@ like the following:
 
 ## Requirements
 
-1. Python (2.7, 3.4, 3.5, 3.6, 3.7)
-2. Django (1.11, 2.0, 2.1, 2.2)
-3. Django REST Framework (3.6, 3.7, 3.8, 3.9)
+1. Python (3.5, 3.6, 3.7)
+2. Django (1.11, 2.1, 2.2)
+3. Django REST Framework (3.9)
 
 ## Installation
 

--- a/example/api/resources/identity.py
+++ b/example/api/resources/identity.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import models as auth_models
 from django.utils import encoding
 from rest_framework import generics, parsers, renderers, serializers, viewsets
-from rest_framework.decorators import detail_route, list_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from rest_framework_json_api import mixins, utils
@@ -15,7 +15,7 @@ class Identity(mixins.MultipleIDMixin, viewsets.ModelViewSet):
     serializer_class = IdentitySerializer
 
     # demonstrate sideloading data for use at app boot time
-    @list_route()
+    @action(detail=False)
     def posts(self, request):
         self.resource_name = False
 
@@ -28,12 +28,12 @@ class Identity(mixins.MultipleIDMixin, viewsets.ModelViewSet):
         }
         return Response(utils.format_field_names(data, format_type='camelize'))
 
-    @detail_route()
+    @action(detail=True)
     def manual_resource_name(self, request, *args, **kwargs):
         self.resource_name = 'data'
         return super(Identity, self).retrieve(request, args, kwargs)
 
-    @detail_route()
+    @action(detail=True)
     def validation(self, request, *args, **kwargs):
         raise serializers.ValidationError('Oh nohs!')
 

--- a/example/models.py
+++ b/example/models.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from polymorphic.models import PolymorphicModel
 
 
@@ -32,7 +31,6 @@ class TaggedItem(BaseModel):
         ordering = ('id',)
 
 
-@python_2_unicode_compatible
 class Blog(BaseModel):
     name = models.CharField(max_length=100)
     tagline = models.TextField()
@@ -45,7 +43,6 @@ class Blog(BaseModel):
         ordering = ('id',)
 
 
-@python_2_unicode_compatible
 class AuthorType(BaseModel):
     name = models.CharField(max_length=50)
 
@@ -56,7 +53,6 @@ class AuthorType(BaseModel):
         ordering = ('id',)
 
 
-@python_2_unicode_compatible
 class Author(BaseModel):
     name = models.CharField(max_length=50)
     email = models.EmailField()
@@ -69,7 +65,6 @@ class Author(BaseModel):
         ordering = ('id',)
 
 
-@python_2_unicode_compatible
 class AuthorBio(BaseModel):
     author = models.OneToOneField(Author, related_name='bio', on_delete=models.CASCADE)
     body = models.TextField()
@@ -81,7 +76,6 @@ class AuthorBio(BaseModel):
         ordering = ('id',)
 
 
-@python_2_unicode_compatible
 class AuthorBioMetadata(BaseModel):
     """
     Just a class to have a relation with author bio
@@ -96,7 +90,6 @@ class AuthorBioMetadata(BaseModel):
         ordering = ('id',)
 
 
-@python_2_unicode_compatible
 class Entry(BaseModel):
     blog = models.ForeignKey(Blog, on_delete=models.CASCADE)
     headline = models.CharField(max_length=255)
@@ -116,7 +109,6 @@ class Entry(BaseModel):
         ordering = ('id',)
 
 
-@python_2_unicode_compatible
 class Comment(BaseModel):
     entry = models.ForeignKey(Entry, related_name='comments', on_delete=models.CASCADE)
     body = models.TextField()
@@ -135,7 +127,6 @@ class Comment(BaseModel):
         ordering = ('id',)
 
 
-@python_2_unicode_compatible
 class ProjectType(BaseModel):
     name = models.CharField(max_length=50)
 
@@ -160,7 +151,6 @@ class ResearchProject(Project):
     supervisor = models.CharField(max_length=30)
 
 
-@python_2_unicode_compatible
 class Company(models.Model):
     name = models.CharField(max_length=100)
     current_project = models.ForeignKey(

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -8,6 +8,5 @@ pluggy
 py
 pyparsing
 pytz
-six
 sqlparse
 django-filter>=2.0

--- a/example/tests/integration/test_non_paginated_responses.py
+++ b/example/tests/integration/test_non_paginated_responses.py
@@ -1,10 +1,7 @@
+from unittest import mock
+
 import pytest
 from django.urls import reverse
-
-try:
-    from unittest import mock
-except ImportError:  # pragma: no cover
-    import mock
 
 pytestmark = pytest.mark.django_db
 

--- a/example/tests/integration/test_pagination.py
+++ b/example/tests/integration/test_pagination.py
@@ -1,11 +1,7 @@
+from unittest import mock
+
 import pytest
 from django.urls import reverse
-
-try:
-    from unittest import mock
-except ImportError:  # pragma: no cover
-    import mock
-
 
 pytestmark = pytest.mark.django_db
 

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from django.test import TestCase
 from django.urls import reverse
@@ -14,11 +16,6 @@ from rest_framework_json_api.utils import format_resource_type
 
 from example.models import Author, Blog, Entry
 from example.serializers import BlogSerializer
-
-try:
-    from unittest import mock
-except ImportError:  # pragma: no cover
-    import mock
 
 request_factory = APIRequestFactory()
 pytestmark = pytest.mark.django_db

--- a/example/tests/unit/test_utils.py
+++ b/example/tests/unit/test_utils.py
@@ -1,7 +1,6 @@
 import pytest
 from django.contrib.auth import get_user_model
 from django.test import override_settings
-from django.utils import six
 from rest_framework import serializers
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
@@ -130,7 +129,7 @@ def test_get_included_serializers_against_class():
         'comments': CommentSerializer,
         'self': klass
     }
-    assert six.viewkeys(included_serializers) == six.viewkeys(klass.included_serializers), (
+    assert included_serializers.keys() == klass.included_serializers.keys(), (
         'the keys must be preserved'
     )
 
@@ -147,7 +146,7 @@ def test_get_included_serializers_against_instance():
         'comments': CommentSerializer,
         'self': klass
     }
-    assert six.viewkeys(included_serializers) == six.viewkeys(klass.included_serializers), (
+    assert included_serializers.keys() == klass.included_serializers.keys(), (
         'the keys must be preserved'
     )
 

--- a/example/views.py
+++ b/example/views.py
@@ -140,7 +140,6 @@ class NonPaginatedEntryViewSet(EntryViewSet):
         'blog__name': rels,
         'blog__tagline': rels,
     }
-    filter_fields = filterset_fields  # django-filter<=1.1  (required for py27)
     search_fields = ('headline', 'body_text', 'blog__name', 'blog__tagline')
 
 
@@ -160,8 +159,6 @@ class FiltersetEntryViewSet(EntryViewSet):
     pagination_class = NoPagination
     filterset_fields = None
     filterset_class = EntryFilter
-    filter_fields = filterset_fields  # django-filter<=1.1
-    filter_class = filterset_class
 
 
 class NoFiltersetEntryViewSet(EntryViewSet):
@@ -171,8 +168,6 @@ class NoFiltersetEntryViewSet(EntryViewSet):
     pagination_class = NoPagination
     filterset_fields = None
     filterset_class = None
-    filter_fields = filterset_fields  # django-filter<=1.1
-    filter_class = filterset_class
 
 
 class AuthorViewSet(ModelViewSet):

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,14 +4,4 @@ filterwarnings =
     error::DeprecationWarning
     error::PendingDeprecationWarning
     # TODO: restructure tests so this can be ignored on a test level
-    ignore:MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly.
-    ignore:use of getfuncargvalue is deprecated, use getfixturevalue
-    ignore:`list_route`
-    ignore:`detail_route`
-    ignore:`FiltersetEntryViewSet.filter_fields` attribute should be renamed
-    ignore:`NoFiltersetEntryViewSet.filter_fields` attribute should be renamed
-    ignore:`NoFiltersetEntryViewSet.filter_class` attribute should be renamed `filterset_class`
     ignore:MultipleIDMixin is deprecated
-    # can be removed once following DRF PR is released
-    # https://github.com/encode/django-rest-framework/pull/6268
-    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -7,7 +7,6 @@ factory-boy==2.12.0
 flake8==3.7.7
 flake8-isort==2.7.0
 isort==4.3.21
-mock==3.0.5
 pytest==4.6.3
 pytest-cov==2.7.1
 pytest-django==3.5.0

--- a/rest_framework_json_api/compat.py
+++ b/rest_framework_json_api/compat.py
@@ -1,4 +1,0 @@
-try:
-    import collections.abc as collections_abc  # noqa: F401
-except ImportError:
-    import collections as collections_abc  # noqa: F401

--- a/rest_framework_json_api/django_filters/backends.py
+++ b/rest_framework_json_api/django_filters/backends.py
@@ -1,6 +1,5 @@
 import re
 
-from django_filters import VERSION
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.exceptions import ValidationError
 from rest_framework.settings import api_settings
@@ -123,22 +122,3 @@ class DjangoFilterBackend(DjangoFilterBackend):
             'request': request,
             'filter_keys': filter_keys,
         }
-
-    def filter_queryset(self, request, queryset, view):
-        """
-        This is backwards compatibility to django-filter 1.1 (required for Python 2.7).
-        In 1.1 `filter_queryset` does not call `get_filterset` or `get_filterset_kwargs`.
-        """
-        # TODO: remove when Python 2.7 support is deprecated
-        if VERSION >= (2, 0, 0):
-            return super(DjangoFilterBackend, self).filter_queryset(request, queryset, view)
-
-        filter_class = self.get_filter_class(view, queryset)
-
-        kwargs = self.get_filterset_kwargs(request, queryset, view)
-        self._validate_filter(kwargs.pop('filter_keys'), filter_class)
-
-        if filter_class:
-            return filter_class(kwargs['data'], queryset=queryset, request=request).qs
-
-        return queryset

--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -1,7 +1,6 @@
 """
 Parsers
 """
-from django.utils import six
 from rest_framework import parsers
 from rest_framework.exceptions import ParseError
 
@@ -121,7 +120,7 @@ class JSONParser(parsers.JSONParser):
         if request.method in ('PUT', 'POST', 'PATCH'):
             resource_name = utils.get_resource_name(
                 parser_context, expand_polymorphic_types=True)
-            if isinstance(resource_name, six.string_types):
+            if isinstance(resource_name, str):
                 if data.get('type') != resource_name:
                     raise exceptions.Conflict(
                         "The resource object's type ({data_type}) is not the type that "

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -1,5 +1,6 @@
 import json
 from collections import OrderedDict
+from collections.abc import Iterable
 
 import inflection
 import six
@@ -13,7 +14,6 @@ from rest_framework.relations import PrimaryKeyRelatedField, RelatedField
 from rest_framework.reverse import reverse
 from rest_framework.serializers import Serializer
 
-from rest_framework_json_api.compat import collections_abc
 from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.utils import (
     Hyperlink,
@@ -388,7 +388,7 @@ class SerializerMethodResourceRelatedField(ResourceRelatedField):
         return super(SerializerMethodResourceRelatedField, self).get_attribute(instance)
 
     def to_representation(self, value):
-        if isinstance(value, collections_abc.Iterable):
+        if isinstance(value, Iterable):
             base = super(SerializerMethodResourceRelatedField, self)
             return [base.to_representation(x) for x in value]
         return super(SerializerMethodResourceRelatedField, self).to_representation(value)

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 from collections.abc import Iterable
 
 import inflection
-import six
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import NoReverseMatch
 from django.utils.translation import ugettext_lazy as _
@@ -210,7 +209,7 @@ class ResourceRelatedField(HyperlinkedMixin, PrimaryKeyRelatedField):
         raise Conflict(message_string)
 
     def to_internal_value(self, data):
-        if isinstance(data, six.text_type):
+        if isinstance(data, str):
             try:
                 data = json.loads(data)
             except ValueError:
@@ -324,7 +323,7 @@ class PolymorphicResourceRelatedField(ResourceRelatedField):
         return False
 
     def to_internal_value(self, data):
-        if isinstance(data, six.text_type):
+        if isinstance(data, str):
             try:
                 data = json.loads(data)
             except ValueError:

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 
 import inflection
 from django.db.models import Manager
-from django.utils import encoding, six
+from django.utils import encoding
 from rest_framework import relations, renderers
 from rest_framework.fields import SkipField, get_attribute
 from rest_framework.relations import PKOnlyObject
@@ -55,7 +55,7 @@ class JSONRenderer(renderers.JSONRenderer):
         Builds the `attributes` object of the JSON API resource object.
         """
         data = OrderedDict()
-        for field_name, field in six.iteritems(fields):
+        for field_name, field in iter(fields.items()):
             # ID is always provided in the root of JSON API so remove it from attributes
             if field_name == 'id':
                 continue
@@ -97,7 +97,7 @@ class JSONRenderer(renderers.JSONRenderer):
         if resource_instance is None:
             return
 
-        for field_name, field in six.iteritems(fields):
+        for field_name, field in iter(fields.items()):
             # Skip URL field
             if field_name == api_settings.URL_FIELD_NAME:
                 continue
@@ -331,7 +331,7 @@ class JSONRenderer(renderers.JSONRenderer):
         included_resources = copy.copy(included_resources)
         included_resources = [inflection.underscore(value) for value in included_resources]
 
-        for field_name, field in six.iteritems(fields):
+        for field_name, field in iter(fields.items()):
             # Skip URL field
             if field_name == api_settings.URL_FIELD_NAME:
                 continue

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -3,6 +3,7 @@ Renderers
 """
 import copy
 from collections import OrderedDict, defaultdict
+from collections.abc import Iterable
 
 import inflection
 from django.db.models import Manager
@@ -15,7 +16,6 @@ from rest_framework.settings import api_settings
 
 import rest_framework_json_api
 from rest_framework_json_api import utils
-from rest_framework_json_api.compat import collections_abc
 from rest_framework_json_api.relations import HyperlinkedMixin, ResourceRelatedField, SkipDataMixin
 
 
@@ -199,7 +199,7 @@ class JSONRenderer(renderers.JSONRenderer):
 
                 relation_data = {}
 
-                if isinstance(resource.get(field_name), collections_abc.Iterable):
+                if isinstance(resource.get(field_name), Iterable):
                     relation_data.update(
                         {
                             'meta': {'count': len(resource.get(field_name))}

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -1,5 +1,4 @@
 import inflection
-import six
 from django.db.models.query import QuerySet
 from django.utils.translation import ugettext_lazy as _
 from rest_framework.exceptions import ParseError
@@ -257,8 +256,7 @@ class PolymorphicSerializerMetaclass(SerializerMetaclass):
         return new_class
 
 
-@six.add_metaclass(PolymorphicSerializerMetaclass)
-class PolymorphicModelSerializer(ModelSerializer):
+class PolymorphicModelSerializer(ModelSerializer, metaclass=PolymorphicSerializerMetaclass):
     """
     A serializer for polymorphic models.
     Useful for "lazy" parent models. Leaves should be represented with a regular serializer.

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -16,14 +16,8 @@ from django.utils.module_loading import import_string as import_class_from_dotte
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import exceptions
 from rest_framework.exceptions import APIException
-from rest_framework.serializers import ManyRelatedField  # noqa: F401
 
 from .settings import json_api_settings
-
-try:
-    from rest_framework_nested.relations import HyperlinkedRouterField
-except ImportError:
-    HyperlinkedRouterField = object()
 
 # Generic relation descriptor from django.contrib.contenttypes.
 if 'django.contrib.contenttypes' not in settings.INSTALLED_APPS:  # pragma: no cover

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -11,7 +11,7 @@ from django.db.models.fields.related_descriptors import (
     ManyToManyDescriptor,
     ReverseManyToOneDescriptor
 )
-from django.utils import encoding, six
+from django.utils import encoding
 from django.utils.module_loading import import_string as import_class_from_dotted_path
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import exceptions
@@ -63,7 +63,7 @@ def get_resource_name(context, expand_polymorphic_types=False):
             except AttributeError:
                 resource_name = view.__class__.__name__
 
-            if not isinstance(resource_name, six.string_types):
+            if not isinstance(resource_name, str):
                 # The resource name is not a string - return as is
                 return resource_name
 
@@ -337,7 +337,7 @@ def get_default_included_resources_from_serializer(serializer):
 def get_included_serializers(serializer):
     included_serializers = copy.copy(getattr(serializer, 'included_serializers', dict()))
 
-    for name, value in six.iteritems(included_serializers):
+    for name, value in iter(included_serializers.items()):
         if not isinstance(value, type):
             if value == 'self':
                 included_serializers[name] = (
@@ -367,7 +367,7 @@ def get_relation_instance(resource_instance, source, serializer):
     return True, relation_instance
 
 
-class Hyperlink(six.text_type):
+class Hyperlink(str):
     """
     A string like object that additionally has an associated name.
     We use this for hyperlinked URLs that may render as a named link
@@ -378,7 +378,7 @@ class Hyperlink(six.text_type):
     """
 
     def __new__(self, url, name):
-        ret = six.text_type.__new__(self, url)
+        ret = str.__new__(self, url)
         ret.name = name
         return ret
 
@@ -405,7 +405,7 @@ def format_drf_errors(response, context, exc):
             # see if they passed a dictionary to ValidationError manually
             if isinstance(error, dict):
                 errors.append(error)
-            elif isinstance(error, six.string_types):
+            elif isinstance(error, str):
                 classes = inspect.getmembers(exceptions, inspect.isclass)
                 # DRF sets the `field` to 'detail' for its own exceptions
                 if isinstance(exc, tuple(x[1] for x in classes)):

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -1,4 +1,5 @@
 import warnings
+from collections.abc import Iterable
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model
@@ -20,7 +21,6 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.serializers import Serializer, SkipField
 
-from rest_framework_json_api.compat import collections_abc
 from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.serializers import ResourceIdentifierObjectSerializer
 from rest_framework_json_api.utils import (
@@ -180,7 +180,7 @@ class RelatedMixin(object):
         if instance is None:
             return Response(data=None)
 
-        if isinstance(instance, collections_abc.Iterable):
+        if isinstance(instance, Iterable):
             serializer_kwargs['many'] = True
 
         serializer = self.get_serializer(instance, **serializer_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,6 @@ setup(
         'inflection>=0.3.0',
         'djangorestframework>=3.9',
         'django>=1.11',
-        'six',
     ],
     setup_requires=pytest_runner + sphinx + wheel,
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,6 @@ import sys
 
 from setuptools import setup
 
-needs_mock = sys.version_info < (3, 3)
-mock = ['mock'] if needs_mock else []
 needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
 needs_sphinx = {'build_sphinx', 'upload_docs'}.intersection(sys.argv)
@@ -86,10 +84,7 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -99,7 +94,7 @@ setup(
     ],
     install_requires=[
         'inflection>=0.3.0',
-        'djangorestframework>=3.6.3',
+        'djangorestframework>=3.9',
         'django>=1.11',
         'six',
     ],
@@ -111,7 +106,8 @@ setup(
         'pytest',
         'pytest-cov',
         'django-polymorphic>=2.0',
+        'django-filter>=2.0',
         'django-debug-toolbar==1.11'
-    ] + mock,
+    ],
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,15 @@
 [tox]
 envlist =
-    py27-df11-django111-drf{36,37,38,39}
-    py{34,35,36}-df21-django111-drf{36,37,38,39,master},
-    py{34,35,36}-df21-django20-drf{37,38,39,master},
-    py37-df21-django20-drf{39,master},
-    py{35,36,37}-df21-django21-drf{39,master},
-    py{35,36,37}-df21-django22-drf{39,master},
+    py{35,36}-django111-drf{39,master},
+    py{35,36,37}-django{21,22}-drf{39,master},
 
 [testenv]
 deps =
     django111: Django>=1.11,<1.12
-    django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
-    drf36: djangorestframework>=3.6.3,<3.7
-    drf37: djangorestframework>=3.7.0,<3.8
-    drf38: djangorestframework>=3.8.0,<3.9
     drf39: djangorestframework>=3.9.0,<3.10
     drfmaster: https://github.com/encode/django-rest-framework/archive/master.zip
-    df11: django-filter<=1.1
-    df21: django-filter>=2.1
 
 setenv =
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
Fixes #658
Fixes #659  

## Description of the Change

Following specific supports are removed:
* Python 2.7
* Python 3.4
* Django Filter 1.1
* Django REST Framework >=3.8
* Django 2.0

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
