### PR TITLE
deprecate DRF 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,20 +18,13 @@ matrix:
       env: TOXENV=flake8
 
     - python: 3.5
-      env: TOXENV=py35-django111-drf39
-    - python: 3.5
       env: TOXENV=py35-django111-drf310
     - python: 3.5
       env: TOXENV=py35-django111-drfmaster
     - python: 3.5
-      env: TOXENV=py35-django21-drf39
-    - python: 3.5
       env: TOXENV=py35-django21-drf310
     - python: 3.5
       env: TOXENV=py35-django21-drfmaster
-    - python: 3.5
-      dist: xenial
-      env: TOXENV=py35-django22-drf39
     - python: 3.5
       dist: xenial
       env: TOXENV=py35-django22-drf310
@@ -40,20 +33,13 @@ matrix:
       env: TOXENV=py35-django22-drfmaster
 
     - python: 3.6
-      env: TOXENV=py36-django111-drf39
-    - python: 3.6
       env: TOXENV=py36-django111-drf310
     - python: 3.6
       env: TOXENV=py36-django111-drfmaster
     - python: 3.6
-      env: TOXENV=py36-django21-drf39
-    - python: 3.6
       env: TOXENV=py36-django21-drf310
     - python: 3.6
       env: TOXENV=py36-django21-drfmaster
-    - python: 3.6
-      dist: xenial
-      env: TOXENV=py36-django22-drf39
     - python: 3.6
       dist: xenial
       env: TOXENV=py36-django22-drf310
@@ -64,19 +50,11 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: required
-      env: TOXENV=py37-django21-drf39
-    - python: 3.7
-      dist: xenial
-      sudo: required
       env: TOXENV=py37-django21-drf310
     - python: 3.7
       dist: xenial
       sudo: required
       env: TOXENV=py37-django21-drfmaster
-    - python: 3.7
-      dist: xenial
-      sudo: required
-      env: TOXENV=py37-django22-drf39
     - python: 3.7
       dist: xenial
       sudo: required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This release is not backwards compatible. For easy migration best upgrade first 
 * Removed support for Python 2.7 and 3.4.
 * Removed support for Django Filter 1.1.
 * Removed obsolete dependency six.
-* Removed support for Django REST Framework <=3.8.
+* Removed support for Django REST Framework <=3.9.
 * Removed support for Django 2.0.
 * Removed obsolete mixins `MultipleIDMixin` and `PrefetchForIncludesHelperMixin`
 * Removed obsolete settings `JSON_API_FORMAT_KEYS`, `JSON_API_FORMAT_RELATION_KEYS` and

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Requirements
 
 1. Python (3.5, 3.6, 3.7)
 2. Django (1.11, 2.1, 2.2)
-3. Django REST Framework (3.9, 3.10)
+3. Django REST Framework (3.10)
 
 ------------
 Installation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ like the following:
 
 1. Python (3.5, 3.6, 3.7)
 2. Django (1.11, 2.1, 2.2)
-3. Django REST Framework (3.9, 3.10)
+3. Django REST Framework (3.10)
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     ],
     install_requires=[
         'inflection>=0.3.0',
-        'djangorestframework>=3.9',
+        'djangorestframework>=3.10',
         'django>=1.11',
     ],
     setup_requires=pytest_runner + sphinx + wheel,

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 envlist =
-    py{35,36}-django111-drf{39,310,master},
-    py{35,36,37}-django{21,22}-drf{39,310,master},
+    py{35,36}-django111-drf{310,master},
+    py{35,36,37}-django{21,22}-drf{310,master},
 
 [testenv]
 deps =
     django111: Django>=1.11,<1.12
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
-    drf39: djangorestframework>=3.9.0,<3.10
     drf310: djangorestframework>=3.10.2,<3.11
     drfmaster: https://github.com/encode/django-rest-framework/archive/master.zip
 


### PR DESCRIPTION

## Description of the Change
Deprecates DRF 3.9.  As of DJA 3.0 we'll only support DRF 3.10+.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
