### PR TITLE
workaround docs failure by requiring old Django

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ commands = flake8
 [testenv:docs]
 basepython = python3.6
 deps =
+     Django>=2.2,<3.0
     -rrequirements/requirements-testing.txt
     -rrequirements/requirements-optionals.txt
     -rrequirements/requirements-documentation.txt


### PR DESCRIPTION
Fixes #803

## Description of the Change

Works around `tox -e docs` failure by forcing old version of Django (<3.0).

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
