### PR TITLE
Allow users to overwrite `get_serializer_class` while using related urls

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,4 +33,5 @@ Sergey Kolomenkin <https://kolomenkin.com>
 Stas S. <stas@nerd.ro>
 Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
+Ulrich Schuster <ulrich.schuster@mailworks.org>
 Yaniv Peer <yanivpeer@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Added
 
 * Ability for the user to select `included_serializers` to apply when using `BrowsableAPI`, based on available `included_serializers` defined for the current endpoint.
+* Fixed #859: Allow users to overwrite a view's `get_serializer()` and `get_serializer_class()` methods for views that have related fields.
 
 
 ## [4.0.0] - 2020-10-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Added
 
 * Ability for the user to select `included_serializers` to apply when using `BrowsableAPI`, based on available `included_serializers` defined for the current endpoint.
-* Fixed #859: Allow users to overwrite a view's `get_serializer()` and `get_serializer_class()` methods for views that have related fields.
+
+### Fixed
+
+* Allow users to overwrite a view's `get_serializer_class()` method when using [related urls](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html#related-urls)
 
 
 ## [4.0.0] - 2020-10-31

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -260,6 +260,12 @@ class AuthorSerializer(serializers.ModelSerializer):
     def get_first_entry(self, obj):
         return obj.entries.first()
 
