### PR TITLE
Define what Python, Django and DRF series are supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,8 @@ Requirements
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST Framework series.
 
+Generally Python and Django series are supported till the official end of life. For Django REST Framework the last two series are supported.
+
 ------------
 Installation
 ------------

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,6 +57,8 @@ like the following:
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST Framework series.
 
+Generally Python and Django series are supported till the official end of life. For Django REST Framework the last two series are supported.
+
 ## Installation
 
 From PyPI


### PR DESCRIPTION
## Description of the Change

Currently whenever a Python, Django and Django REST framework series is end of life there is a conversation on when to drop it. I think for a user of DJA it is good to have this defined to avoid surprises.

Django REST framework does not really have an end of life definition (or have I overlooked this?) so supporting the last two series is feasible. In our upcoming release 4.0.0 we actually started supporting a new DRF release and dropping all lower DRF versions. Therefore a user is forced to update DJA and DRF at the same time.

I think it is fine for this round but should be avoided this in the future.

This PR should be the basis of discussion and can also be merged after the release of 4.0.0 whatever fits best.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
