### PR TITLE
Allow POST, PATCH, DELETE for custom actions in ReadOnlyModelViewSet

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,6 +19,7 @@ Raphael Cohen <raphael.cohen.utt@gmail.com>
 Roberto Barreda <roberto.barreda@gmail.com>
 Rohith PR <praroh2@gmail.com>
 santiavenda <santiavenda2@gmail.com>
+Sergey Kolomenkin <https://kolomenkin.com>
 Tim Selman <timcbaoth@gmail.com>
 Yaniv Peer <yanivpeer@gmail.com>
 Mohammed Ali Zubair <mazg1493@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Avoid `AttributeError` for PUT and PATCH methods when using `APIView`
 * Clear many-to-many relationships instead of deleting related objects during PATCH on `RelationshipView`
+* Allow POST, PATCH, DELETE for actions in `ReadOnlyModelViewSet`. It was problematic since 2.8.0.
 
 ### Changed
 

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -210,7 +210,7 @@ class ModelViewSet(AutoPrefetchMixin,
 class ReadOnlyModelViewSet(AutoPrefetchMixin,
                            RelatedMixin,
                            viewsets.ReadOnlyModelViewSet):
-    http_method_names = ['get', 'head', 'options']
+    http_method_names = ['get', 'post', 'patch', 'delete', 'head', 'options']
 
 
 class RelationshipView(generics.GenericAPIView):


### PR DESCRIPTION
Allow POST, PATCH, DELETE for actions in ReadOnlyModelViewSet (#797)

Currently if you try to use `POST` for action in `ReadOnlyModelViewSet` you will get problems:
- with DRF UI you will loose data input forms
- `drf_yasg` package will not generate OpenAPI specifications for such actions

This behavior was added to `django-rest-framework-json-api` in version 2.8.0 by mistake:

Commit: 7abd7649bff7116b8c23087b8fda3ea9b5bd38d6
Subject: remove disallowed PUT method. (#643)

=========================
@n2ygk, please review my PR because I'm changing your code from commit 7abd7649bff7116b8c23087b8fda3ea9b5bd38d6.
