### PR TITLE
Remove global ignore of serializer warnings

### DIFF
--- a/example/serializers.py
+++ b/example/serializers.py
@@ -40,9 +40,9 @@ class TaggedItemDRFSerializer(drf_serilazers.ModelSerializer):
 
 class BlogSerializer(serializers.ModelSerializer):
     copyright = serializers.SerializerMethodField()
-    tags = TaggedItemSerializer(many=True, read_only=True)
+    tags = relations.ResourceRelatedField(many=True, read_only=True)
 
-    include_serializers = {
+    included_serializers = {
         'tags': 'example.serializers.TaggedItemSerializer',
     }
 
@@ -147,7 +147,7 @@ class EntrySerializer(serializers.ModelSerializer):
         model=Entry,
         read_only=True
     )
-    tags = TaggedItemSerializer(many=True, read_only=True)
+    tags = relations.ResourceRelatedField(many=True, read_only=True)
 
     def get_suggested(self, obj):
         return Entry.objects.exclude(pk=obj.pk)

--- a/example/settings/dev.py
+++ b/example/settings/dev.py
@@ -67,6 +67,7 @@ INTERNAL_IPS = ('127.0.0.1', )
 
 JSON_API_FORMAT_FIELD_NAMES = 'camelize'
 JSON_API_FORMAT_TYPES = 'camelize'
+JSON_API_SERIALIZE_NESTED_SERIALIZERS_AS_ATTRIBUTE = True
 REST_FRAMEWORK = {
     'PAGE_SIZE': 5,
     'EXCEPTION_HANDLER': 'rest_framework_json_api.exceptions.exception_handler',

--- a/example/tests/integration/test_meta.py
+++ b/example/tests/integration/test_meta.py
@@ -18,11 +18,7 @@ def test_top_level_meta_for_list_view(blog, client):
             "links": {
                 "self": 'http://testserver/blogs/1'
             },
-            "relationships": {
-                "tags": {
-                    "data": []
-                }
-            },
+            'relationships': {'tags': {'data': [], 'meta': {'count': 0}}},
             "meta": {
                 "copyright": datetime.now().year
             },
@@ -53,11 +49,7 @@ def test_top_level_meta_for_detail_view(blog, client):
             "attributes": {
                 "name": blog.name
             },
-            "relationships": {
-                "tags": {
-                    "data": []
-                }
-            },
+            'relationships': {'tags': {'data': [], 'meta': {'count': 0}}},
             "links": {
                 "self": "http://testserver/blogs/1"
             },

--- a/example/tests/integration/test_non_paginated_responses.py
+++ b/example/tests/integration/test_non_paginated_responses.py
@@ -72,9 +72,7 @@ def test_multiple_entries_no_pagination(multiple_entries, client):
                             "self": "http://testserver/entries/1/relationships/featured_hyperlinked"
                         }
                     },
-                    "tags": {
-                        "data": []
-                    }
+                    'tags': {'data': [], 'meta': {'count': 0}},
                 }
             },
             {
@@ -135,9 +133,7 @@ def test_multiple_entries_no_pagination(multiple_entries, client):
                             "self": "http://testserver/entries/2/relationships/featured_hyperlinked"
                         }
                     },
-                    "tags": {
-                        "data": []
-                    }
+                    'tags': {'data': [], 'meta': {'count': 0}},
                 }
             },
         ]

