### PR TITLE
OAS 3.0 schema generation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ Jason Housley <housleyjk@gmail.com>
 Jerel Unruh <mail@unruhdesigns.com>
 Jonathan Senecal <contact@jonathansenecal.com>
 Joseba Mendivil <git@jma.email>
+Kieran Evans <keyz182@gmail.com>
 Léo S. <leo@naeka.fr>
 Luc Cary <luc.cary@gmail.com>
 Matt Layman <https://www.mattlayman.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ This release is not backwards compatible. For easy migration best upgrade first 
 
 * Added support for Django REST framework 3.12
 * Added support for Django 3.1
+* Added initial optional support for [openapi](https://www.openapis.org/) schema generation. Enable with:
+  ```
+  pip install djangorestframework-jsonapi['openapi']
+  ```
+  This first release is a start at implementing OAS schema generation. To use the generated schema you may
+  still need to manually add some schema attributes but can expect future improvements here and as
+  upstream DRF's OAS schema generation continues to mature.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This release is not backwards compatible. For easy migration best upgrade first 
 
 ### Removed
 
+
 * Removed support for Python 3.5.
 * Removed support for Django 1.11.
 * Removed support for Django 2.1.

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,7 @@ From PyPI
     $ # for optional package integrations
     $ pip install djangorestframework-jsonapi['django-filter']
     $ pip install djangorestframework-jsonapi['django-polymorphic']
+    $ pip install djangorestframework-jsonapi['openapi']
 
 
 From Source

--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,10 @@ installed and activated:
     $ django-admin loaddata drf_example --settings=example.settings
     $ django-admin runserver --settings=example.settings
 
-Browse to http://localhost:8000
+Browse to
+* http://localhost:8000 for the list of available collections (in a non-JSONAPI format!),
+* http://localhost:8000/swagger-ui/ for a Swagger user interface to the dynamic schema view, or
+* http://localhost:8000/openapi for the schema view's OpenAPI specification document.
 
 
 Running Tests and linting

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,7 +86,10 @@ From Source
 	django-admin runserver --settings=example.settings
 
 
-Browse to http://localhost:8000
+Browse to
+* [http://localhost:8000](http://localhost:8000) for the list of available collections (in a non-JSONAPI format!),
+* [http://localhost:8000/swagger-ui/](http://localhost:8000/swagger-ui/) for a Swagger user interface to the dynamic schema view, or
+* [http://localhost:8000/openapi](http://localhost:8000/openapi) for the schema view's OpenAPI specification document.
 
 ## Running Tests
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,6 +67,7 @@ From PyPI
     # for optional package integrations
     pip install djangorestframework-jsonapi['django-filter']
     pip install djangorestframework-jsonapi['django-polymorphic']
+    pip install djangorestframework-jsonapi['openapi']
 
 From Source
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -958,8 +958,6 @@ In order to produce an OAS schema that properly represents the JSON:API structur
 you have to either add a `schema` attribute to each view class or set the `REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS']`
 to DJA's version of AutoSchema.
 
-You can also extend the OAS schema with additional static content (a feature not available in DRF at this time).
-
 #### View-based
 
 ```python
@@ -979,16 +977,16 @@ REST_FRAMEWORK = {
 }
 ```
 
-### Adding static OAS schema content
+### Adding additional OAS schema content
 
-You can optionally include an OAS schema document initialization by subclassing `SchemaGenerator`
-and setting `schema_init`.
+You can extend the OAS schema document by subclassing
+[`SchemaGenerator`](https://www.django-rest-framework.org/api-guide/schemas/#schemagenerator)
+and extending `get_schema`.
 
-Here's an example that fills out OAS `info` and `servers` objects.
+
+Here's an example that adds OAS `info` and `servers` objects.
 
 ```python
-# views.py
-
 from rest_framework_json_api.schemas.openapi import SchemaGenerator as JSONAPISchemaGenerator
 
 
@@ -1047,14 +1045,22 @@ is published.
 ### Generate a Dynamic Schema in a View
 
 See [DRF documentation for a Dynamic Schema](https://www.django-rest-framework.org/api-guide/schemas/#generating-a-dynamic-schema-with-schemaview).
-You will need to pass in your custom SchemaGenerator if you've created one.
 
 ```python
 from rest_framework.schemas import get_schema_view
-from views import MySchemaGenerator
 
 urlpatterns = [
-    path('openapi', get_schema_view(generator_class=MySchemaGenerator), name='openapi-schema'),
+    ...
+    path('openapi', get_schema_view(
+        title="Example API",
+        description="API for all things …",
+        version="1.0.0",
+        generator_class=MySchemaGenerator,
+    ), name='openapi-schema'),
+    path('swagger-ui/', TemplateView.as_view(
+        template_name='swagger-ui.html',
+        extra_context={'schema_url': 'openapi-schema'}
+    ), name='swagger-ui'),
     ...
 ]
 ```

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -230,6 +230,16 @@ class AuthorSerializer(serializers.ModelSerializer):
         queryset=Comment.objects,
         many=True
     )
+    secrets = serializers.HiddenField(
+        default='Shhhh!'
+    )
+    defaults = serializers.CharField(
+        default='default',
+        max_length=20,
+        min_length=3,
+        write_only=True,
+        help_text='help for defaults',
+    )
     included_serializers = {
         'bio': AuthorBioSerializer,
         'type': AuthorTypeSerializer
@@ -244,7 +254,8 @@ class AuthorSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Author
-        fields = ('name', 'email', 'bio', 'entries', 'comments', 'first_entry', 'type')
+        fields = ('name', 'email', 'bio', 'entries', 'comments', 'first_entry', 'type',
+                  'secrets', 'defaults')
 
     def get_first_entry(self, obj):
         return obj.entries.first()

--- a/example/settings/dev.py
+++ b/example/settings/dev.py
@@ -21,6 +21,7 @@ INSTALLED_APPS = [
     'django.contrib.sites',
     'django.contrib.sessions',
     'django.contrib.auth',
+    'rest_framework_json_api',
     'rest_framework',
     'polymorphic',
     'example',
@@ -88,6 +89,7 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.BrowsableAPIRenderer',
     ),
     'DEFAULT_METADATA_CLASS': 'rest_framework_json_api.metadata.JSONAPIMetadata',
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework_json_api.schemas.openapi.AutoSchema',
     'DEFAULT_FILTER_BACKENDS': (
         'rest_framework_json_api.filters.OrderingFilter',
         'rest_framework_json_api.django_filters.DjangoFilterBackend',

--- a/example/templates/swagger-ui.html
+++ b/example/templates/swagger-ui.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Swagger</title>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@3/swagger-ui.css" />
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="//unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+    <script>
+    const ui = SwaggerUIBundle({
+        url: "{% url schema_url %}",
+        dom_id: '#swagger-ui',
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIBundle.SwaggerUIStandalonePreset
+        ],
+        layout: "BaseLayout",
+        requestInterceptor: (request) => {
+          request.headers['X-CSRFToken'] = "{{ csrf_token }}"
+          return request;
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/example/tests/snapshots/snap_test_openapi.py
+++ b/example/tests/snapshots/snap_test_openapi.py
@@ -1,0 +1,647 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['test_path_without_parameters 1'] = '''{
+  "description": "",
+  "operationId": "List/authors/",
+  "parameters": [
+    {
+      "$ref": "#/components/parameters/include"
+    },
+    {
+      "$ref": "#/components/parameters/fields"
+    },
+    {
+      "$ref": "#/components/parameters/sort"
+    },
+    {
+      "description": "A page number within the paginated result set.",
+      "in": "query",
+      "name": "page[number]",
+      "required": false,
+      "schema": {
+        "type": "integer"
+      }
+    },
+    {
+      "description": "Number of results to return per page.",
+      "in": "query",
+      "name": "page[size]",
+      "required": false,
+      "schema": {
+        "type": "integer"
+      }
+    },
+    {
+      "description": "Which field to use when ordering the results.",
+      "in": "query",
+      "name": "sort",
+      "required": false,
+      "schema": {
+        "type": "string"
+      }
+    },
+    {
+      "description": "A search term.",
+      "in": "query",
+      "name": "filter[search]",
+      "required": false,
+      "schema": {
+        "type": "string"
+      }
+    }
+  ],
+  "responses": {
+    "200": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "properties": {
+              "data": {
+                "items": {
+                  "$ref": "#/components/schemas/Author"
+                },
+                "type": "array"
+              },
+              "included": {
+                "items": {
+                  "$ref": "#/components/schemas/resource"
+                },
+                "type": "array",
+                "uniqueItems": true
+              },
+              "jsonapi": {
+                "$ref": "#/components/schemas/jsonapi"
+              },
+              "links": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/links"
+                  },
+                  {
+                    "$ref": "#/components/schemas/pagination"
+                  }
+                ],
+                "description": "Link members related to primary data"
+              }
+            },
+            "required": [
+              "data"
+            ],
+            "type": "object"
+          }
+        }
+      },
+      "description": "List/authors/"
+    },
+    "401": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "not authorized"
+    },
+    "404": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "not found"
+    }
+  }
+}'''
+
+snapshots['test_path_with_id_parameter 1'] = '''{
+  "description": "",
+  "operationId": "retrieve/authors/{id}/",
+  "parameters": [
+    {
+      "description": "A unique integer value identifying this author.",
+      "in": "path",
+      "name": "id",
+      "required": true,
+      "schema": {
+        "type": "string"
+      }
+    },
+    {
+      "$ref": "#/components/parameters/include"
+    },
+    {
+      "$ref": "#/components/parameters/fields"
+    },
+    {
+      "$ref": "#/components/parameters/sort"
+    },
+    {
+      "description": "Which field to use when ordering the results.",
+      "in": "query",
+      "name": "sort",
+      "required": false,
+      "schema": {
+        "type": "string"
+      }
+    },
+    {
+      "description": "A search term.",
+      "in": "query",
+      "name": "filter[search]",
+      "required": false,
+      "schema": {
+        "type": "string"
+      }
+    }
+  ],
+  "responses": {
+    "200": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/Author"
+              },
+              "included": {
+                "items": {
+                  "$ref": "#/components/schemas/resource"
+                },
+                "type": "array",
+                "uniqueItems": true
+              },
+              "jsonapi": {
+                "$ref": "#/components/schemas/jsonapi"
+              },
+              "links": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/links"
+                  },
+                  {
+                    "$ref": "#/components/schemas/pagination"
+                  }
+                ],
+                "description": "Link members related to primary data"
+              }
+            },
+            "required": [
+              "data"
+            ],
+            "type": "object"
+          }
+        }
+      },
+      "description": "retrieve/authors/{id}/"
+    },
+    "401": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "not authorized"
+    },
+    "404": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "not found"
+    }
+  }
+}'''
+
+snapshots['test_post_request 1'] = '''{
+  "description": "",
+  "operationId": "create/authors/",
+  "parameters": [],
+  "requestBody": {
+    "content": {
+      "application/vnd.api+json": {
+        "schema": {
+          "properties": {
+            "data": {
+              "additionalProperties": false,
+              "properties": {
+                "attributes": {
+                  "properties": {
+                    "defaults": {
+                      "default": "default",
+                      "description": "help for defaults",
+                      "maxLength": 20,
+                      "minLength": 3,
+                      "type": "string",
+                      "writeOnly": true
+                    },
+                    "email": {
+                      "format": "email",
+                      "maxLength": 254,
+                      "type": "string"
+                    },
+                    "name": {
+                      "maxLength": 50,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "email"
+                  ],
+                  "type": "object"
+                },
+                "id": {
+                  "$ref": "#/components/schemas/id"
+                },
+                "links": {
+                  "properties": {
+                    "self": {
+                      "$ref": "#/components/schemas/link"
+                    }
+                  },
+                  "type": "object"
+                },
+                "relationships": {
+                  "properties": {
+                    "bio": {
+                      "$ref": "#/components/schemas/reltoone"
+                    },
+                    "comments": {
+                      "$ref": "#/components/schemas/reltomany"
+                    },
+                    "entries": {
+                      "$ref": "#/components/schemas/reltomany"
+                    },
+                    "first_entry": {
+                      "$ref": "#/components/schemas/reltoone"
+                    },
+                    "type": {
+                      "$ref": "#/components/schemas/reltoone"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": {
+                  "$ref": "#/components/schemas/type"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "data"
+          ]
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/Author"
+              },
+              "included": {
+                "items": {
+                  "$ref": "#/components/schemas/resource"
+                },
+                "type": "array",
+                "uniqueItems": true
+              },
+              "jsonapi": {
+                "$ref": "#/components/schemas/jsonapi"
+              },
+              "links": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/links"
+                  },
+                  {
+                    "$ref": "#/components/schemas/pagination"
+                  }
+                ],
+                "description": "Link members related to primary data"
+              }
+            },
+            "required": [
+              "data"
+            ],
+            "type": "object"
+          }
+        }
+      },
+      "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-201). Assigned `id` and/or any other changes are in this response."
+    },
+    "202": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/datum"
+          }
+        }
+      },
+      "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)"
+    },
+    "204": {
+      "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+    },
+    "401": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "not authorized"
+    },
+    "403": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)"
+    },
+    "404": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-creating-responses-404)"
+    },
+    "409": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)"
+    }
+  }
+}'''
+
+snapshots['test_patch_request 1'] = '''{
+  "description": "",
+  "operationId": "update/authors/{id}",
+  "parameters": [
+    {
+      "description": "A unique integer value identifying this author.",
+      "in": "path",
+      "name": "id",
+      "required": true,
+      "schema": {
+        "type": "string"
+      }
+    }
+  ],
+  "requestBody": {
+    "content": {
+      "application/vnd.api+json": {
+        "schema": {
+          "properties": {
+            "data": {
+              "additionalProperties": false,
+              "properties": {
+                "attributes": {
+                  "properties": {
+                    "defaults": {
+                      "default": "default",
+                      "description": "help for defaults",
+                      "maxLength": 20,
+                      "minLength": 3,
+                      "type": "string",
+                      "writeOnly": true
+                    },
+                    "email": {
+                      "format": "email",
+                      "maxLength": 254,
+                      "type": "string"
+                    },
+                    "name": {
+                      "maxLength": 50,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "id": {
+                  "$ref": "#/components/schemas/id"
+                },
+                "links": {
+                  "properties": {
+                    "self": {
+                      "$ref": "#/components/schemas/link"
+                    }
+                  },
+                  "type": "object"
+                },
+                "relationships": {
+                  "properties": {
+                    "bio": {
+                      "$ref": "#/components/schemas/reltoone"
+                    },
+                    "comments": {
+                      "$ref": "#/components/schemas/reltomany"
+                    },
+                    "entries": {
+                      "$ref": "#/components/schemas/reltomany"
+                    },
+                    "first_entry": {
+                      "$ref": "#/components/schemas/reltoone"
+                    },
+                    "type": {
+                      "$ref": "#/components/schemas/reltoone"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": {
+                  "$ref": "#/components/schemas/type"
+                }
+              },
+              "required": [
+                "type",
+                "id"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "data"
+          ]
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/Author"
+              },
+              "included": {
+                "items": {
+                  "$ref": "#/components/schemas/resource"
+                },
+                "type": "array",
+                "uniqueItems": true
+              },
+              "jsonapi": {
+                "$ref": "#/components/schemas/jsonapi"
+              },
+              "links": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/links"
+                  },
+                  {
+                    "$ref": "#/components/schemas/pagination"
+                  }
+                ],
+                "description": "Link members related to primary data"
+              }
+            },
+            "required": [
+              "data"
+            ],
+            "type": "object"
+          }
+        }
+      },
+      "description": "update/authors/{id}"
+    },
+    "401": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "not authorized"
+    },
+    "403": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)"
+    },
+    "404": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "[Related resource does not exist](https://jsonapi.org/format/#crud-updating-responses-404)"
+    },
+    "409": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "[Conflict]([Conflict](https://jsonapi.org/format/#crud-updating-responses-409)"
+    }
+  }
+}'''
+
+snapshots['test_delete_request 1'] = '''{
+  "description": "",
+  "operationId": "destroy/authors/{id}",
+  "parameters": [
+    {
+      "description": "A unique integer value identifying this author.",
+      "in": "path",
+      "name": "id",
+      "required": true,
+      "schema": {
+        "type": "string"
+      }
+    }
+  ],
+  "responses": {
+    "200": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/onlymeta"
+          }
+        }
+      },
+      "description": "[OK](https://jsonapi.org/format/#crud-deleting-responses-200)"
+    },
+    "202": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/datum"
+          }
+        }
+      },
+      "description": "Accepted for [asynchronous processing](https://jsonapi.org/recommendations/#asynchronous-processing)"
+    },
+    "204": {
+      "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
+    },
+    "401": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "not authorized"
+    },
+    "404": {
+      "content": {
+        "application/vnd.api+json": {
+          "schema": {
+            "$ref": "#/components/schemas/failure"
+          }
+        }
+      },
+      "description": "[Resource does not exist](https://jsonapi.org/format/#crud-deleting-responses-404)"
+    }
+  }
+}'''

--- a/example/tests/test_format_keys.py
+++ b/example/tests/test_format_keys.py
@@ -58,5 +58,6 @@ def test_options_format_field_names(db, client):
     response = client.options(reverse('author-list'))
     assert response.status_code == status.HTTP_200_OK
     data = response.json()['data']
-    expected_keys = {'name', 'email', 'bio', 'entries', 'firstEntry', 'type', 'comments'}
+    expected_keys = {'name', 'email', 'bio', 'entries', 'firstEntry', 'type',
+                     'comments', 'secrets', 'defaults'}
     assert expected_keys == data['actions']['POST'].keys()

--- a/example/tests/test_openapi.py
+++ b/example/tests/test_openapi.py
@@ -8,7 +8,6 @@ from rest_framework.request import Request
 from rest_framework_json_api.schemas.openapi import AutoSchema, SchemaGenerator
 
 from example import views
-from example.tests import TestBase
 
 
 def create_request(path):
@@ -126,34 +125,33 @@ def test_schema_construction():
     assert 'components' in schema
 
 
-class TestSchemaRelatedField(TestBase):
-    def test_schema_related_serializers(self):
-        """
-        Confirm that paths are generated for related fields. For example:
-        url path '/authors/{pk}/{related_field>}/' generates:
-            /authors/{id}/relationships/comments/
-            /authors/{id}/relationships/entries/
-            /authors/{id}/relationships/first_entry/ -- Maybe?
-            /authors/{id}/comments/
-            /authors/{id}/entries/
-            /authors/{id}/first_entry/
-        and confirm that the schema for the related field is properly rendered
-        """
-        generator = SchemaGenerator()
-        request = create_request('/')
-        schema = generator.get_schema(request=request)
-        # make sure the path's relationship and related {related_field}'s got expanded
-        assert '/authors/{id}/relationships/entries' in schema['paths']
-        assert '/authors/{id}/relationships/comments' in schema['paths']
-        # first_entry is a special case (SerializerMethodRelatedField)
-        # TODO: '/authors/{id}/relationships/first_entry' supposed to be there?
-        # It fails when doing the actual GET, so this schema excluding it is OK.
-        # assert '/authors/{id}/relationships/first_entry/' in schema['paths']
-        assert '/authors/{id}/comments/' in schema['paths']
-        assert '/authors/{id}/entries/' in schema['paths']
-        assert '/authors/{id}/first_entry/' in schema['paths']
-        first_get = schema['paths']['/authors/{id}/first_entry/']['get']['responses']['200']
-        first_schema = first_get['content']['application/vnd.api+json']['schema']
-        first_props = first_schema['properties']['data']
-        assert '$ref' in first_props
-        assert first_props['$ref'] == '#/components/schemas/Entry'
+def test_schema_related_serializers():
+    """
+    Confirm that paths are generated for related fields. For example:
+    url path '/authors/{pk}/{related_field>}/' generates:
+        /authors/{id}/relationships/comments/
+        /authors/{id}/relationships/entries/
+        /authors/{id}/relationships/first_entry/ -- Maybe?
+        /authors/{id}/comments/
+        /authors/{id}/entries/
+        /authors/{id}/first_entry/
+    and confirm that the schema for the related field is properly rendered
+    """
+    generator = SchemaGenerator()
+    request = create_request('/')
+    schema = generator.get_schema(request=request)
+    # make sure the path's relationship and related {related_field}'s got expanded
+    assert '/authors/{id}/relationships/entries' in schema['paths']
+    assert '/authors/{id}/relationships/comments' in schema['paths']
+    # first_entry is a special case (SerializerMethodRelatedField)
+    # TODO: '/authors/{id}/relationships/first_entry' supposed to be there?
+    # It fails when doing the actual GET, so this schema excluding it is OK.
+    # assert '/authors/{id}/relationships/first_entry/' in schema['paths']
+    assert '/authors/{id}/comments/' in schema['paths']
+    assert '/authors/{id}/entries/' in schema['paths']
+    assert '/authors/{id}/first_entry/' in schema['paths']
+    first_get = schema['paths']['/authors/{id}/first_entry/']['get']['responses']['200']
+    first_schema = first_get['content']['application/vnd.api+json']['schema']
+    first_props = first_schema['properties']['data']
+    assert '$ref' in first_props
+    assert first_props['$ref'] == '#/components/schemas/Entry'

--- a/example/tests/test_openapi.py
+++ b/example/tests/test_openapi.py
@@ -128,7 +128,10 @@ def test_schema_construction():
 def test_schema_related_serializers():
     """
     Confirm that paths are generated for related fields. For example:
-        /authors/{pk}/{related_field>}
+    url path '/authors/{pk}/{related_field>}/' generates:
+        /authors/{id}/relationships/comments/
+        /authors/{id}/relationships/entries/
+        /authors/{id}/relationships/first_entry/ -- Maybe?
         /authors/{id}/comments/
         /authors/{id}/entries/
         /authors/{id}/first_entry/
@@ -138,7 +141,12 @@ def test_schema_related_serializers():
     request = create_request('/')
     schema = generator.get_schema(request=request)
     # make sure the path's relationship and related {related_field}'s got expanded
-    assert '/authors/{id}/relationships/{related_field}' in schema['paths']
+    assert '/authors/{id}/relationships/entries' in schema['paths']
+    assert '/authors/{id}/relationships/comments' in schema['paths']
+    # first_entry is a special case (SerializerMethodRelatedField)
+    # TODO: '/authors/{id}/relationships/first_entry' supposed to be there?
+    # It fails when doing the actual GET, so this schema excluding it is OK.
+    # assert '/authors/{id}/relationships/first_entry/' in schema['paths']
     assert '/authors/{id}/comments/' in schema['paths']
     assert '/authors/{id}/entries/' in schema['paths']
     assert '/authors/{id}/first_entry/' in schema['paths']

--- a/example/tests/test_openapi.py
+++ b/example/tests/test_openapi.py
@@ -102,15 +102,6 @@ def test_delete_request(snapshot):
         {'delete': 'delete'}
     )
     inspector = AutoSchema()
-    # DRF >=3.12 changes the capitalization of these method mappings which breaks the snapshot,
-    # so just override them to be consistent with >=3.12
-    inspector.method_mapping = {
-        'get': 'retrieve',
-        'post': 'create',
-        'put': 'update',
-        'patch': 'partialUpdate',
-        'delete': 'destroy',
-    }
     inspector.view = view
 
     operation = inspector.get_operation(path, method)

--- a/example/tests/test_openapi.py
+++ b/example/tests/test_openapi.py
@@ -1,0 +1,168 @@
+# largely based on DRF's test_openapi
+import json
+
+from django.test import RequestFactory, override_settings
+from django.urls import re_path
+from rest_framework.request import Request
+
+from rest_framework_json_api.schemas.openapi import AutoSchema, SchemaGenerator
+
+from example import views
+from example.tests import TestBase
+
+
+def create_request(path):
+    factory = RequestFactory()
+    request = Request(factory.get(path))
+    return request
+
+
+def create_view_with_kw(view_cls, method, request, initkwargs):
+    generator = SchemaGenerator()
+    view = generator.create_view(view_cls.as_view(initkwargs), method, request)
+    return view
+
+
+def test_path_without_parameters(snapshot):
+    path = '/authors/'
+    method = 'GET'
+
+    view = create_view_with_kw(
+        views.AuthorViewSet,
+        method,
+        create_request(path),
+        {'get': 'list'}
+    )
+    inspector = AutoSchema()
+    inspector.view = view
+
+    operation = inspector.get_operation(path, method)
+    snapshot.assert_match(json.dumps(operation, indent=2, sort_keys=True))
+
+
+def test_path_with_id_parameter(snapshot):
+    path = '/authors/{id}/'
+    method = 'GET'
+
+    view = create_view_with_kw(
+        views.AuthorViewSet,
+        method,
+        create_request(path),
+        {'get': 'retrieve'}
+    )
+    inspector = AutoSchema()
+    inspector.view = view
+
+    operation = inspector.get_operation(path, method)
+    snapshot.assert_match(json.dumps(operation, indent=2, sort_keys=True))
+
+
+def test_post_request(snapshot):
+    method = 'POST'
+    path = '/authors/'
+
+    view = create_view_with_kw(
+        views.AuthorViewSet,
+        method,
+        create_request(path),
+        {'post': 'create'}
+    )
+    inspector = AutoSchema()
+    inspector.view = view
+
+    operation = inspector.get_operation(path, method)
+    snapshot.assert_match(json.dumps(operation, indent=2, sort_keys=True))
+
+
+def test_patch_request(snapshot):
+    method = 'PATCH'
+    path = '/authors/{id}'
+
+    view = create_view_with_kw(
+        views.AuthorViewSet,
+        method,
+        create_request(path),
+        {'patch': 'update'}
+    )
+    inspector = AutoSchema()
+    inspector.view = view
+
+    operation = inspector.get_operation(path, method)
+    snapshot.assert_match(json.dumps(operation, indent=2, sort_keys=True))
+
+
+def test_delete_request(snapshot):
+    method = 'DELETE'
+    path = '/authors/{id}'
+
+    view = create_view_with_kw(
+        views.AuthorViewSet,
+        method,
+        create_request(path),
+        {'delete': 'delete'}
+    )
+    inspector = AutoSchema()
+    # DRF >=3.12 changes the capitalization of these method mappings which breaks the snapshot,
+    # so just override them to be consistent with >=3.12
+    inspector.method_mapping = {
+        'get': 'retrieve',
+        'post': 'create',
+        'put': 'update',
+        'patch': 'partialUpdate',
+        'delete': 'destroy',
+    }
+    inspector.view = view
+
+    operation = inspector.get_operation(path, method)
+    snapshot.assert_match(json.dumps(operation, indent=2, sort_keys=True))
+
+
+@override_settings(REST_FRAMEWORK={
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework_json_api.schemas.openapi.AutoSchema'})
+def test_schema_construction():
+    """Construction of the top level dictionary."""
+    patterns = [
+        re_path('^authors/?$', views.AuthorViewSet.as_view({'get': 'list'})),
+    ]
+    generator = SchemaGenerator(patterns=patterns)
+
+    request = create_request('/')
+    schema = generator.get_schema(request=request)
+
+    assert 'openapi' in schema
+    assert 'info' in schema
+    assert 'paths' in schema
+    assert 'components' in schema
+
+
+class TestSchemaRelatedField(TestBase):
+    def test_schema_related_serializers(self):
+        """
+        Confirm that paths are generated for related fields. For example:
+        url path '/authors/{pk}/{related_field>}/' generates:
+            /authors/{id}/relationships/comments/
+            /authors/{id}/relationships/entries/
+            /authors/{id}/relationships/first_entry/ -- Maybe?
+            /authors/{id}/comments/
+            /authors/{id}/entries/
+            /authors/{id}/first_entry/
+        and confirm that the schema for the related field is properly rendered
+        """
+        generator = SchemaGenerator()
+        request = create_request('/')
+        schema = generator.get_schema(request=request)
+        # make sure the path's relationship and related {related_field}'s got expanded
+        assert '/authors/{id}/relationships/entries' in schema['paths']
+        assert '/authors/{id}/relationships/comments' in schema['paths']
+        # first_entry is a special case (SerializerMethodRelatedField)
+        # TODO: '/authors/{id}/relationships/first_entry' supposed to be there?
+        # It fails when doing the actual GET, so this schema excluding it is OK.
+        # assert '/authors/{id}/relationships/first_entry/' in schema['paths']
+        assert '/authors/{id}/comments/' in schema['paths']
+        assert '/authors/{id}/entries/' in schema['paths']
+        assert '/authors/{id}/first_entry/' in schema['paths']
+        first_get = schema['paths']['/authors/{id}/first_entry/']['get']['responses']['200']
+        first_schema = first_get['content']['application/vnd.api+json']['schema']
+        first_props = first_schema['properties']['data']
+        assert '$ref' in first_props
+        assert first_props['$ref'] == '#/components/schemas/Entry'

--- a/example/tests/test_openapi.py
+++ b/example/tests/test_openapi.py
@@ -128,10 +128,7 @@ def test_schema_construction():
 def test_schema_related_serializers():
     """
     Confirm that paths are generated for related fields. For example:
-    url path '/authors/{pk}/{related_field>}/' generates:
-        /authors/{id}/relationships/comments/
-        /authors/{id}/relationships/entries/
-        /authors/{id}/relationships/first_entry/ -- Maybe?
+        /authors/{pk}/{related_field>}
         /authors/{id}/comments/
         /authors/{id}/entries/
         /authors/{id}/first_entry/
@@ -141,12 +138,7 @@ def test_schema_related_serializers():
     request = create_request('/')
     schema = generator.get_schema(request=request)
     # make sure the path's relationship and related {related_field}'s got expanded
-    assert '/authors/{id}/relationships/entries' in schema['paths']
-    assert '/authors/{id}/relationships/comments' in schema['paths']
-    # first_entry is a special case (SerializerMethodRelatedField)
-    # TODO: '/authors/{id}/relationships/first_entry' supposed to be there?
-    # It fails when doing the actual GET, so this schema excluding it is OK.
-    # assert '/authors/{id}/relationships/first_entry/' in schema['paths']
+    assert '/authors/{id}/relationships/{related_field}' in schema['paths']
     assert '/authors/{id}/comments/' in schema['paths']
     assert '/authors/{id}/entries/' in schema['paths']
     assert '/authors/{id}/first_entry/' in schema['paths']

--- a/example/tests/unit/test_filter_schema_params.py
+++ b/example/tests/unit/test_filter_schema_params.py
@@ -1,0 +1,77 @@
+from rest_framework import filters as drf_filters
+
+from rest_framework_json_api import filters as dja_filters
+from rest_framework_json_api.django_filters import backends
+
+from example.views import EntryViewSet
+
+
+class DummyEntryViewSet(EntryViewSet):
+    filter_backends = (dja_filters.QueryParameterValidationFilter, dja_filters.OrderingFilter,
+                       backends.DjangoFilterBackend, drf_filters.SearchFilter)
+    filterset_fields = {
+        'id': ('exact',),
+        'headline': ('exact', 'contains'),
+        'blog__name': ('contains', ),
+    }
+
+    def __init__(self, **kwargs):
+        # dummy up self.request since PreloadIncludesMixin expects it to be defined
+        self.request = None
+        super(DummyEntryViewSet, self).__init__(**kwargs)
+
+
+def test_filters_get_schema_params():
+    """
+    test all my filters for `get_schema_operation_parameters()`
+    """
+    # list of tuples: (filter, expected result)
+    filters = [
+        (dja_filters.QueryParameterValidationFilter, []),
+        (backends.DjangoFilterBackend, [
+            {
+                'name': 'filter[id]', 'required': False, 'in': 'query',
+                'description': 'id', 'schema': {'type': 'string'}
+            },
+            {
+                'name': 'filter[headline]', 'required': False, 'in': 'query',
+                'description': 'headline', 'schema': {'type': 'string'}
+            },
+            {
+                'name': 'filter[headline.contains]', 'required': False, 'in': 'query',
+                'description': 'headline__contains', 'schema': {'type': 'string'}
+            },
+            {
+                'name': 'filter[blog.name.contains]', 'required': False, 'in': 'query',
+                'description': 'blog__name__contains', 'schema': {'type': 'string'}
+            },
+        ]),
+        (dja_filters.OrderingFilter, [
+            {
+                'name': 'sort', 'required': False, 'in': 'query',
+                'description': 'Which field to use when ordering the results.',
+                'schema': {'type': 'string'}
+            }
+        ]),
+        (drf_filters.SearchFilter, [
+            {
+                'name': 'filter[search]', 'required': False, 'in': 'query',
+                'description': 'A search term.',
+                'schema': {'type': 'string'}
+            }
+        ]),
+    ]
+    view = DummyEntryViewSet()
+
+    for c, expected in filters:
+        f = c()
+        result = f.get_schema_operation_parameters(view)
+        assert len(result) == len(expected)
+        if len(result) == 0:
+            continue
+        # py35: the result list/dict ordering isn't guaranteed
+        for res_item in result:
+            assert 'name' in res_item
+            for exp_item in expected:
+                if res_item['name'] == exp_item['name']:
+                    assert res_item == exp_item

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,6 +1,11 @@
 from django.conf import settings
 from django.conf.urls import include, url
+from django.urls import path
+from django.views.generic import TemplateView
 from rest_framework import routers
+from rest_framework.schemas import get_schema_view
+
+from rest_framework_json_api.schemas.openapi import SchemaGenerator
 
 from example.views import (
     AuthorRelationshipView,
@@ -63,11 +68,21 @@ urlpatterns = [
     url(r'^authors/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)$',
         AuthorRelationshipView.as_view(),
         name='author-relationships'),
+    path('openapi', get_schema_view(
+        title="Example API",
+        description="API for all things …",
+        version="1.0.0",
+        generator_class=SchemaGenerator
+    ), name='openapi-schema'),
+    path('swagger-ui/', TemplateView.as_view(
+        template_name='swagger-ui.html',
+        extra_context={'schema_url': 'openapi-schema'}
+    ), name='swagger-ui'),
 ]
-
 
 if settings.DEBUG:
     import debug_toolbar
+
     urlpatterns = [
         url(r'^__debug__/', include(debug_toolbar.urls)),
     ] + urlpatterns

--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,2 +1,4 @@
 django-filter==2.4.0
 django-polymorphic==3.0.0
+pyyaml==5.3
+uritemplate==3.0.1

--- a/rest_framework_json_api/django_filters/backends.py
+++ b/rest_framework_json_api/django_filters/backends.py
@@ -122,3 +122,17 @@ class DjangoFilterBackend(DjangoFilterBackend):
             'request': request,
             'filter_keys': filter_keys,
         }
+
+    def get_schema_operation_parameters(self, view):
+        """
+        Convert backend filter `name` to JSON:API-style `filter[name]`.
+        For filters that are relationship paths, rewrite ORM-style `__` to our preferred `.`.
+        For example: `blog__name__contains` becomes `filter[blog.name.contains]`.
+
+        This is basically the reverse of `get_filterset_kwargs` above.
+        """
+        result = super(DjangoFilterBackend, self).get_schema_operation_parameters(view)
+        for res in result:
+            if 'name' in res:
+                res['name'] = 'filter[{}]'.format(res['name']).replace('__', '.')
+        return result

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -468,17 +468,17 @@ class AutoSchema(drf_openapi.AutoSchema):
         # get request and response code schemas
         if method == 'GET':
             if is_list_view(path, method, self.view):
-                self._get_collection_response(operation)
+                self._add_get_collection_response(operation)
             else:
-                self._get_item_response(operation)
+                self._add_get_item_response(operation)
         elif method == 'POST':
-            self._post_item_response(operation, path, action)
+            self._add_post_item_response(operation, path, action)
         elif method == 'PATCH':
-            self._patch_item_response(operation, path, action)
+            self._add_patch_item_response(operation, path, action)
         elif method == 'DELETE':
             # should only allow deleting a resource, not a collection
             # TODO: implement delete of a relationship in future release.
-            self._delete_item_response(operation, path, action)
+            self._add_delete_item_response(operation, path, action)
         return operation
 
     def get_operation_id(self, path, method):
@@ -528,18 +528,18 @@ class AutoSchema(drf_openapi.AutoSchema):
         """
         return [{'$ref': '#/components/parameters/sort'}]
 
-    def _get_collection_response(self, operation):
+    def _add_get_collection_response(self, operation):
         """
-        jsonapi-structured 200 response for GET of a collection
+        Add GET 200 response for a collection to operation
         """
         operation['responses'] = {
             '200': self._get_toplevel_200_response(operation, collection=True)
         }
         self._add_get_4xx_responses(operation)
 
-    def _get_item_response(self, operation):
+    def _add_get_item_response(self, operation):
         """
-        jsonapi-structured 200 response for GET of an item
+        add GET 200 response for an item to operation
         """
         operation['responses'] = {
             '200': self._get_toplevel_200_response(operation, collection=False)
@@ -548,7 +548,7 @@ class AutoSchema(drf_openapi.AutoSchema):
 
     def _get_toplevel_200_response(self, operation, collection=True):
         """
-        top-level JSONAPI GET 200 response
+        return top-level JSONAPI GET 200 response
 
         :param collection: True for collections; False for individual items.
 
@@ -591,9 +591,9 @@ class AutoSchema(drf_openapi.AutoSchema):
             }
         }
 
-    def _post_item_response(self, operation, path, action):
+    def _add_post_item_response(self, operation, path, action):
         """
-        jsonapi-structured response for POST of an item
+        add response for POST of an item to operation
         """
         operation['requestBody'] = self.get_request_body(path, 'POST', action)
         operation['responses'] = {
@@ -610,9 +610,9 @@ class AutoSchema(drf_openapi.AutoSchema):
         }
         self._add_post_4xx_responses(operation)
 
-    def _patch_item_response(self, operation, path, action):
+    def _add_patch_item_response(self, operation, path, action):
         """
-        jsonapi-structured response for PATCH of an item
+        Add PATCH response for an item to operation
         """
         operation['requestBody'] = self.get_request_body(path, 'PATCH', action)
         operation['responses'] = {
@@ -620,9 +620,9 @@ class AutoSchema(drf_openapi.AutoSchema):
         }
         self._add_patch_4xx_responses(operation)
 
-    def _delete_item_response(self, operation, path, action):
+    def _add_delete_item_response(self, operation, path, action):
         """
-        jsonapi-structured response for DELETE of an item or relationship(s)
+        add DELETE response for item or relationship(s) to operation
         """
         # Only DELETE of relationships has a requestBody
         if action in ['rels', 'rel']:
@@ -773,6 +773,9 @@ class AutoSchema(drf_openapi.AutoSchema):
         return result
 
     def _add_async_response(self, operation):
+        """
+        Add async response to operation
+        """
         operation['responses']['202'] = {
             'description': 'Accepted for [asynchronous processing]'
                            '(https://jsonapi.org/recommendations/#asynchronous-processing)',
@@ -784,6 +787,9 @@ class AutoSchema(drf_openapi.AutoSchema):
         }
 
     def _failure_response(self, reason):
+        """
+        Return failure response reason as the description
+        """
         return {
             'description': reason,
             'content': {
@@ -793,19 +799,26 @@ class AutoSchema(drf_openapi.AutoSchema):
             }
         }
 
-    def _generic_failure_responses(self, operation):
+    def _add_generic_failure_responses(self, operation):
+        """
+        Add generic failure response(s) to operation
+        """
         for code, reason in [('401', 'not authorized'), ]:
             operation['responses'][code] = self._failure_response(reason)
 
     def _add_get_4xx_responses(self, operation):
-        """ Add generic responses for get """
-        self._generic_failure_responses(operation)
+        """
+        Add generic 4xx GET responses to operation
+        """
+        self._add_generic_failure_responses(operation)
         for code, reason in [('404', 'not found')]:
             operation['responses'][code] = self._failure_response(reason)
 
     def _add_post_4xx_responses(self, operation):
-        """ Add error responses for post """
-        self._generic_failure_responses(operation)
+        """
+        Add POST 4xx error responses to operation
+        """
+        self._add_generic_failure_responses(operation)
         for code, reason in [
             ('403', '[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)'),
             ('404', '[Related resource does not exist]'
@@ -815,8 +828,10 @@ class AutoSchema(drf_openapi.AutoSchema):
             operation['responses'][code] = self._failure_response(reason)
 
     def _add_patch_4xx_responses(self, operation):
-        """ Add error responses for patch """
-        self._generic_failure_responses(operation)
+        """
+        Add PATCH 4xx error responses to operation
+        """
+        self._add_generic_failure_responses(operation)
         for code, reason in [
             ('403', '[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)'),
             ('404', '[Related resource does not exist]'
@@ -827,7 +842,9 @@ class AutoSchema(drf_openapi.AutoSchema):
             operation['responses'][code] = self._failure_response(reason)
 
     def _add_delete_responses(self, operation):
-        """ Add generic responses for delete """
+        """
+        Add generic DELETE responses to operation
+        """
         # the 2xx statuses:
         operation['responses'] = {
             '200': {
@@ -844,7 +861,7 @@ class AutoSchema(drf_openapi.AutoSchema):
             'description': '[no content](https://jsonapi.org/format/#crud-deleting-responses-204)',
         }
         # the 4xx errors:
-        self._generic_failure_responses(operation)
+        self._add_generic_failure_responses(operation)
         for code, reason in [
             ('404', '[Resource does not exist]'
                     '(https://jsonapi.org/format/#crud-deleting-responses-404)'),

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -338,18 +338,18 @@ class SchemaGenerator(drf_openapi.SchemaGenerator):
 
             components_schemas.update(components)
 
-            if hasattr(view.schema, 'get_security_schemes'):
+            if hasattr(view.schema, 'get_security_schemes'):  # pragma: no cover
                 security_schemes = view.schema.get_security_schemes(path, method)
             else:
                 security_schemes = {}
-            for k in security_schemes.keys():
+            for k in security_schemes.keys():  # pragma: no cover
                 if k not in security_schemes_schemas:
                     continue
                 if security_schemes_schemas[k] == security_schemes[k]:
                     continue
                 warnings.warn('Securit scheme component "{}" has been overriden with a different '
                               'value.'.format(k))
-            security_schemes_schemas.update(security_schemes)
+            security_schemes_schemas.update(security_schemes)  # pragma: no cover
 
             if hasattr(view, 'action'):
                 view.action = current_action
@@ -367,7 +367,7 @@ class SchemaGenerator(drf_openapi.SchemaGenerator):
         schema['paths'] = paths
         schema['components'] = self.jsonapi_components
         schema['components']['schemas'].update(components_schemas)
-        if len(security_schemes_schemas) > 0:
+        if len(security_schemes_schemas) > 0:  # pragma: no cover
             schema['components']['securitySchemes'] = security_schemes_schemas
 
         return schema
@@ -475,7 +475,7 @@ class AutoSchema(drf_openapi.AutoSchema):
         operation = {}
         operation['operationId'] = self.get_operation_id(path, method)
         operation['description'] = self.get_description(path, method)
-        if hasattr(self, 'get_security_requirements'):
+        if hasattr(self, 'get_security_requirements'):  # pragma: no cover
             security = self.get_security_requirements(path, method)
             if security is not None:
                 operation['security'] = security

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -267,11 +267,6 @@ class SchemaGenerator(drf_openapi.SchemaGenerator):
                 'style': 'deepObject',
                 'schema': {
                     'type': 'object',
-                    'properties': {
-                        '<typename>': {  # placeholder for actual type names
-                            'type': 'string'
-                        }
-                    }
                 },
                 'explode': True
             },

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -293,7 +293,6 @@ class SchemaGenerator(drf_openapi.SchemaGenerator):
         schema = super().get_schema(request, public)
 
         components_schemas = {}
-        security_schemes_schemas = {}
 
         # Iterate endpoints generating per method path operations.
         paths = {}
@@ -332,19 +331,6 @@ class SchemaGenerator(drf_openapi.SchemaGenerator):
 
             components_schemas.update(components)
 
-            if hasattr(view.schema, 'get_security_schemes'):  # pragma: no cover
-                security_schemes = view.schema.get_security_schemes(path, method)
-            else:
-                security_schemes = {}
-            for k in security_schemes.keys():  # pragma: no cover
-                if k not in security_schemes_schemas:
-                    continue
-                if security_schemes_schemas[k] == security_schemes[k]:
-                    continue
-                warnings.warn('Securit scheme component "{}" has been overriden with a different '
-                              'value.'.format(k))
-            security_schemes_schemas.update(security_schemes)  # pragma: no cover
-
             if hasattr(view, 'action'):
                 view.action = current_action
             # Normalise path for any provided mount url.
@@ -361,8 +347,6 @@ class SchemaGenerator(drf_openapi.SchemaGenerator):
         schema['paths'] = paths
         schema['components'] = self.jsonapi_components
         schema['components']['schemas'].update(components_schemas)
-        if len(security_schemes_schemas) > 0:  # pragma: no cover
-            schema['components']['securitySchemes'] = security_schemes_schemas
 
         return schema
 
@@ -469,10 +453,6 @@ class AutoSchema(drf_openapi.AutoSchema):
         operation = {}
         operation['operationId'] = self.get_operation_id(path, method)
         operation['description'] = self.get_description(path, method)
-        if hasattr(self, 'get_security_requirements'):  # pragma: no cover
-            security = self.get_security_requirements(path, method)
-            if security is not None:
-                operation['security'] = security
 
         parameters = []
         parameters += self.get_path_parameters(path, method)

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -645,7 +645,7 @@ class AutoSchema(drf_openapi.AutoSchema):
         # doesn't work for jsonapi due to the different required fields based on
         # the method, so make those changes and inline another copy of the schema.
         # TODO: A future improvement could make this DRYer with multiple components?
-        item_schema = self.map_serializer(serializer).copy()
+        item_schema = self.map_serializer(serializer)
 
         # 'type' and 'id' are both required for:
         # - all relationship operations

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -308,8 +308,7 @@ class SchemaGenerator(drf_openapi.SchemaGenerator):
             elif hasattr(view, 'action') and view.action == 'retrieve_related':
                 expanded_endpoints += self._expand_related(path, method, view, view_endpoints)
             else:
-                expanded_endpoints.append((path, method, view,
-                                           view.action if hasattr(view, 'action') else None))
+                expanded_endpoints.append((path, method, view, getattr(view, 'action', None)))
 
         for path, method, view, action in expanded_endpoints:
             if not self.has_view_permissions(path, method, view):

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -1,6 +1,7 @@
 import warnings
 from urllib.parse import urljoin
 
+from django.db.models.fields import related_descriptors as rd
 from django.utils.module_loading import import_string as import_class_from_dotted_path
 from rest_framework.fields import empty
 from rest_framework.relations import ManyRelatedField
@@ -8,6 +9,7 @@ from rest_framework.schemas import openapi as drf_openapi
 from rest_framework.schemas.utils import is_list_view
 
 from rest_framework_json_api import serializers
+from rest_framework_json_api.views import RelationshipView
 
 
 class SchemaGenerator(drf_openapi.SchemaGenerator):
@@ -300,7 +302,9 @@ class SchemaGenerator(drf_openapi.SchemaGenerator):
         #: - 'action' copy of current view.action (list/fetch) as this gets reset for each request.
         expanded_endpoints = []
         for path, method, view in view_endpoints:
-            if hasattr(view, 'action') and view.action == 'retrieve_related':
+            if isinstance(view, RelationshipView):
+                expanded_endpoints += self._expand_relationships(path, method, view)
+            elif hasattr(view, 'action') and view.action == 'retrieve_related':
                 expanded_endpoints += self._expand_related(path, method, view, view_endpoints)
             else:
                 expanded_endpoints.append((path, method, view, getattr(view, 'action', None)))
@@ -345,6 +349,28 @@ class SchemaGenerator(drf_openapi.SchemaGenerator):
         schema['components']['schemas'].update(components_schemas)
 
         return schema
+
+    def _expand_relationships(self, path, method, view):
+        """
+        Expand path containing .../{id}/relationships/{related_field} into list of related fields.
+        :return:list[tuple(path, method, view, action)]
+        """
+        queryset = view.get_queryset()
+        if not queryset.model:
+            return [(path, method, view, getattr(view, 'action', '')), ]
+        result = []
+        # TODO: what about serializer-only (non-model) fields?
+        #       Shouldn't this be iterating over serializer fields rather than model fields?
+        #       Look at parent view's serializer to get the list of fields.
+        #       OR maybe like _expand_related?
+        m = queryset.model
+        for field in [f for f in dir(m) if not f.startswith('_')]:
+            attr = getattr(m, field)
+            if isinstance(attr, (rd.ReverseManyToOneDescriptor, rd.ForwardOneToOneDescriptor)):
+                action = 'rels' if isinstance(attr, rd.ReverseManyToOneDescriptor) else 'rel'
+                result.append((path.replace('{related_field}', field), method, view, action))
+
+        return result
 
     def _expand_related(self, path, method, view, view_endpoints):
         """

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -1,0 +1,878 @@
+import warnings
+from urllib.parse import urljoin
+
+from django.db.models.fields import related_descriptors as rd
+from django.utils.module_loading import import_string as import_class_from_dotted_path
+from rest_framework.fields import empty
+from rest_framework.relations import ManyRelatedField
+from rest_framework.schemas import openapi as drf_openapi
+from rest_framework.schemas.utils import is_list_view
+
+from rest_framework_json_api import serializers
+from rest_framework_json_api.views import RelationshipView
+
+
+class SchemaGenerator(drf_openapi.SchemaGenerator):
+    """
+    Extend DRF's SchemaGenerator to implement jsonapi-flavored generateschema command.
+    """
+    #: These JSONAPI component definitions are referenced by the generated OAS schema.
+    #: If you need to add more or change these static component definitions, extend this dict.
+    jsonapi_components = {
+        'schemas': {
+            'jsonapi': {
+                'type': 'object',
+                'description': "The server's implementation",
+                'properties': {
+                    'version': {'type': 'string'},
+                    'meta': {'$ref': '#/components/schemas/meta'}
+                },
+                'additionalProperties': False
+            },
+            'ResourceIdentifierObject': {
+                'type': 'object',
+                'required': ['type', 'id'],
+                'additionalProperties': False,
+                'properties': {
+                    'type': {
+                        '$ref': '#/components/schemas/type'
+                    },
+                    'id': {
+                        '$ref': '#/components/schemas/id'
+                    },
+                },
+            },
+            'resource': {
+                'type': 'object',
+                'required': ['type', 'id'],
+                'additionalProperties': False,
+                'properties': {
+                    'type': {
+                        '$ref': '#/components/schemas/type'
+                    },
+                    'id': {
+                        '$ref': '#/components/schemas/id'
+                    },
+                    'attributes': {
+                        'type': 'object',
+                        # ...
+                    },
+                    'relationships': {
+                        'type': 'object',
+                        # ...
+                    },
+                    'links': {
+                        '$ref': '#/components/schemas/links'
+                    },
+                    'meta': {'$ref': '#/components/schemas/meta'},
+                }
+            },
+            'link': {
+                'oneOf': [
+                    {
+                        'description': "a string containing the link's URL",
+                        'type': 'string',
+                        'format': 'uri-reference'
+                    },
+                    {
+                        'type': 'object',
+                        'required': ['href'],
+                        'properties': {
+                            'href': {
+                                'description': "a string containing the link's URL",
+                                'type': 'string',
+                                'format': 'uri-reference'
+                            },
+                            'meta': {'$ref': '#/components/schemas/meta'}
+                        }
+                    }
+                ]
+            },
+            'links': {
+                'type': 'object',
+                'additionalProperties': {'$ref': '#/components/schemas/link'}
+            },
+            'reltoone': {
+                'description': "a singular 'to-one' relationship",
+                'type': 'object',
+                'properties': {
+                    'links': {'$ref': '#/components/schemas/relationshipLinks'},
+                    'data': {'$ref': '#/components/schemas/relationshipToOne'},
+                    'meta': {'$ref': '#/components/schemas/meta'}
+                }
+            },
+            'relationshipToOne': {
+                'description': "reference to other resource in a to-one relationship",
+                'anyOf': [
+                    {'$ref': '#/components/schemas/nulltype'},
+                    {'$ref': '#/components/schemas/linkage'}
+                ],
+            },
+            'reltomany': {
+                'description': "a multiple 'to-many' relationship",
+                'type': 'object',
+                'properties': {
+                    'links': {'$ref': '#/components/schemas/relationshipLinks'},
+                    'data': {'$ref': '#/components/schemas/relationshipToMany'},
+                    'meta': {'$ref': '#/components/schemas/meta'}
+                }
+            },
+            'relationshipLinks': {
+                'description': 'optional references to other resource objects',
+                'type': 'object',
+                'additionalProperties': True,
+                'properties': {
+                    'self': {'$ref': '#/components/schemas/link'},
+                    'related': {'$ref': '#/components/schemas/link'}
+                }
+            },
+            'relationshipToMany': {
+                'description': "An array of objects each containing the "
+                               "'type' and 'id' for to-many relationships",
+                'type': 'array',
+                'items': {'$ref': '#/components/schemas/linkage'},
+                'uniqueItems': True
+            },
+            'linkage': {
+                'type': 'object',
+                'description': "the 'type' and 'id'",
+                'required': ['type', 'id'],
+                'properties': {
+                    'type': {'$ref': '#/components/schemas/type'},
+                    'id': {'$ref': '#/components/schemas/id'},
+                    'meta': {'$ref': '#/components/schemas/meta'}
+                }
+            },
+            'pagination': {
+                'type': 'object',
+                'properties': {
+                    'first': {'$ref': '#/components/schemas/pageref'},
+                    'last': {'$ref': '#/components/schemas/pageref'},
+                    'prev': {'$ref': '#/components/schemas/pageref'},
+                    'next': {'$ref': '#/components/schemas/pageref'},
+                }
+            },
+            'pageref': {
+                'oneOf': [
+                    {'type': 'string', 'format': 'uri-reference'},
+                    {'$ref': '#/components/schemas/nulltype'}
+                ]
+            },
+            'failure': {
+                'type': 'object',
+                'required': ['errors'],
+                'properties': {
+                    'errors': {'$ref': '#/components/schemas/errors'},
+                    'meta': {'$ref': '#/components/schemas/meta'},
+                    'jsonapi': {'$ref': '#/components/schemas/jsonapi'},
+                    'links': {'$ref': '#/components/schemas/links'}
+                }
+            },
+            'errors': {
+                'type': 'array',
+                'items': {'$ref': '#/components/schemas/error'},
+                'uniqueItems': True
+            },
+            'error': {
+                'type': 'object',
+                'additionalProperties': False,
+                'properties': {
+                    'id': {'type': 'string'},
+                    'status': {'type': 'string'},
+                    'links': {'$ref': '#/components/schemas/links'},
+                    'code': {'type': 'string'},
+                    'title': {'type': 'string'},
+                    'detail': {'type': 'string'},
+                    'source': {
+                        'type': 'object',
+                        'properties': {
+                            'pointer': {
+                                'type': 'string',
+                                'description':
+                                    "A [JSON Pointer](https://tools.ietf.org/html/rfc6901) "
+                                    "to the associated entity in the request document "
+                                    "[e.g. `/data` for a primary data object, or "
+                                    "`/data/attributes/title` for a specific attribute."
+                            },
+                            'parameter': {
+                                'type': 'string',
+                                'description':
+                                    "A string indicating which query parameter "
+                                    "caused the error."
+                            },
+                            'meta': {'$ref': '#/components/schemas/meta'}
+                        }
+                    }
+                }
+            },
+            'onlymeta': {
+                'additionalProperties': False,
+                'properties': {
+                    'meta': {'$ref': '#/components/schemas/meta'}
+                }
+            },
+            'meta': {
+                'type': 'object',
+                'additionalProperties': True
+            },
+            'datum': {
+                'description': 'singular item',
+                'properties': {
+                    'data': {'$ref': '#/components/schemas/resource'}
+                }
+            },
+            'nulltype': {
+                'type': 'object',
+                'nullable': True,
+                'default': None
+            },
+            'type': {
+                'type': 'string',
+                'description':
+                    'The [type]'
+                    '(https://jsonapi.org/format/#document-resource-object-identification) '
+                    'member is used to describe resource objects that share common attributes '
+                    'and relationships.'
+            },
+            'id': {
+                'type': 'string',
+                'description':
+                    "Each resource object’s type and id pair MUST "
+                    "[identify]"
+                    "(https://jsonapi.org/format/#document-resource-object-identification) "
+                    "a single, unique resource."
+            },
+        },
+        'parameters': {
+            'include': {
+                'name': 'include',
+                'in': 'query',
+                'description': '[list of included related resources]'
+                               '(https://jsonapi.org/format/#fetching-includes)',
+                'required': False,
+                'style': 'form',
+                'schema': {
+                    'type': 'string'
+                }
+            },
+            # TODO: deepObject not well defined/supported:
+            #       https://github.com/OAI/OpenAPI-Specification/issues/1706
+            'fields': {
+                'name': 'fields',
+                'in': 'query',
+                'description': '[sparse fieldsets]'
+                               '(https://jsonapi.org/format/#fetching-sparse-fieldsets).\n'
+                               'Use fields[\\<typename\\>]=field1,field2,...,fieldN',
+                'required': False,
+                'style': 'deepObject',
+                'schema': {
+                    'type': 'object',
+                    'properties': {
+                        '<typename>': {  # placeholder for actual type names
+                            'type': 'string'
+                        }
+                    }
+                },
+                'explode': True
+            },
+            'sort': {
+                'name': 'sort',
+                'in': 'query',
+                'description': '[list of fields to sort by]'
+                               '(https://jsonapi.org/format/#fetching-sorting)',
+                'required': False,
+                'style': 'form',
+                'schema': {
+                    'type': 'string'
+                }
+            },
+        },
+    }
+
+    def get_schema(self, request=None, public=False):
+        """
+        Generate a JSONAPI OpenAPI schema.
+        Overrides upstream DRF's get_schema.
+        """
+        # TODO: avoid copying so much of upstream get_schema()
+        schema = super().get_schema(request, public)
+
+        components_schemas = {}
+        security_schemes_schemas = {}
+
+        # Iterate endpoints generating per method path operations.
+        paths = {}
+        _, view_endpoints = self._get_paths_and_endpoints(None if public else request)
+
+        #: `expanded_endpoints` is like view_endpoints with one extra field tacked on:
+        #: - 'action' copy of current view.action (list/fetch) as this gets reset for each request.
+        expanded_endpoints = []
+        for path, method, view in view_endpoints:
+            if isinstance(view, RelationshipView):
+                expanded_endpoints += self._expand_relationships(path, method, view)
+            elif hasattr(view, 'action') and view.action == 'retrieve_related':
+                expanded_endpoints += self._expand_related(path, method, view, view_endpoints)
+            else:
+                expanded_endpoints.append((path, method, view,
+                                           view.action if hasattr(view, 'action') else None))
+
+        for path, method, view, action in expanded_endpoints:
+            if not self.has_view_permissions(path, method, view):
+                continue
+            # kludge to preserve view.action as it changes "globally" for the same ViewSet
+            # whether it is used for a collection, item or related serializer. _expand_related
+            # sets it based on whether the related field is a toMany collection or toOne item.
+            current_action = None
+            if hasattr(view, 'action'):
+                current_action = view.action
+                view.action = action
+            operation = view.schema.get_operation(path, method, action)
+            components = view.schema.get_components(path, method)
+            for k in components.keys():
+                if k not in components_schemas:
+                    continue
+                if components_schemas[k] == components[k]:
+                    continue
+                warnings.warn(
+                    'Schema component "{}" has been overriden with a different value.'.format(k))
+
+            components_schemas.update(components)
+
+            if hasattr(view.schema, 'get_security_schemes'):
+                security_schemes = view.schema.get_security_schemes(path, method)
+            else:
+                security_schemes = {}
+            for k in security_schemes.keys():
+                if k not in security_schemes_schemas:
+                    continue
+                if security_schemes_schemas[k] == security_schemes[k]:
+                    continue
+                warnings.warn('Securit scheme component "{}" has been overriden with a different '
+                              'value.'.format(k))
+            security_schemes_schemas.update(security_schemes)
+
+            if hasattr(view, 'action'):
+                view.action = current_action
+            # Normalise path for any provided mount url.
+            if path.startswith('/'):
+                path = path[1:]
+            path = urljoin(self.url or '/', path)
+
+            paths.setdefault(path, {})
+            paths[path][method.lower()] = operation
+
+        self.check_duplicate_operation_id(paths)
+
+        # Compile final schema, overriding stuff from super class.
+        schema['paths'] = paths
+        schema['components'] = self.jsonapi_components
+        schema['components']['schemas'].update(components_schemas)
+        if len(security_schemes_schemas) > 0:
+            schema['components']['securitySchemes'] = security_schemes_schemas
+
+        return schema
+
+    def _expand_relationships(self, path, method, view):
+        """
+        Expand path containing .../{id}/relationships/{related_field} into list of related fields.
+        :return:list[tuple(path, method, view, action)]
+        """
+        queryset = view.get_queryset()
+        if not queryset.model:
+            return [(path, method, view, getattr(view, 'action', '')), ]
+        result = []
+        # TODO: what about serializer-only (non-model) fields?
+        #       Shouldn't this be iterating over serializer fields rather than model fields?
+        #       Look at parent view's serializer to get the list of fields.
+        #       OR maybe like _expand_related?
+        m = queryset.model
+        for field in [f for f in dir(m) if not f.startswith('_')]:
+            attr = getattr(m, field)
+            if isinstance(attr, (rd.ReverseManyToOneDescriptor, rd.ForwardOneToOneDescriptor)):
+                action = 'rels' if isinstance(attr, rd.ReverseManyToOneDescriptor) else 'rel'
+                result.append((path.replace('{related_field}', field), method, view, action))
+
+        return result
+
+    def _expand_related(self, path, method, view, view_endpoints):
+        """
+        Expand path containing .../{id}/{related_field} into list of related fields
+        and **their** views, making sure toOne relationship's views are a 'fetch' and toMany
+        relationship's are a 'list'.
+        :param path
+        :param method
+        :param view
+        :param view_endpoints
+        :return:list[tuple(path, method, view, action)]
+        """
+        result = []
+        serializer = view.get_serializer()
+        # It's not obvious if it's allowed to have both included_ and related_ serializers,
+        # so just merge both dicts.
+        serializers = {}
+        if hasattr(serializer, 'included_serializers'):
+            serializers = {**serializers, **serializer.included_serializers}
+        if hasattr(serializer, 'related_serializers'):
+            serializers = {**serializers, **serializer.related_serializers}
+        related_fields = [fs for fs in serializers.items()]
+
+        for field, related_serializer in related_fields:
+            related_view = self._find_related_view(view_endpoints, related_serializer, view)
+            if related_view:
+                action = self._field_is_one_or_many(field, view)
+                result.append(
+                    (path.replace('{related_field}', field), method, related_view, action)
+                )
+
+        return result
+
+    def _find_related_view(self, view_endpoints, related_serializer, parent_view):
+        """
+        For a given related_serializer, try to find it's "parent" view instance in view_endpoints.
+        :param view_endpoints: list of all view endpoints
+        :param related_serializer: the related serializer for a given related field
+        :param parent_view: the parent view (used to find toMany vs. toOne).
+               TODO: not actually used.
+        :return:view
+        """
+        for path, method, view in view_endpoints:
+            view_serializer = view.get_serializer()
+            if not isinstance(related_serializer, type):
+                related_serializer_class = import_class_from_dotted_path(related_serializer)
+            else:
+                related_serializer_class = related_serializer
+            if isinstance(view_serializer, related_serializer_class):
+                return view
+
+        return None
+
+    def _field_is_one_or_many(self, field, view):
+        serializer = view.get_serializer()
+        if isinstance(serializer.fields[field], ManyRelatedField):
+            return 'list'
+        else:
+            return 'fetch'
+
+
+class AutoSchema(drf_openapi.AutoSchema):
+    """
+    Extend DRF's openapi.AutoSchema for JSONAPI serialization.
+    """
+    #: ignore all the media types and only generate a JSONAPI schema.
+    content_types = ['application/vnd.api+json']
+
+    def get_operation(self, path, method, action=None):
+        """
+        JSONAPI adds some standard fields to the API response that are not in upstream DRF:
+        - some that only apply to GET/HEAD methods.
+        - collections
+        - special handling for POST, PATCH, DELETE:
+
+        :param action: One of the usual actions for a conventional path (list, retrieve, update,
+            partial_update, destroy) or special case 'rel' or 'rels' for a singular or
+            plural relationship.
+        """
+        operation = {}
+        operation['operationId'] = self.get_operation_id(path, method)
+        operation['description'] = self.get_description(path, method)
+        if hasattr(self, 'get_security_requirements'):
+            security = self.get_security_requirements(path, method)
+            if security is not None:
+                operation['security'] = security
+
+        parameters = []
+        parameters += self.get_path_parameters(path, method)
+        # pagination, filters only apply to GET/HEAD of collections and items
+        if method in ['GET', 'HEAD']:
+            parameters += self._get_include_parameters(path, method)
+            parameters += self._get_fields_parameters(path, method)
+            parameters += self._get_sort_parameters(path, method)
+            parameters += self.get_pagination_parameters(path, method)
+            parameters += self.get_filter_parameters(path, method)
+        operation['parameters'] = parameters
+
+        # get request and response code schemas
+        if method == 'GET':
+            if is_list_view(path, method, self.view):
+                self._get_collection_response(operation)
+            else:
+                self._get_item_response(operation)
+        elif method == 'POST':
+            self._post_item_response(operation, path, action)
+        elif method == 'PATCH':
+            self._patch_item_response(operation, path, action)
+        elif method == 'DELETE':
+            # should only allow deleting a resource, not a collection
+            # TODO: implement delete of a relationship in future release.
+            self._delete_item_response(operation, path, action)
+        return operation
+
+    def get_operation_id(self, path, method):
+        """
+        The upstream DRF version creates non-unique operationIDs, because the same view is
+        used for the main path as well as such as related and relationships.
+        This concatenates the (mapped) method name and path as the spec allows most any
+        """
+        method_name = getattr(self.view, 'action', method.lower())
+        if is_list_view(path, method, self.view):
+            action = 'List'
+        elif method_name not in self.method_mapping:
+            action = method_name
+        else:
+            action = self.method_mapping[method.lower()]
+        return action + path
+
+    def _get_include_parameters(self, path, method):
+        """
+        includes parameter: https://jsonapi.org/format/#fetching-includes
+        """
+        return [{'$ref': '#/components/parameters/include'}]
+
+    def _get_fields_parameters(self, path, method):
+        """
+        sparse fieldsets https://jsonapi.org/format/#fetching-sparse-fieldsets
+        """
+        # TODO: See if able to identify the specific types for fields[type]=... and return this:
+        # name: fields
+        # in: query
+        # description: '[sparse fieldsets](https://jsonapi.org/format/#fetching-sparse-fieldsets)'
+        # required: true
+        # style: deepObject
+        # schema:
+        #   type: object
+        #   properties:
+        #     hello:
+        #       type: string  # noqa F821
+        #     world:
+        #       type: string  # noqa F821
+        # explode: true
+        return [{'$ref': '#/components/parameters/fields'}]
+
+    def _get_sort_parameters(self, path, method):
+        """
+        sort parameter: https://jsonapi.org/format/#fetching-sorting
+        """
+        return [{'$ref': '#/components/parameters/sort'}]
+
+    def _get_collection_response(self, operation):
+        """
+        jsonapi-structured 200 response for GET of a collection
+        """
+        operation['responses'] = {
+            '200': self._get_toplevel_200_response(operation, collection=True)
+        }
+        self._add_get_4xx_responses(operation)
+
+    def _get_item_response(self, operation):
+        """
+        jsonapi-structured 200 response for GET of an item
+        """
+        operation['responses'] = {
+            '200': self._get_toplevel_200_response(operation, collection=False)
+        }
+        self._add_get_4xx_responses(operation)
+
+    def _get_toplevel_200_response(self, operation, collection=True):
+        """
+        top-level JSONAPI GET 200 response
+
+        :param collection: True for collections; False for individual items.
+
+        Uses a $ref to the components.schemas.<Name> component definition.
+        """
+        if collection:
+            data = {'type': 'array', 'items': self._get_reference(self.view.get_serializer())}
+        else:
+            data = self._get_reference(self.view.get_serializer())
+
+        return {
+            'description': operation['operationId'],
+            'content': {
+                'application/vnd.api+json': {
+                    'schema': {
+                        'type': 'object',
+                        'required': ['data'],
+                        'properties': {
+                            'data': data,
+                            'included': {
+                                'type': 'array',
+                                'uniqueItems': True,
+                                'items': {
+                                    '$ref': '#/components/schemas/resource'
+                                }
+                            },
+                            'links': {
+                                'description': 'Link members related to primary data',
+                                'allOf': [
+                                    {'$ref': '#/components/schemas/links'},
+                                    {'$ref': '#/components/schemas/pagination'}
+                                ]
+                            },
+                            'jsonapi': {
+                                '$ref': '#/components/schemas/jsonapi'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    def _post_item_response(self, operation, path, action):
+        """
+        jsonapi-structured response for POST of an item
+        """
+        operation['requestBody'] = self.get_request_body(path, 'POST', action)
+        operation['responses'] = {
+            '201': self._get_toplevel_200_response(operation, collection=False)
+        }
+        operation['responses']['201']['description'] = (
+            '[Created](https://jsonapi.org/format/#crud-creating-responses-201). '
+            'Assigned `id` and/or any other changes are in this response.'
+        )
+        self._add_async_response(operation)
+        operation['responses']['204'] = {
+            'description': '[Created](https://jsonapi.org/format/#crud-creating-responses-204) '
+            'with the supplied `id`. No other changes from what was POSTed.'
+        }
+        self._add_post_4xx_responses(operation)
+
+    def _patch_item_response(self, operation, path, action):
+        """
+        jsonapi-structured response for PATCH of an item
+        """
+        operation['requestBody'] = self.get_request_body(path, 'PATCH', action)
+        operation['responses'] = {
+            '200': self._get_toplevel_200_response(operation, collection=False)
+        }
+        self._add_patch_4xx_responses(operation)
+
+    def _delete_item_response(self, operation, path, action):
+        """
+        jsonapi-structured response for DELETE of an item or relationship(s)
+        """
+        # Only DELETE of relationships has a requestBody
+        if action in ['rels', 'rel']:
+            operation['requestBody'] = self.get_request_body(path, 'DELETE', action)
+        self._add_delete_responses(operation)
+
+    def get_request_body(self, path, method, action=None):
+        """
+        A request body is required by jsonapi for POST, PATCH, and DELETE methods.
+        This has an added parameter which is not in upstream DRF:
+
+        :param action: None for conventional path; 'rel' or 'rels' for a singular or plural
+            relationship of a related path, respectively.
+        """
+        serializer = self.get_serializer(path, method)
+        if not isinstance(serializer, (serializers.BaseSerializer, )):
+            return {}
+
+        # DRF uses a $ref to the component definition, but this
+        # doesn't work for jsonapi due to the different required fields based on
+        # the method, so make those changes and inline another copy of the schema.
+        # TODO: A future improvement could make this DRYer with multiple components?
+        item_schema = self.map_serializer(serializer).copy()
+
+        # 'type' and 'id' are both required for:
+        # - all relationship operations
+        # - regular PATCH or DELETE
+        # Only 'type' is required for POST: system may assign the 'id'.
+        if action in ['rels', 'rel']:
+            item_schema['required'] = ['type', 'id']
+        elif method in ['PATCH', 'DELETE']:
+            item_schema['required'] = ['type', 'id']
+        elif method == 'POST':
+            item_schema['required'] = ['type']
+
+        if 'attributes' in item_schema['properties']:
+            # No required attributes for PATCH
+            if method in ['PATCH', 'PUT'] and 'required' in item_schema['properties']['attributes']:
+                del item_schema['properties']['attributes']['required']
+            # No read_only fields for request.
+            for name, schema in item_schema['properties']['attributes']['properties'].copy().items():  # noqa E501
+                if 'readOnly' in schema:
+                    del item_schema['properties']['attributes']['properties'][name]
+        # relationships special case: plural request body (data is array of items)
+        if action == 'rels':
+            return {
+                'content': {
+                    ct: {
+                        'schema': {
+                            'required': ['data'],
+                            'properties': {
+                                'data': {
+                                    'type': 'array',
+                                    'items': item_schema
+                                }
+                            }
+                        }
+                    }
+                    for ct in self.content_types
+                }
+            }
+        # singular request body for all other cases
+        else:
+            return {
+                'content': {
+                    ct: {
+                        'schema': {
+                            'required': ['data'],
+                            'properties': {
+                                'data': item_schema
+                            }
+                        }
+                    }
+                    for ct in self.content_types
+                }
+            }
+
+    def map_serializer(self, serializer):
+        """
+        Custom map_serializer that serializes the schema using the jsonapi spec.
+        Non-attributes like related and identity fields, are move to 'relationships' and 'links'.
+        """
+        # TODO: remove attributes, etc. for relationshipView??
+        required = []
+        attributes = {}
+        relationships = {}
+
+        for field in serializer.fields.values():
+            if isinstance(field, serializers.HyperlinkedIdentityField):
+                # the 'url' is not an attribute but rather a self.link, so don't map it here.
+                continue
+            if isinstance(field, serializers.HiddenField):
+                continue
+            if isinstance(field, serializers.RelatedField):
+                relationships[field.field_name] = {'$ref': '#/components/schemas/reltoone'}
+                continue
+            if isinstance(field, serializers.ManyRelatedField):
+                relationships[field.field_name] = {'$ref': '#/components/schemas/reltomany'}
+                continue
+
+            if field.required:
+                required.append(field.field_name)
+
+            schema = self.map_field(field)
+            if field.read_only:
+                schema['readOnly'] = True
+            if field.write_only:
+                schema['writeOnly'] = True
+            if field.allow_null:
+                schema['nullable'] = True
+            if field.default and field.default != empty:
+                schema['default'] = field.default
+            if field.help_text:
+                # Ensure django gettext_lazy is rendered correctly
+                schema['description'] = str(field.help_text)
+            self.map_field_validators(field, schema)
+
+            attributes[field.field_name] = schema
+
+        result = {
+            'type': 'object',
+            'required': ['type', 'id'],
+            'additionalProperties': False,
+            'properties': {
+                'type': {'$ref': '#/components/schemas/type'},
+                'id': {'$ref': '#/components/schemas/id'},
+                'links': {
+                    'type': 'object',
+                    'properties': {
+                        'self': {'$ref': '#/components/schemas/link'}
+                    }
+                }
+            }
+        }
+        if attributes:
+            result['properties']['attributes'] = {
+                'type': 'object',
+                'properties': attributes
+            }
+            if required:
+                result['properties']['attributes']['required'] = required
+
+        if relationships:
+            result['properties']['relationships'] = {
+                'type': 'object',
+                'properties': relationships
+            }
+        return result
+
+    def _add_async_response(self, operation):
+        operation['responses']['202'] = {
+            'description': 'Accepted for [asynchronous processing]'
+                           '(https://jsonapi.org/recommendations/#asynchronous-processing)',
+            'content': {
+                'application/vnd.api+json': {
+                    'schema': {'$ref': '#/components/schemas/datum'}
+                }
+            }
+        }
+
+    def _failure_response(self, reason):
+        return {
+            'description': reason,
+            'content': {
+                'application/vnd.api+json': {
+                    'schema': {'$ref': '#/components/schemas/failure'}
+                }
+            }
+        }
+
+    def _generic_failure_responses(self, operation):
+        for code, reason in [('401', 'not authorized'), ]:
+            operation['responses'][code] = self._failure_response(reason)
+
+    def _add_get_4xx_responses(self, operation):
+        """ Add generic responses for get """
+        self._generic_failure_responses(operation)
+        for code, reason in [('404', 'not found')]:
+            operation['responses'][code] = self._failure_response(reason)
+
+    def _add_post_4xx_responses(self, operation):
+        """ Add error responses for post """
+        self._generic_failure_responses(operation)
+        for code, reason in [
+            ('403', '[Forbidden](https://jsonapi.org/format/#crud-creating-responses-403)'),
+            ('404', '[Related resource does not exist]'
+                    '(https://jsonapi.org/format/#crud-creating-responses-404)'),
+            ('409', '[Conflict](https://jsonapi.org/format/#crud-creating-responses-409)'),
+        ]:
+            operation['responses'][code] = self._failure_response(reason)
+
+    def _add_patch_4xx_responses(self, operation):
+        """ Add error responses for patch """
+        self._generic_failure_responses(operation)
+        for code, reason in [
+            ('403', '[Forbidden](https://jsonapi.org/format/#crud-updating-responses-403)'),
+            ('404', '[Related resource does not exist]'
+                    '(https://jsonapi.org/format/#crud-updating-responses-404)'),
+            ('409', '[Conflict]([Conflict]'
+                    '(https://jsonapi.org/format/#crud-updating-responses-409)'),
+        ]:
+            operation['responses'][code] = self._failure_response(reason)
+
+    def _add_delete_responses(self, operation):
+        """ Add generic responses for delete """
+        # the 2xx statuses:
+        operation['responses'] = {
+            '200': {
+                'description': '[OK](https://jsonapi.org/format/#crud-deleting-responses-200)',
+                'content': {
+                    'application/vnd.api+json': {
+                        'schema': {'$ref': '#/components/schemas/onlymeta'}
+                    }
+                }
+            }
+        }
+        self._add_async_response(operation)
+        operation['responses']['204'] = {
+            'description': '[no content](https://jsonapi.org/format/#crud-deleting-responses-204)',
+        }
+        # the 4xx errors:
+        self._generic_failure_responses(operation)
+        for code, reason in [
+            ('404', '[Resource does not exist]'
+                    '(https://jsonapi.org/format/#crud-deleting-responses-404)'),
+        ]:
+            operation['responses'][code] = self._failure_response(reason)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ exclude =
     .tox,
     env
     .venv
-    example/tests/snapshots
 
 [isort]
 indent = 4

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ exclude =
     .tox,
     env
     .venv
+    example/tests/snapshots
 
 [isort]
 indent = 4

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,8 @@ setup(
     ],
     extras_require={
         'django-polymorphic': ['django-polymorphic>=2.0'],
-        'django-filter': ['django-filter>=2.0']
+        'django-filter': ['django-filter>=2.0'],
+        'openapi': ['pyyaml>=5.3', 'uritemplate>=3.0.1']
     },
     setup_requires=wheel,
     python_requires=">=3.6",


### PR DESCRIPTION
Fixes #604
Fixes #644 

## Description of the Change

Extends DRF >= 3.12's generateschema to produce a jsonapi-formatted OAS schema document.
Builds on @n2ygk's work in https://github.com/django-json-api/django-rest-framework-json-api/pull/689
- Updated to latest DJA version

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
