### PR TITLE
Replace relative imports to make isort happy

### DIFF
--- a/example/api/resources/identity.py
+++ b/example/api/resources/identity.py
@@ -6,8 +6,8 @@ from rest_framework.response import Response
 
 from rest_framework_json_api import utils
 
-from ..serializers.identity import IdentitySerializer
-from ..serializers.post import PostSerializer
+from example.api.serializers.identity import IdentitySerializer
+from example.api.serializers.post import PostSerializer
 
 
 class Identity(viewsets.ModelViewSet):

--- a/example/tests/test_filters.py
+++ b/example/tests/test_filters.py
@@ -1,7 +1,7 @@
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
-from ..models import Blog, Entry
+from example.models import Blog, Entry
 
 
 class DJATestFilters(APITestCase):

--- a/example/tests/test_utils.py
+++ b/example/tests/test_utils.py
@@ -3,8 +3,8 @@ Test rest_framework_json_api's utils functions.
 """
 from rest_framework_json_api import utils
 
-from ..serializers import AuthorSerializer, EntrySerializer
-from ..tests import TestBase
+from example.serializers import AuthorSerializer, EntrySerializer
+from example.tests import TestBase
 
 
 class GetRelatedResourceTests(TestBase):

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -10,8 +10,8 @@ from rest_framework.test import APIRequestFactory, APITestCase, force_authentica
 
 from rest_framework_json_api.utils import format_resource_type
 
-from .. import views
 from . import TestBase
+from .. import views
 from example.factories import AuthorFactory, CommentFactory, EntryFactory
 from example.models import Author, Blog, Comment, Entry
 from example.serializers import AuthorBioSerializer, AuthorTypeSerializer, EntrySerializer

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -10,12 +10,11 @@ from rest_framework.test import APIRequestFactory, APITestCase, force_authentica
 
 from rest_framework_json_api.utils import format_resource_type
 
-from . import TestBase
-from .. import views
 from example.factories import AuthorFactory, CommentFactory, EntryFactory
 from example.models import Author, Blog, Comment, Entry
 from example.serializers import AuthorBioSerializer, AuthorTypeSerializer, EntrySerializer
-from example.views import AuthorViewSet
+from example.tests import TestBase
+from example.views import AuthorViewSet, BlogViewSet
 
 
 class TestRelationshipView(APITestCase):
@@ -427,7 +426,7 @@ class TestRelatedMixin(APITestCase):
 
 class TestValidationErrorResponses(TestBase):
     def test_if_returns_error_on_empty_post(self):
-        view = views.BlogViewSet.as_view({'post': 'create'})
+        view = BlogViewSet.as_view({'post': 'create'})
         response = self._get_create_response("{}", view)
         self.assertEqual(400, response.status_code)
         expected = [{
@@ -438,7 +437,7 @@ class TestValidationErrorResponses(TestBase):
         self.assertEqual(expected, response.data)
 
     def test_if_returns_error_on_missing_form_data_post(self):
-        view = views.BlogViewSet.as_view({'post': 'create'})
+        view = BlogViewSet.as_view({'post': 'create'})
         response = self._get_create_response('{"data":{"attributes":{},"type":"blogs"}}', view)
         self.assertEqual(400, response.status_code)
         expected = [{
@@ -449,7 +448,7 @@ class TestValidationErrorResponses(TestBase):
         self.assertEqual(expected, response.data)
 
     def test_if_returns_error_on_bad_endpoint_name(self):
-        view = views.BlogViewSet.as_view({'post': 'create'})
+        view = BlogViewSet.as_view({'post': 'create'})
         response = self._get_create_response('{"data":{"attributes":{},"type":"bad"}}', view)
         self.assertEqual(409, response.status_code)
         expected = [{


### PR DESCRIPTION
README suggest running flake8 before contributing, but current `master` reports issues.
```
$ flake8
./example/tests/test_views.py:14:1: I001 isort found an import in the wrong position
```

This fixes the current issue. Long term you'd probably want to add `flake8` to the test suite and reject PRs that have flake8 problems. If you don't care about `flake8` issues then maybe we should remove it from README?