### PR TITLE
Install DJA locally within requirements context

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ installed and activated:
 
     $ git clone https://github.com/django-json-api/django-rest-framework-json-api.git
     $ cd django-rest-framework-json-api
-    $ pip install -U -e . -r requirements.txt
+    $ pip install -Ur requirements.txt
     $ django-admin migrate --settings=example.settings
     $ django-admin loaddata drf_example --settings=example.settings
     $ django-admin runserver --settings=example.settings

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,7 +77,7 @@ From Source
 	cd django-rest-framework-json-api
 	python3 -m venv env
 	source env/bin/activate
-	pip install -U -e . r requirements.txt
+	pip install -Ur requirements.txt
 	django-admin migrate --settings=example.settings
 	django-admin loaddata drf_example --settings=example.settings
 	django-admin runserver --settings=example.settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,10 @@
 # there are a number of packages that are useful to install.
 
 # Laying these out as separate requirements files, allows us to
-# only included the relevant sets when running tox, and ensures
+# only include the relevant sets when running tox, and ensures
 # we are only ever declaring our dependencies in one place.
 
+-e .
 -r requirements/requirements-optionals.txt
 -r requirements/requirements-testing.txt
 -r requirements/requirements-documentation.txt


### PR DESCRIPTION
## Description of the Change

This resolves issue that ReadTheDocs uses setup.py and requirements.txt separately. Resolves [build error](https://readthedocs.org/projects/django-rest-framework-json-api/builds/11687758/)

Additionally is it now easier to run test without running several pip installs.

## Checklist

- [ ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
