### PR TITLE
Clear m2m relationships instead of deleting related objects during PATCH

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ Ola Tarkowska <ola@red-aries.com>
 Oliver Sauder <os@esite.ch>
 Raphael Cohen <raphael.cohen.utt@gmail.com>
 Roberto Barreda <roberto.barreda@gmail.com>
+Rohith PR <praroh2@gmail.com>
 santiavenda <santiavenda2@gmail.com>
 Tim Selman <timcbaoth@gmail.com>
 Yaniv Peer <yanivpeer@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Fixed
 
 * Avoid `AttributeError` for PUT and PATCH methods when using `APIView`
+* Clear many-to-many relationships instead of deleting related objects during PATCH on `RelationshipView`
 
 ### Changed
 

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -135,6 +135,7 @@ class TestRelationshipView(APITestCase):
         response = self.client.get(url)
         assert response.data == request_data['data']
 
+        # retry a second time should end up with same result
         response = self.client.patch(url, data=request_data)
         assert response.status_code == 200, response.content.decode()
         assert response.data == request_data['data']
@@ -159,6 +160,7 @@ class TestRelationshipView(APITestCase):
         response = self.client.get(url)
         assert response.data == request_data['data']
 
+        # retry a second time should end up with same result
         response = self.client.patch(url, data=request_data)
         assert response.status_code == 200, response.content.decode()
         assert response.data == request_data['data']

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -135,6 +135,13 @@ class TestRelationshipView(APITestCase):
         response = self.client.get(url)
         assert response.data == request_data['data']
 
+        response = self.client.patch(url, data=request_data)
+        assert response.status_code == 200, response.content.decode()
+        assert response.data == request_data['data']
+
+        response = self.client.get(url)
+        assert response.data == request_data['data']
+
     def test_patch_many_to_many_relationship(self):
         url = '/entries/{}/relationships/authors'.format(self.first_entry.id)
         request_data = {

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -143,6 +143,18 @@ class TestRelationshipView(APITestCase):
         response = self.client.get(url)
         assert response.data == request_data['data']
 
+    def test_patch_one_to_many_relaitonship_with_none(self):
+        url = '/blogs/{}/relationships/entry_set'.format(self.first_entry.id)
+        request_data = {
+            'data': None
+        }
+        response = self.client.patch(url, data=request_data)
+        assert response.status_code == 200, response.content.decode()
+        assert response.data == []
+
+        response = self.client.get(url)
+        assert response.data == []
+
     def test_patch_many_to_many_relationship(self):
         url = '/entries/{}/relationships/authors'.format(self.first_entry.id)
         request_data = {

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -152,6 +152,13 @@ class TestRelationshipView(APITestCase):
         response = self.client.get(url)
         assert response.data == request_data['data']
 
+        response = self.client.patch(url, data=request_data)
+        assert response.status_code == 200, response.content.decode()
+        assert response.data == request_data['data']
+
+        response = self.client.get(url)
+        assert response.data == request_data['data']
+
     def test_post_to_one_relationship_should_fail(self):
         url = '/entries/{}/relationships/blog'.format(self.first_entry.id)
         request_data = {

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -286,6 +286,8 @@ class RelationshipView(generics.GenericAPIView):
             for obj in instance_manager.all():
                 setattr(obj, field_object.name, None)
                 obj.save()
+        elif hasattr(instance_manager, 'clear'):
+            instance_manager.clear()
         else:
             instance_manager.all().delete()
 


### PR DESCRIPTION
## Description of the Change

Calling PATCH on an M2M RelationshipView when there were already some relationships was breaking. This was because the related objects were being deleted instead of just clearing the relationship and starting afresh.

Fixes #784
Fixes #244 

Manual testing proof: 
<img width="1383" alt="image" src="https://user-images.githubusercontent.com/10276811/81935827-c34c6c80-95e0-11ea-925e-90636ba21e84.png">


## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
