### PR TITLE
Properly return parser error when primary data is of invalid type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Fixed
 
 * Ensure that `409 Conflict` is returned when processing a `PATCH` request in which the resource object’s type and id do not match the server’s endpoint properly as outlined in [JSON:API](https://jsonapi.org/format/#crud-updating-responses-409) spec.
+* Properly return parser error when primary data is of invalid type
 
 ## [3.0.0] - 2019-10-14
 

--- a/example/tests/test_parsers.py
+++ b/example/tests/test_parsers.py
@@ -52,3 +52,21 @@ class TestJSONParser(TestCase):
 
         with self.assertRaises(ParseError):
             parser.parse(stream, None, self.parser_context)
+
+    def test_parse_invalid_data_key(self):
+        parser = JSONParser()
+
+        string = json.dumps({
+            'data': [{
+                'id': 123,
+                'type': 'Blog',
+                'attributes': {
+                    'json-value': {'JsonKey': 'JsonValue'}
+                },
+            }]
+        })
+        stream = BytesIO(string.encode('utf-8'))
+
+        with self.assertRaises(ParseError):
+            parser.parse(stream, None, self.parser_context)
+

--- a/example/tests/test_parsers.py
+++ b/example/tests/test_parsers.py
@@ -69,4 +69,3 @@ class TestJSONParser(TestCase):
 
         with self.assertRaises(ParseError):
             parser.parse(stream, None, self.parser_context)
-

--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -118,6 +118,8 @@ class JSONParser(parsers.JSONParser):
 
         # Check for inconsistencies
         if request.method in ('PUT', 'POST', 'PATCH'):
+            if not isinstance(data, dict):
+                raise ParseError('Received data is not a valid JSONAPI Resource Identifier Object')
             resource_name = utils.get_resource_name(
                 parser_context, expand_polymorphic_types=True)
             if isinstance(resource_name, str):

--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -116,10 +116,12 @@ class JSONParser(parsers.JSONParser):
 
         request = parser_context.get('request')
 
+        # Sanity check
+        if not isinstance(data, dict):
+            raise ParseError('Received data is not a valid JSONAPI Resource Identifier Object')
+
         # Check for inconsistencies
         if request.method in ('PUT', 'POST', 'PATCH'):
-            if not isinstance(data, dict):
-                raise ParseError('Received data is not a valid JSONAPI Resource Identifier Object')
             resource_name = utils.get_resource_name(
                 parser_context, expand_polymorphic_types=True)
             if isinstance(resource_name, str):


### PR DESCRIPTION
If you submit a list with one object, for example, drf_json_api will respond to you with unobvious errors.
