### PR TITLE
Format metadata field names correctly for OPTIONS request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This release is not backwards compatible. For easy migration best upgrade first 
 
 * Avoid printing invalid pointer when api returns 404
 * Avoid exception when using `ResourceIdentifierObjectSerializer` with unexisting primary key
+* Format metadata field names correctly for OPTIONS request
 
 
 ## [2.8.0] - 2019-06-13

--- a/example/tests/test_format_keys.py
+++ b/example/tests/test_format_keys.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils import encoding
+from rest_framework import status
 
 from example.tests import TestBase
 
@@ -51,3 +52,11 @@ class FormatKeysSetTests(TestBase):
         }
 
         assert expected == response.json()
+
+
+def test_options_format_field_names(db, client):
+    response = client.options(reverse('author-list'))
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()['data']
+    expected_keys = {'name', 'email', 'bio', 'entries', 'firstEntry', 'type', 'comments'}
+    assert expected_keys == data['actions']['POST'].keys()

--- a/rest_framework_json_api/metadata.py
+++ b/rest_framework_json_api/metadata.py
@@ -7,7 +7,7 @@ from rest_framework.metadata import SimpleMetadata
 from rest_framework.settings import api_settings
 from rest_framework.utils.field_mapping import ClassLookupDict
 
-from rest_framework_json_api.utils import get_related_resource_type
+from rest_framework_json_api.utils import format_value, get_related_resource_type
 
 
 class JSONAPIMetadata(SimpleMetadata):
@@ -83,7 +83,7 @@ class JSONAPIMetadata(SimpleMetadata):
         serializer.fields.pop(api_settings.URL_FIELD_NAME, None)
 
         return OrderedDict([
-            (field_name, self.get_field_info(field))
+            (format_value(field_name), self.get_field_info(field))
             for field_name, field in serializer.fields.items()
         ])
 


### PR DESCRIPTION
Supersedes #500

## Description of the Change

Take into account setting JSON_API_FORMAT_FIELD_NAMES

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
