### PR TITLE
Clarify issue in changelog through introduction of new Serializer class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Added
 
 * Added support for serializing nested serializers as attribute json value introducing setting `JSON_API_SERIALIZE_NESTED_SERIALIZERS_AS_ATTRIBUTE`
- * Note: As keys of nested serializers are not json api spec field names they are not inflected by format field names option.
+ * Note: As keys of nested serializers are not json:api spec field names they are not inflected by format field names option.
+* Added `rest_framework_json_api.serializer.Serializer` class to support initial JSON API views without models.
+  * Note that serializers derived from this class need to define `resource_name` in their `Meta` class.
+  * This fix might be a **BREAKING CHANGE** if you use `rest_framework_json_api.serializers.Serializer` for non json:api spec views (usually `APIView`). You need to change those serializers classes to use `rest_framework.serializers.Serializer` instead.
 
 ### Fixed
 


### PR DESCRIPTION
Fixes #821 

## Description of the Change

Clarify potential issue in changelog through introduction of `rest_framework_json_api.serializers.Serializer` class.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
