### PR TITLE
django >=2.2, <=3.1 (drops 1.11)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
     - env: TOXENV=py36-django30-drfmaster
     - env: TOXENV=py37-django30-drfmaster
     - env: TOXENV=py38-django30-drfmaster
+    - env: TOXENV=py36-django31-drfmaster
+    - env: TOXENV=py37-django31-drfmaster
+    - env: TOXENV=py38-django31-drfmaster
 
   include:
     - python: 3.6
@@ -65,6 +68,10 @@ matrix:
       env: TOXENV=py36-django30-drf311
     - python: 3.6
       env: TOXENV=py36-django30-drfmaster
+    - python: 3.6
+      env: TOXENV=py36-django31-drf311
+    - python: 3.6
+      env: TOXENV=py36-django31-drfmaster
 
     - python: 3.7
       env: TOXENV=py37-django21-drf310
@@ -82,6 +89,10 @@ matrix:
       env: TOXENV=py37-django30-drf311
     - python: 3.7
       env: TOXENV=py37-django30-drfmaster
+    - python: 3.7
+      env: TOXENV=py37-django31-drf311
+    - python: 3.7
+      env: TOXENV=py37-django31-drfmaster
 
     - python: 3.8
       env: TOXENV=py38-django22-drf311
@@ -91,6 +102,10 @@ matrix:
       env: TOXENV=py38-django30-drf311
     - python: 3.8
       env: TOXENV=py38-django30-drfmaster
+    - python: 3.8
+      env: TOXENV=py38-django31-drf311
+    - python: 3.8
+      env: TOXENV=py38-django31-drfmaster
 
 install:
   - pip install tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST Framework policy](http://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
+## [Unreleased]
+
+### Added
+* Added support for Django 3.1
+
 ## [3.2.0] - 2020-08-26
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -84,14 +84,15 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=[
         'inflection>=0.3.0',
-        'djangorestframework>=3.10,<3.12',
-        'django>=1.11,<3.1',
+        'djangorestframework>=3.10,<3.13',
+        'django>=1.11,<3.2',
     ],
     extras_require={
         'django-polymorphic': ['django-polymorphic>=2.0'],

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{35,36}-django{111}-drf{310,311,master},
     py{35,36,37}-django{21,22}-drf{310,311,master},
     py38-django22-drf{311,master},
-    py{36,37,38}-django{30}-drf{311,master},
+    py{36,37,38}-django{30,31}-drf{311,master},
     lint,docs
 
 [testenv]
@@ -12,6 +12,7 @@ deps =
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
     drf310: djangorestframework>=3.10.2,<3.11
     drf311: djangorestframework>=3.11,<3.12
     drfmaster: https://github.com/encode/django-rest-framework/archive/master.zip


### PR DESCRIPTION
Fixes #822, #803

## Description of the Change

Remove Django 1.11 from and add Django 3.1 to test matrix, setup.py

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
