### PR TITLE
Reimplement SerializerMethodResourceRelatedField

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ Nathanael Gordon <nathanael.l.gordon@gmail.com>
 Charlie Allatson <charles.allatson@gmail.com>
 Joseba Mendivil <git@jma.email>
 Felix Viernickel <felix@gedankenspieler.org>
+Tom Glowka <glowka.tom@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Avoid `AttributeError` for PUT and PATCH methods when using `APIView` 
 
+### Changed
+
+* `SerializerMethodResourceRelatedField` is now consistent with DRF `SerializerMethodField`:
+   * Pass `method_name` argument to specify method name. If no value is provided, it defaults to `get_{field_name}`
+
+### Deprecated
+
+* Deprecate `source` argument of `SerializerMethodResourceRelatedField`, use `method_name` instead
+
+
 ## [3.1.0] - 2020-02-08
 
 ### Added

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -586,9 +586,67 @@ class LineItemViewSet(viewsets.ModelViewSet):
 
 #### HyperlinkedRelatedField
 
-`HyperlinkedRelatedField` has same functionality as `ResourceRelatedField` but does
+`relations.HyperlinkedRelatedField` has same functionality as `ResourceRelatedField` but does
 not render `data`. Use this in case you only need links of relationships and want to lower payload
 and increase performance.
+
+#### SerializerMethodResourceRelatedField
+
+`relations.SerializerMethodResourceRelatedField` combines behaviour of DRF `SerializerMethodField` and 
+`ResourceRelatedField`, so it accepts `method_name` together with `model` and links-related arguments.
+`data` is rendered in `ResourceRelatedField` manner.
+
+```python
+from rest_framework_json_api import serializers
+from rest_framework_json_api.relations import SerializerMethodResourceRelatedField
+
+from myapp.models import Order, LineItem
+
+
+class OrderSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Order
+
+    line_items = SerializerMethodResourceRelatedField(
+        model=LineItem,
+        many=True,
+        method_name='get_big_line_items'
+    )
+
+    small_line_items = SerializerMethodResourceRelatedField(
+        model=LineItem,
+        many=True,
+        # default to method_name='get_small_line_items'
+    )
+
+    def get_big_line_items(self, instance):
+        return LineItem.objects.filter(order=instance).filter(amount__gt=1000)
+
+    def get_small_line_items(self, instance):
+        return LineItem.objects.filter(order=instance).filter(amount__lte=1000)
+
+```
+
+or using `related_link_*` with `HyperlinkedModelSerializer`
+
+```python
+class OrderSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Order
+
+    line_items = SerializerMethodResourceRelatedField(
+        model=LineItem,
+        many=True,
+        method_name='get_big_line_items',
+        related_link_view_name='order-lineitems-list',
+        related_link_url_kwarg='order_pk',
+    )
+
+    def get_big_line_items(self, instance):
+        return LineItem.objects.filter(order=instance).filter(amount__gt=1000)
+
+```
+
 
 #### Related urls
 

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -126,30 +126,24 @@ class EntrySerializer(serializers.ModelSerializer):
         related_link_view_name='entry-suggested',
         related_link_url_kwarg='entry_pk',
         self_link_view_name='entry-relationships',
-        source='get_suggested',
         model=Entry,
         many=True,
-        read_only=True
     )
     # many related hyperlinked from serializer
     suggested_hyperlinked = relations.SerializerMethodHyperlinkedRelatedField(
         related_link_view_name='entry-suggested',
         related_link_url_kwarg='entry_pk',
         self_link_view_name='entry-relationships',
-        source='get_suggested',
         model=Entry,
         many=True,
-        read_only=True
     )
     # single related from serializer
-    featured = relations.SerializerMethodResourceRelatedField(
-        source='get_featured', model=Entry, read_only=True)
+    featured = relations.SerializerMethodResourceRelatedField(model=Entry)
     # single related hyperlinked from serializer
     featured_hyperlinked = relations.SerializerMethodHyperlinkedRelatedField(
         related_link_view_name='entry-featured',
         related_link_url_kwarg='entry_pk',
         self_link_view_name='entry-relationships',
-        source='get_featured',
         model=Entry,
         read_only=True
     )