--- a/example/tests/integration/test_pagination.py
+++ b/example/tests/integration/test_pagination.py
@@ -73,6 +73,7 @@ def test_pagination_with_single_entry(single_entry, client):
                         }
                     },
                     "tags": {
+                        'meta': {'count': 1},
                         "data": [
                             {
                                 "id": "1",

--- a/example/tests/test_filters.py
+++ b/example/tests/test_filters.py
@@ -461,9 +461,7 @@ class DJATestFilters(APITestCase):
                                 'self': 'http://testserver/entries/7/relationships/suggested_hyperlinked',  # noqa: E501
                                 'related': 'http://testserver/entries/7/suggested/'}
                         },
-                        'tags': {
-                            'data': []
-                        },
+                        'tags': {'data': [], 'meta': {'count': 0}},
                         'featuredHyperlinked': {
                             'links': {
                                 'self': 'http://testserver/entries/7/relationships/featured_hyperlinked',  # noqa: E501

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -45,7 +45,7 @@ class TestResourceIdentifierObjectSerializer(TestCase):
             )
 
     def test_forward_relationship_not_loaded_when_not_included(self):
-        to_representation_method = 'example.serializers.BlogSerializer.to_representation'
+        to_representation_method = 'example.serializers.TaggedItemSerializer.to_representation'
         with mock.patch(to_representation_method) as mocked_serializer:
             class EntrySerializer(ModelSerializer):
                 blog = BlogSerializer()
@@ -79,7 +79,12 @@ class TestResourceIdentifierObjectSerializer(TestCase):
         expected = dict(
             [
                 ('id', 1),
-                ('blog', dict([('type', 'blogs'), ('id', 1)])),
+                ('blog', dict([
+                    ('name', 'Some Blog'),
+                    ('tags', []),
+                    ('copyright', 2020),
+                    ('url', 'http://testserver/blogs/1')
+                ])),
                 ('headline', 'headline'),
                 ('body_text', 'body_text'),
                 ('pub_date', DateField().to_representation(self.entry.pub_date)),

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -538,7 +538,7 @@ class TestBlogViewSet(APITestCase):
                 'id': '{}'.format(self.blog.id),
                 'links': {'self': 'http://testserver/blogs/{}'.format(self.blog.id)},
                 'meta': {'copyright': datetime.now().year},
-                'relationships': {'tags': {'data': []}},
+                'relationships': {'tags': {'data': [], 'meta': {'count': 0}}},
                 'type': 'blogs'
             },
             'meta': {'apiDocs': '/docs/api/blogs'}
@@ -632,7 +632,7 @@ class TestEntryViewSet(APITestCase):
                                     '/suggested_hyperlinked'.format(self.second_entry.id)
                         }
                     },
-                    'tags': {'data': []}},
+                    'tags': {'data': [], 'meta': {'count': 0}}},
                 'type': 'posts'
             }
         }

--- a/example/tests/unit/test_default_drf_serializers.py
+++ b/example/tests/unit/test_default_drf_serializers.py
@@ -95,11 +95,10 @@ def test_blog_create(client):
 
     expected = {
         'data': {
-            'attributes': {'name': blog.name},
+            'attributes': {'name': blog.name, 'tags': []},
             'id': '{}'.format(blog.id),
             'links': {'self': 'http://testserver/blogs/{}'.format(blog.id)},
             'meta': {'copyright': datetime.now().year},
-            'relationships': {'tags': {'data': []}},
             'type': 'blogs'
         },
         'meta': {'apiDocs': '/docs/api/blogs'}
@@ -116,11 +115,10 @@ def test_get_object_gives_correct_blog(client, blog, entry):
     resp = client.get(url)
     expected = {
         'data': {
-            'attributes': {'name': blog.name},
+            'attributes': {'name': blog.name, 'tags': []},
             'id': '{}'.format(blog.id),
             'links': {'self': 'http://testserver/blogs/{}'.format(blog.id)},
             'meta': {'copyright': datetime.now().year},
-            'relationships': {'tags': {'data': []}},
             'type': 'blogs'
         },
         'meta': {'apiDocs': '/docs/api/blogs'}
@@ -154,11 +152,10 @@ def test_get_object_patches_correct_blog(client, blog, entry):
 
     expected = {
         'data': {
-            'attributes': {'name': new_name},
+            'attributes': {'name': new_name, 'tags': []},
             'id': '{}'.format(blog.id),
             'links': {'self': 'http://testserver/blogs/{}'.format(blog.id)},
             'meta': {'copyright': datetime.now().year},
-            'relationships': {'tags': {'data': []}},
             'type': 'blogs'
         },
         'meta': {'apiDocs': '/docs/api/blogs'}
@@ -189,17 +186,14 @@ def test_get_entry_list_with_blogs(client, entry):
             'first': 'http://testserver/drf-entries/1/suggested/?page%5Bnumber%5D=1',
             'last': 'http://testserver/drf-entries/1/suggested/?page%5Bnumber%5D=1',
             'next': None,
-            'prev': None
+            'prev': None,
         },
         'data': [
             {
                 'type': 'entries',
                 'id': '1',
-                'attributes': {},
-                'relationships': {
-                    'tags': {
-                        'data': []
-                    }
+                'attributes': {
+                    'tags': [],
                 },
                 'links': {
                     'self': 'http://testserver/drf-blogs/1'

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,3 @@ DJANGO_SETTINGS_MODULE=example.settings.test
 filterwarnings =
     error::DeprecationWarning
     error::PendingDeprecationWarning
-    ignore::DeprecationWarning:rest_framework_json_api.serializers


### PR DESCRIPTION
## Description of the Change

Deprecation warnings should not be suppressed globally but instead test code be adjusted to new default behavior.

Cleanup of #776 

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
