### PR TITLE
Replace old setting reference in documentation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -370,7 +370,7 @@ Example - With format conversion set to `dasherize`:
 
 #### Types
 
-A similar option to JSON\_API\_FORMAT\_KEYS can be set for the types:
+A similar option to `JSON_API_FORMAT_FIELD_NAMES` can be set for the types:
 
 ``` python
 JSON_API_FORMAT_TYPES = 'dasherize'


### PR DESCRIPTION
## Description of the Change

`FORMAT_KEYS` has been removed in version 3.0 and only
setting `JSON_API_FORMAT_FIELD_NAMES` is now available.

## Checklist

- [ ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