@@ -229,8 +223,6 @@ class AuthorSerializer(serializers.ModelSerializer):
         related_link_view_name='author-related',
         self_link_view_name='author-relationships',
         model=Entry,
-        read_only=True,
-        source='get_first_entry'
     )
     comments = relations.HyperlinkedRelatedField(
         related_link_view_name='author-related',

--- a/example/tests/test_parsers.py
+++ b/example/tests/test_parsers.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from django.conf.urls import url
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from rest_framework import views, status
+from rest_framework import status, views
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 from rest_framework.test import APITestCase

--- a/example/tests/test_relations.py
+++ b/example/tests/test_relations.py
@@ -290,16 +290,12 @@ class EntryModelSerializerWithHyperLinks(serializers.ModelSerializer):
         related_link_url_kwarg='entry_pk',
         self_link_view_name='entry-relationships',
         many=True,
-        read_only=True,
-        source='get_blog'
     )
     comments = SerializerMethodHyperlinkedRelatedField(
         related_link_view_name='entry-comments',
         related_link_url_kwarg='entry_pk',
         self_link_view_name='entry-relationships',
         many=True,
-        read_only=True,
-        source='get_comments'
     )
 
     class Meta:

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -7,21 +7,17 @@ from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
-from example.factories import ArtProjectFactory
 from rest_framework_json_api.serializers import (
     DateField,
     ModelSerializer,
     ResourceIdentifierObjectSerializer,
-    empty,
+    empty
 )
 from rest_framework_json_api.utils import format_resource_type
 
+from example.factories import ArtProjectFactory
 from example.models import Author, Blog, Entry
-from example.serializers import (
-    BlogSerializer,
-    ProjectSerializer,
-    ArtProjectSerializer,
-)
+from example.serializers import ArtProjectSerializer, BlogSerializer, ProjectSerializer
 
 request_factory = APIRequestFactory()
 pytestmark = pytest.mark.django_db

--- a/example/tests/unit/test_serializer_method_field.py
+++ b/example/tests/unit/test_serializer_method_field.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import
+
+import pytest
+from rest_framework import serializers
+
+from rest_framework_json_api.relations import SerializerMethodResourceRelatedField
+
+from example.models import Blog, Entry
+
+
+def test_method_name_default():
+    class BlogSerializer(serializers.ModelSerializer):
+        one_entry = SerializerMethodResourceRelatedField(model=Entry)
+
+        class Meta:
+            model = Blog
+            fields = ['one_entry']
+
+        def get_one_entry(self, instance):
+            return Entry(id=100)
+
+    serializer = BlogSerializer(instance=Blog())
+    assert serializer.data['one_entry']['id'] == '100'
+
+
+def test_method_name_custom():
+    class BlogSerializer(serializers.ModelSerializer):
+        one_entry = SerializerMethodResourceRelatedField(
+            model=Entry,
+            method_name='get_custom_entry'
+        )
+
+        class Meta:
+            model = Blog
+            fields = ['one_entry']
+
+        def get_custom_entry(self, instance):
+            return Entry(id=100)
+
+    serializer = BlogSerializer(instance=Blog())
+    assert serializer.data['one_entry']['id'] == '100'
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_source():
+    class BlogSerializer(serializers.ModelSerializer):
+        one_entry = SerializerMethodResourceRelatedField(
+            model=Entry,
+            source='get_custom_entry'
+        )
+
+        class Meta:
+            model = Blog
+            fields = ['one_entry']
+
+        def get_custom_entry(self, instance):
+            return Entry(id=100)
+
+    serializer = BlogSerializer(instance=Blog())
+    assert serializer.data['one_entry']['id'] == '100'
+
+
+@pytest.mark.filterwarnings("error::DeprecationWarning")
+def test_source_is_deprecated():
+    with pytest.raises(DeprecationWarning):
+        SerializerMethodResourceRelatedField(model=Entry, source='get_custom_entry')


### PR DESCRIPTION
## Description of the Change

Fixes #639 - interface not consistent with `SerializerMethodField`
Fixes #779 - no enforcement of `read_only`
Fixes #780 - broken `parent` chain

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
