### PR TITLE
Stopped SparseFieldsetsMixin interpreting invalid fields parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ This release is not backwards compatible. For easy migration best upgrade first 
 * Removed obsolete `source` argument of `SerializerMethodResourceRelatedField`
 * Removed obsolete setting `JSON_API_SERIALIZE_NESTED_SERIALIZERS_AS_ATTRIBUTE` to render nested serializers as relationships. Default is as attribute now.
 
+### Fixed
+
+* Stopped `SparseFieldsetsMixin` interpretting invalid fields query parameter (e.g. invalidfields[entries]=blog,headline)
 
 ## [3.2.0] - 2020-08-26
 

--- a/example/tests/integration/test_sparse_fieldsets.py
+++ b/example/tests/integration/test_sparse_fieldsets.py
@@ -1,12 +1,36 @@
 import pytest
 from django.urls import reverse
+from rest_framework import status
 
 pytestmark = pytest.mark.django_db
 
 
-def test_sparse_fieldset_ordered_dict_error(multiple_entries, client):
+def test_sparse_fieldset_valid_fields(client, entry):
     base_url = reverse('entry-list')
-    querystring = '?fields[entries]=blog,headline'
-    # RuntimeError: OrderedDict mutated during iteration
-    response = client.get(base_url + querystring)
-    assert response.status_code == 200  # succeed if we didn't fail due to the above RuntimeError
+    response = client.get(base_url, data={'fields[entries]': 'blog,headline'})
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()['data']
+
+    assert len(data) == 1
+    entry = data[0]
+    assert entry['attributes'].keys() == {'headline'}
+    assert entry['relationships'].keys() == {'blog'}
+
+
+@pytest.mark.parametrize("fields_param", ['invalidfields[entries]', 'fieldsinvalid[entries'])
+def test_sparse_fieldset_invalid_fields_parameter(client, entry, fields_param):
+    """
+    Test that invalid fields query parameter is not processed by sparse fieldset.
+
+    rest_framework_json_api.filters.QueryParameterValidationFilter takes care of error
+    handling in such a case.
+    """
+    base_url = reverse('entry-list')
+    response = client.get(base_url, data={'invalidfields[entries]': 'blog,headline'})
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()['data']
+
+    assert len(data) == 1
+    entry = data[0]
+    assert entry['attributes'].keys() != {'headline'}
+    assert entry['relationships'].keys() != {'blog'}

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -71,7 +71,7 @@ class SparseFieldsetsMixin(object):
             )
             try:
                 param_name = next(
-                    key for key in request.query_params if sparse_fieldset_query_param in key
+                    key for key in request.query_params if sparse_fieldset_query_param == key
                 )
             except StopIteration:
                 pass


### PR DESCRIPTION
Fixes #519

## Description of the Change

Stopped SparseFieldsetsMixin interpreting invalid fields query parameter

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
