### PR TITLE
Drop support for Django 1.11 and 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ cache: pip
 # Favor explicit over implicit and use an explicit build matrix.
 matrix:
   allow_failures:
-    - env: TOXENV=py35-django111-drfmaster
-    - env: TOXENV=py36-django111-drfmaster
-    - env: TOXENV=py35-django21-drfmaster
-    - env: TOXENV=py36-django21-drfmaster
-    - env: TOXENV=py37-django21-drfmaster
     - env: TOXENV=py35-django22-drfmaster
     - env: TOXENV=py36-django22-drfmaster
     - env: TOXENV=py37-django22-drfmaster
@@ -25,36 +20,12 @@ matrix:
       env: TOXENV=docs
 
     - python: 3.5
-      env: TOXENV=py35-django111-drf310
-    - python: 3.5
-      env: TOXENV=py35-django111-drf311
-    - python: 3.5
-      env: TOXENV=py35-django111-drfmaster
-    - python: 3.5
-      env: TOXENV=py35-django21-drf310
-    - python: 3.5
-      env: TOXENV=py35-django21-drf311
-    - python: 3.5
-      env: TOXENV=py35-django21-drfmaster
-    - python: 3.5
       env: TOXENV=py35-django22-drf310
     - python: 3.5
       env: TOXENV=py35-django22-drf311
     - python: 3.5
       env: TOXENV=py35-django22-drfmaster
 
-    - python: 3.6
-      env: TOXENV=py36-django111-drf310
-    - python: 3.6
-      env: TOXENV=py36-django111-drf311
-    - python: 3.6
-      env: TOXENV=py36-django111-drfmaster
-    - python: 3.6
-      env: TOXENV=py36-django21-drf310
-    - python: 3.6
-      env: TOXENV=py36-django21-drf311
-    - python: 3.6
-      env: TOXENV=py36-django21-drfmaster
     - python: 3.6
       env: TOXENV=py36-django22-drf310
     - python: 3.6
@@ -66,12 +37,6 @@ matrix:
     - python: 3.6
       env: TOXENV=py36-django30-drfmaster
 
-    - python: 3.7
-      env: TOXENV=py37-django21-drf310
-    - python: 3.7
-      env: TOXENV=py37-django21-drf311
-    - python: 3.7
-      env: TOXENV=py37-django21-drfmaster
     - python: 3.7
       env: TOXENV=py37-django22-drf310
     - python: 3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST Framework policy](http://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
+## [Unreleased]
+
+### Removed
+
+* Removed support for Django 1.11.
+* Removed support for Django 2.1.
+
 ## [3.2.0] - 2020-08-26
+
+This is the last release supporting Django 1.11 and Django 2.1.
 
 ### Added
 

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Requirements
 ------------
 
 1. Python (3.5, 3.6, 3.7, 3.8)
-2. Django (1.11, 2.1, 2.2, 3.0)
+2. Django (2.2, 3.0)
 3. Django REST Framework (3.10, 3.11)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST Framework series.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ like the following:
 ## Requirements
 
 1. Python (3.5, 3.6, 3.7, 3.8)
-2. Django (1.11, 2.1, 2.2, 3.0)
+2. Django (2.2, 3.0)
 3. Django REST Framework (3.10, 3.11)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST Framework series.

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
     install_requires=[
         'inflection>=0.3.0',
         'djangorestframework>=3.10,<3.12',
-        'django>=1.11,<3.1',
+        'django>=2.2,<3.1',
     ],
     extras_require={
         'django-polymorphic': ['django-polymorphic>=2.0'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,12 @@
 [tox]
 envlist =
-    py{35,36}-django{111}-drf{310,311,master},
-    py{35,36,37}-django{21,22}-drf{310,311,master},
+    py{35,36,37}-django22-drf{310,311,master},
     py38-django22-drf{311,master},
-    py{36,37,38}-django{30}-drf{311,master},
+    py{36,37,38}-django30-drf{311,master},
     lint,docs
 
 [testenv]
 deps =
-    django111: Django>=1.11,<1.12
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     drf310: djangorestframework>=3.10.2,<3.11


### PR DESCRIPTION
Fixes #830

## Description of the Change

Drop support for end of life Django versions 1.11 and 2.1

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
