### PR TITLE
Correctly document JSON API ids as string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ like the following::
         },
         "data": [{
             "type": "identities",
-            "id": 3,
+            "id": "3",
             "attributes": {
                 "username": "john",
                 "full-name": "John Coltrane"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ like the following:
     },
     "data": [{
         "type": "identities",
-        "id": 3,
+        "id": "3",
         "attributes": {
             "username": "john",
             "full-name": "John Coltrane"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -338,7 +338,7 @@ Example - Without format conversion:
 {
     "data": [{
         "type": "identities",
-        "id": 3,
+        "id": "3",
         "attributes": {
             "username": "john",
             "first_name": "John",
@@ -359,7 +359,7 @@ Example - With format conversion set to `dasherize`:
 {
     "data": [{
         "type": "identities",
-        "id": 3,
+        "id": "3",
         "attributes": {
             "username": "john",
             "first-name": "John",
@@ -389,7 +389,7 @@ Example without format conversion:
 {
 	"data": [{
         "type": "blog_identity",
-        "id": 3,
+        "id": "3",
         "attributes": {
                 ...
         },
@@ -412,7 +412,7 @@ When set to dasherize:
 {
 	"data": [{
         "type": "blog-identity",
-        "id": 3,
+        "id": "3",
         "attributes": {
                 ...
         },
@@ -438,7 +438,7 @@ Example without pluralization:
 {
 	"data": [{
         "type": "identity",
-        "id": 3,
+        "id": "3",
         "attributes": {
                 ...
         },
@@ -446,7 +446,7 @@ Example without pluralization:
             "home_towns": {
                 "data": [{
                     "type": "home_town",
-                    "id": 3
+                    "id": "3"
                 }]
             }
         }
@@ -461,7 +461,7 @@ When set to pluralize:
 {
 	"data": [{
         "type": "identities",
-        "id": 3,
+        "id": "3",
         "attributes": {
                 ...
         },
@@ -469,7 +469,7 @@ When set to pluralize:
             "home_towns": {
                 "data": [{
                     "type": "home_towns",
-                    "id": 3
+                    "id": "3"
                 }]
             }
         }

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -33,7 +33,7 @@ class JSONRenderer(renderers.JSONRenderer):
           "data": [
             {
               "type": "companies",
-              "id": 1,
+              "id": "1",
               "attributes": {
                 "name": "Mozilla",
                 "slug": "mozilla",


### PR DESCRIPTION
Fixes #818 

## Description of the Change

Correctly document JSON API ids as string

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
