### PR TITLE
Add code to error object if `ErrorDetail` has code

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Beni Keller <beni@matraxi.ch>
 Stas S. <stas@nerd.ro>
 Nathanael Gordon <nathanael.l.gordon@gmail.com>
 Charlie Allatson <charles.allatson@gmail.com>
+Joseba Mendivil <git@jma.email>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This release is not backwards compatible. For easy migration best upgrade first 
 ### Added
 
 * Add support for Django REST framework 3.10.
+* Add code from ErrorDetail into the JSON:API error object
 
 ### Removed
 

--- a/example/tests/test_generic_validation.py
+++ b/example/tests/test_generic_validation.py
@@ -25,7 +25,8 @@ class GenericValidationTest(TestBase):
                 'source': {
                     'pointer': '/data'
                 },
-                'detail': 'Oh nohs!'
+                'detail': 'Oh nohs!',
+                'code': 'invalid',
             }]
         }
 

--- a/example/tests/test_generic_viewset.py
+++ b/example/tests/test_generic_viewset.py
@@ -65,6 +65,7 @@ class GenericViewSet(TestBase):
                         'pointer': '/data/attributes/email',
                     },
                     'detail': 'Enter a valid email address.',
+                    'code': 'invalid',
                 },
                 {
                     'status': '400',
@@ -72,6 +73,7 @@ class GenericViewSet(TestBase):
                         'pointer': '/data/attributes/first-name',
                     },
                     'detail': 'There\'s a problem with first name',
+                    'code': 'invalid',
                 }
             ]
         }
@@ -104,6 +106,7 @@ class GenericViewSet(TestBase):
                         'pointer': '/data/attributes/email',
                     },
                     'detail': 'Enter a valid email address.',
+                    'code': 'invalid',
                 },
             ]
         }

--- a/example/tests/test_model_viewsets.py
+++ b/example/tests/test_model_viewsets.py
@@ -217,7 +217,7 @@ class ModelViewSetTests(TestBase):
         not_found_url = reverse('user-detail', kwargs={'pk': 12345})
         errors = {
             'errors': [
-                {'detail': 'Not found.', 'status': '404'}
+                {'detail': 'Not found.', 'status': '404', 'code': 'not_found'}
             ]
         }
 

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -432,7 +432,8 @@ class TestValidationErrorResponses(TestBase):
         expected = [{
             'detail': 'Received document does not contain primary data',
             'status': '400',
-            'source': {'pointer': '/data'}
+            'source': {'pointer': '/data'},
+            'code': 'parse_error',
         }]
         self.assertEqual(expected, response.data)
 
@@ -443,7 +444,8 @@ class TestValidationErrorResponses(TestBase):
         expected = [{
             'status': '400',
             'detail': 'This field is required.',
-            'source': {'pointer': '/data/attributes/name'}
+            'source': {'pointer': '/data/attributes/name'},
+            'code': 'required',
         }]
         self.assertEqual(expected, response.data)
 
@@ -457,7 +459,8 @@ class TestValidationErrorResponses(TestBase):
                 "represented by the endpoint (blogs)."
             ),
             'source': {'pointer': '/data'},
-            'status': '409'
+            'status': '409',
+            'code': 'error',
         }]
         self.assertEqual(expected, response.data)
 


### PR DESCRIPTION
# Description of the Change
JSON:API specification allows for a `code` value in the [error object](https://jsonapi.org/format/#error-objects). This PR copies the `code` inside the `ErrorDetail` from rest_framework's `APIException` into the JSON:API error object. Allowing users of the library to send application-specific error codes back to the clients by specifying a code alongside the detail when raising an `APIException`

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
