### PR TITLE
Remove pytest runner to run test

### DIFF
--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -14,4 +14,3 @@ pytest-factoryboy==2.0.3
 recommonmark==0.6.0
 Sphinx==2.2.0
 sphinx_rtd_theme==0.4.3
-twine==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,6 @@ import sys
 
 from setuptools import setup
 
-needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
-pytest_runner = ['pytest-runner'] if needs_pytest else []
-needs_sphinx = {'build_sphinx', 'upload_docs'}.intersection(sys.argv)
-sphinx = ['sphinx'] if needs_sphinx else []
-needs_wheel = {'bdist_wheel'}.intersection(sys.argv)
-wheel = ['wheel'] if needs_wheel else []
-
 
 def read(*paths):
     """
@@ -97,16 +90,6 @@ setup(
         'djangorestframework>=3.10',
         'django>=1.11',
     ],
-    setup_requires=pytest_runner + sphinx + wheel,
-    tests_require=[
-        'pytest-factoryboy',
-        'factory-boy',
-        'pytest-django',
-        'pytest',
-        'pytest-cov',
-        'django-polymorphic>=2.0',
-        'django-filter>=2.0',
-        'django-debug-toolbar==1.11'
-    ],
+    python_requires=">=3.5",
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -10,20 +10,23 @@ deps =
     django22: Django>=2.2,<2.3
     drf310: djangorestframework>=3.10.2,<3.11
     drfmaster: https://github.com/encode/django-rest-framework/archive/master.zip
+    -rrequirements-development.txt
 
 setenv =
     PYTHONPATH = {toxinidir}
     DJANGO_SETTINGS_MODULE=example.settings.test
 
 commands =
-    python setup.py test --addopts '--cov --no-cov-on-fail --cov-report xml' {posargs}
+    pytest --cov --no-cov-on-fail --cov-report xml {posargs}
 
 [testenv:flake8]
+basepython = python3.6
 deps =
     -rrequirements-development.txt
 commands = flake8
 
 [testenv:sphinx]
+basepython = python3.6
 deps =
     -rrequirements-development.txt
 commands =


### PR DESCRIPTION
## Description of the Change

pytest was already used when running test manually but not when running tox or travis. Partially addressing #635 

I want to keep the PRs small so for now removed twine dependency and django-filter resp. django-polymorphic dependency definition. Those will be reintroduced again later when introducing `extra_requires` and splitting up dependencies as in DRF.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
