### PR TITLE
Drop EOL Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: pip
 # Favor explicit over implicit and use an explicit build matrix.
 matrix:
   allow_failures:
-    - env: TOXENV=py35-django22-drfmaster
     - env: TOXENV=py36-django22-drfmaster
     - env: TOXENV=py37-django22-drfmaster
     - env: TOXENV=py38-django22-drfmaster
@@ -21,11 +20,6 @@ matrix:
       env: TOXENV=lint
     - python: 3.6
       env: TOXENV=docs
-
-    - python: 3.5
-      env: TOXENV=py35-django22-drf312
-    - python: 3.5
-      env: TOXENV=py35-django22-drfmaster
 
     - python: 3.6
       env: TOXENV=py36-django22-drf312

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This release is not backwards compatible. For easy migration best upgrade first 
 
 ### Removed
 
+* Removed support for Python 3.5.
 * Removed support for Django 1.11.
 * Removed support for Django 2.1.
 * Removed support for Django REST framework 3.10, 3.11
@@ -29,7 +30,7 @@ This release is not backwards compatible. For easy migration best upgrade first 
 
 ## [3.2.0] - 2020-08-26
 
-This is the last release supporting Django 1.11, Django 2.1, DRF 3.10 and DRF 3.11.
+This is the last release supporting Django 1.11, Django 2.1, DRF 3.10, DRF 3.11 and Python 3.5.
 
 ### Added
 

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ As a Django REST Framework JSON API (short DJA) we are trying to address followi
 Requirements
 ------------
 
-1. Python (3.5, 3.6, 3.7, 3.8)
+1. Python (3.6, 3.7, 3.8)
 2. Django (2.2, 3.0, 3.1)
 3. Django REST Framework (3.12)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ like the following:
 
 ## Requirements
 
-1. Python (3.5, 3.6, 3.7, 3.8)
+1. Python (3.6, 3.7, 3.8)
 2. Django (2.2, 3.0, 3.1)
 3. Django REST Framework (3.12)
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -99,6 +98,6 @@ setup(
         'django-filter': ['django-filter>=2.0']
     },
     setup_requires=wheel,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37,38}-django22-drf{312,master},
-    py{36,37,38}-django{30.31}-drf{312,master},
+    py{36,37,38}-django{22,30,31}-drf{312,master},
     lint,docs
 
 [testenv]


### PR DESCRIPTION
Fixes #829

## Description of the Change

Drop [EOL](https://endoflife.date/python) Python 3.5 support

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