+class AuthorListSerializer(AuthorSerializer):
+    pass
+
+class AuthorDetailSerializer(AuthorSerializer):
+    pass
+
 
 class WriterSerializer(serializers.ModelSerializer):
     included_serializers = {

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -260,8 +260,10 @@ class AuthorSerializer(serializers.ModelSerializer):
     def get_first_entry(self, obj):
         return obj.entries.first()
 
+
 class AuthorListSerializer(AuthorSerializer):
     pass
+
 
 class AuthorDetailSerializer(AuthorSerializer):
     pass

--- a/example/tests/snapshots/snap_test_openapi.py
+++ b/example/tests/snapshots/snap_test_openapi.py
@@ -65,7 +65,7 @@ snapshots['test_path_without_parameters 1'] = '''{
             "properties": {
               "data": {
                 "items": {
-                  "$ref": "#/components/schemas/Author"
+                  "$ref": "#/components/schemas/AuthorList"
                 },
                 "type": "array"
               },
@@ -171,7 +171,7 @@ snapshots['test_path_with_id_parameter 1'] = '''{
           "schema": {
             "properties": {
               "data": {
-                "$ref": "#/components/schemas/Author"
+                "$ref": "#/components/schemas/AuthorDetail"
               },
               "included": {
                 "items": {

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -367,16 +367,16 @@ class TestRelatedMixin(APITestCase):
         got = view.get_related_instance()
         self.assertEqual(got, self.author.id)
 
-    def test_get_serializer_class(self):
+    def test_get_related_serializer_class(self):
         kwargs = {'pk': self.author.id, 'related_field': 'bio'}
         view = self._get_view(kwargs)
-        got = view.get_serializer_class()
+        got = view.get_related_serializer_class()
         self.assertEqual(got, AuthorBioSerializer)
 
-    def test_get_serializer_class_many(self):
+    def test_get_related_serializer_class_many(self):
         kwargs = {'pk': self.author.id, 'related_field': 'entries'}
         view = self._get_view(kwargs)
-        got = view.get_serializer_class()
+        got = view.get_related_serializer_class()
         self.assertEqual(got, EntrySerializer)
 
     def test_get_serializer_comes_from_included_serializers(self):
@@ -384,15 +384,15 @@ class TestRelatedMixin(APITestCase):
         view = self._get_view(kwargs)
         related_serializers = view.serializer_class.related_serializers
         delattr(view.serializer_class, 'related_serializers')
-        got = view.get_serializer_class()
+        got = view.get_related_serializer_class()
         self.assertEqual(got, AuthorTypeSerializer)
 
         view.serializer_class.related_serializers = related_serializers
 
-    def test_get_serializer_class_raises_error(self):
+    def test_get_related_serializer_class_raises_error(self):
         kwargs = {'pk': self.author.id, 'related_field': 'unknown'}
         view = self._get_view(kwargs)
-        self.assertRaises(NotFound, view.get_serializer_class)
+        self.assertRaises(NotFound, view.get_related_serializer_class)
 
     def test_retrieve_related_single_reverse_lookup(self):
         url = reverse('author-related', kwargs={'pk': self.author.pk, 'related_field': 'bio'})

--- a/example/views.py
+++ b/example/views.py
@@ -15,9 +15,9 @@ from rest_framework_json_api.views import ModelViewSet, RelationshipView
 
 from example.models import Author, Blog, Comment, Company, Entry, Project, ProjectType
 from example.serializers import (
-    AuthorSerializer,
-    AuthorListSerializer,
     AuthorDetailSerializer,
+    AuthorListSerializer,
+    AuthorSerializer,
     BlogDRFSerializer,
     BlogSerializer,
     CommentSerializer,
@@ -190,7 +190,7 @@ class AuthorViewSet(ModelViewSet):
     serializer_classes = {
         "list": AuthorListSerializer,
         "retrieve": AuthorDetailSerializer}
-    serializer_class = AuthorSerializer # fallback
+    serializer_class = AuthorSerializer  # fallback
 
     def get_serializer_class(self):
         try:

--- a/example/views.py
+++ b/example/views.py
@@ -16,6 +16,8 @@ from rest_framework_json_api.views import ModelViewSet, RelationshipView
 from example.models import Author, Blog, Comment, Company, Entry, Project, ProjectType
 from example.serializers import (
     AuthorSerializer,
+    AuthorListSerializer,
+    AuthorDetailSerializer,
     BlogDRFSerializer,
     BlogSerializer,
     CommentSerializer,
@@ -185,7 +187,16 @@ class NoFiltersetEntryViewSet(EntryViewSet):
 
 class AuthorViewSet(ModelViewSet):
     queryset = Author.objects.all()
-    serializer_class = AuthorSerializer
+    serializer_classes = {
+        "list": AuthorListSerializer,
+        "retrieve": AuthorDetailSerializer}
+    serializer_class = AuthorSerializer # fallback
+
+    def get_serializer_class(self):
+        try:
+            return self.serializer_classes.get(self.action, self.serializer_class)
+        except AttributeError:
+            return self.serializer_class
 
 
 class CommentViewSet(ModelViewSet):

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -52,7 +52,10 @@ def get_resource_name(context, expand_polymorphic_types=False):
         resource_name = getattr(view, 'resource_name')
     except AttributeError:
         try:
-            serializer = view.get_serializer_class()
+            if 'kwargs' in context and 'related_field' in context['kwargs']:
+                serializer = view.get_related_serializer_class()
+            else:
+                serializer = view.get_serializer_class()
             if expand_polymorphic_types and issubclass(serializer, PolymorphicModelSerializer):
                 return serializer.get_polymorphic_types()
             else:

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -144,10 +144,19 @@ class RelatedMixin(object):
         if isinstance(instance, Iterable):
             serializer_kwargs['many'] = True
 
-        serializer = self.get_serializer(instance, **serializer_kwargs)
+        serializer = self.get_related_serializer(instance, **serializer_kwargs)
         return Response(serializer.data)
 
-    def get_serializer_class(self):
+    def get_related_serializer(self, *args, **kwargs):
+        """
+        Return the serializer instance that should be used for validating and
+        deserializing input, and for serializing output.
+        """
+        serializer_class = self.get_related_serializer_class()
+        kwargs.setdefault('context', self.get_serializer_context())
+        return serializer_class(*args, **kwargs)
+
+    def get_related_serializer_class(self):
         parent_serializer_class = super(RelatedMixin, self).get_serializer_class()
 
         if 'related_field' in self.kwargs:

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -148,10 +148,6 @@ class RelatedMixin(object):
         return Response(serializer.data)
 
     def get_related_serializer(self, *args, **kwargs):
-        """
-        Return the serializer instance that should be used for validating and
-        deserializing input, and for serializing output.
-        """
         serializer_class = self.get_related_serializer_class()
         kwargs.setdefault('context', self.get_serializer_context())
         return serializer_class(*args, **kwargs)

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -147,10 +147,10 @@ class RelatedMixin(object):
         serializer = self.get_related_serializer(instance, **serializer_kwargs)
         return Response(serializer.data)
 
-    def get_related_serializer(self, *args, **kwargs):
+    def get_related_serializer(self, instance, **kwargs):
         serializer_class = self.get_related_serializer_class()
         kwargs.setdefault('context', self.get_serializer_context())
-        return serializer_class(*args, **kwargs)
+        return serializer_class(instance, **kwargs)
 
     def get_related_serializer_class(self):
         parent_serializer_class = super(RelatedMixin, self).get_serializer_class()
@@ -184,7 +184,8 @@ class RelatedMixin(object):
 
     def get_related_instance(self):
         parent_obj = self.get_object()
-        parent_serializer = self.serializer_class(parent_obj)
+        parent_serializer_class = self.get_serializer_class()
+        parent_serializer = parent_serializer_class(parent_obj)
         field_name = self.get_related_field_name()
         field = parent_serializer.fields.get(field_name, None)
 


### PR DESCRIPTION
Fixes #859 

## Description of the Change
Allows users to overwrite the `get_serializer()` and `get_serializer_class()` methods in subclassed views that have related or included serializers.

This change seems to interfere with OpenAPI Schema generation. As it stands, the tests `test_path_with_id_parameter` and `test_path_without_parameters` are failing, because the result no longer matches the expected snapshot. I suspect that the snapshots were incorrect in the first place, but I am not able to tell for sure.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [o] unit-test added: I did not add a new unit test, but modified the test setup such that the problems became apparent in the existing test cases.
- [-] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
