### PR TITLE
Pass on instance when using polymorphic serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Ensure that `409 Conflict` is returned when processing a `PATCH` request in which the resource object’s type and id do not match the server’s endpoint properly as outlined in [JSON:API](https://jsonapi.org/format/#crud-updating-responses-409) spec.
 * Properly return parser error when primary data is of invalid type
+* Pass instance to child serializer when `PolymorphicModelSerializer` inits it in `to_internal_value`
 
 ## [3.0.0] - 2019-10-14
 

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -232,6 +232,7 @@ class TestPolymorphicModelSerializer(TestCase):
                 instance, data, **kwargs
             )
 
+        original_init = ArtProjectSerializer.__init__
         ArtProjectSerializer.__init__ = init_with_asserts
 
         parent_serializer.is_valid(raise_exception=True)
@@ -240,3 +241,6 @@ class TestPolymorphicModelSerializer(TestCase):
         parent_serializer.save()
 
         # Asserts in the overridden `__init__` method declared above
+
+        # Restore original init to avoid affecting other tests
+        ArtProjectSerializer.__init__ = original_init

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -207,20 +207,21 @@ class TestPolymorphicModelSerializer(TestCase):
     def test_polymorphic_model_serializer_passes_instance_to_child(self):
         """
         Ensure that `PolymorphicModelSerializer` is passing the instance to the
-        child serializer when initializing it in `to_internal_value`
+        child serializer when initializing them
         """
         # Arrange
-        def to_internal_value(serializer_self, data):
+        self.serializer_instance = None
+
+        def save(serializer_self):
             """
-            Override `ArtProjectSerializer.to_internal_value` to get the
-            instance serializer, which is later used assertion
+            Override `ArtProjectSerializer.save` to get the instance serializer,
+            which is later used assertion
             """
             self.serializer_instance = serializer_self.instance
-            return super(ArtProjectSerializer,
-                         serializer_self).to_internal_value(data)
+            return super(ArtProjectSerializer, serializer_self).save()
 
-        # Override `to_internal_value` with our own method
-        ArtProjectSerializer.to_internal_value = to_internal_value
+        # Override `save` with our own method
+        ArtProjectSerializer.save = save
 
         # Initialize a serializer that would partially update a model instance
         data = {"artist": "Mark Bishop", "type": "artProjects"}
@@ -228,8 +229,6 @@ class TestPolymorphicModelSerializer(TestCase):
             instance=self.project, data=data, partial=True
         )
         serializer.is_valid(raise_exception=True)
-
-        self.serializer_instance = None
 
         # Act
         serializer.save()

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -352,5 +352,5 @@ class PolymorphicModelSerializer(ModelSerializer, metaclass=PolymorphicSerialize
                     expected_types=', '.join(expected_types), received_type=received_type))
         serializer_class = self.get_polymorphic_serializer_for_type(received_type)
         self.__class__ = serializer_class
-        return serializer_class(data, context=self.context,
+        return serializer_class(self.instance, data, context=self.context,
                                 partial=self.partial).to_internal_value(data)


### PR DESCRIPTION
Fixes #759

## Description of the Change
As per issue #759 pass `self.instance` as the first parameter when initialising the child serializer from a polymorphic serialiser. This does not affect basic functionality, but makes the child serializer instance consistent with its usage of `instance` and `data`, which can fix potential issues when extending serilaizers that are part of a polymorphic serializer.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] ~~unit-test added~~ -> I couldn't find anywhere relevant to add such a test without making the code less maintainable and harder to refactor in the future
- [ ] ~~documentation updated~~ -> Being such a minimal change that doesn't affect normal usage of the library, I think it would complicate things more than anything else
- [x] ~~`CHANGELOG.md` updated (only for user relevant changes)~~ -> This is not a user relevant change
- [x] author name in `AUTHORS` -> It already was there
