### PR TITLE
Avoid exception when using `ResourceIdentifierObjectSerializer` with unexisting primary key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This release is not backwards compatible. For easy migration best upgrade first 
 ### Fixed
 
 * Avoid printing invalid pointer when api returns 404
+* Avoid exception when using `ResourceIdentifierObjectSerializer` with unexisting primary key
 
 
 ## [2.8.0] - 2019-06-13

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -119,6 +119,20 @@ class TestResourceIdentifierObjectSerializer(TestCase):
         self.assertTrue(serializer.is_valid(), msg=serializer.errors)
         assert serializer.validated_data == self.blog
 
+    def test_deserialize_primitive_data_blog_with_unexisting_pk(self):
+        unexisting_pk = self.blog.id
+        self.blog.delete()
+        assert not Blog.objects.filter(id=unexisting_pk).exists()
+
+        initial_data = {
+            'type': format_resource_type('Blog'),
+            'id': str(unexisting_pk)
+        }
+        serializer = ResourceIdentifierObjectSerializer(data=initial_data, model_class=Blog)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors[0].code, 'does_not_exist')
+
     def test_data_in_correct_format_when_instantiated_with_queryset(self):
         qs = Author.objects.all()
         serializer = ResourceIdentifierObjectSerializer(instance=qs, many=True)

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -1,4 +1,5 @@
 import inflection
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.query import QuerySet
 from django.utils.translation import ugettext_lazy as _
 from rest_framework.exceptions import ParseError


### PR DESCRIPTION
Fixes #683

## Description of the Change

Because of star import linting didn't realize that `ObjectDoesNotExist` exception was not properly imported.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
