### PR TITLE
Introduce pre-commit to simplify contributions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: local
+    hooks:
+      - id: black
+        stages: [commit]
+        name: black
+        language: system
+        entry: black
+        types: [python]
+      - id: isort
+        stages: [commit]
+        name: isort
+        language: system
+        entry: isort
+        types: [python]
+      - id: flake8
+        stages: [commit]
+        name: flake8
+        language: system
+        entry: flake8
+        types: [python]

--- a/README.rst
+++ b/README.rst
@@ -142,18 +142,6 @@ Browse to
 * http://localhost:8000/openapi for the schema view's OpenAPI specification document.
 
 
-Running Tests and linting
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-It is recommended to create a virtualenv for testing. Assuming it is already
-installed and activated:
-
-::
-
-    $ pip install -Ur requirements.txt
-    $ flake8
-    $ pytest
-
 -----
 Usage
 -----

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,30 +1,53 @@
-Contributing
-============
+# Contributing
 
-DJA should be easy to contribute to.
+Django REST Framework JSON API (aka DJA)  should be easy to contribute to.
 If anything is unclear about how to contribute,
 please submit an issue on GitHub so that we can fix it!
 
-How
----
+Before writing any code, have a conversation on a GitHub issue to see
+if the proposed change makes sense for the project.
 
-Before writing any code,
-have a conversation on a GitHub issue
-to see if the proposed change makes sense
-for the project.
+## Setup development environment
 
-Fork DJA on [GitHub](https://github.com/django-json-api/django-rest-framework-json-api) and
-[submit a Pull Request](https://help.github.com/articles/creating-a-pull-request/)
-when you're ready.
+### Clone
 
-For maintainers
----------------
+To start developing on Django REST Framework JSON API you need to first clone the repository:
 
-To upload a release (using version 1.2.3 as the example):
+    git clone https://github.com/django-json-api/django-rest-framework-json-api.git
 
-```bash
-(venv)$ python setup.py sdist bdist_wheel
-(venv)$ twine upload dist/*
-(venv)$ git tag -a v1.2.3 -m 'Release 1.2.3'
-(venv)$ git push --tags
-```
+### Testing
+
+To run tests clone the repository, and then:
+
+     # Setup the virtual environment
+     python3 -m venv env
+     source env/bin/activate
+     pip install -r requirements.txt
+
+     # Format code
+     black .
+
+     # Run linting
+     flake8
+
+     # Run tests
+     pytest
+
+### Setup pre-commit
+
+pre-commit hooks is an additional option to check linting and formatting of code independent of
+an editor before you commit your changes with git.
+
+To setup pre-commit hooks first create a testing environment as explained above before running below commands:
+
+    pip install pre-commit
+    pre-commit install
+
+## For maintainers
+
+To upload a release (using version 1.2.3 as the example) first setup testing environment as above before running below commands:
+
+    python setup.py sdist bdist_wheel
+    twine upload dist/*
+    git tag -a v1.2.3 -m 'Release 1.2.3'
+    git push --tags

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,6 +33,13 @@ To run tests clone the repository, and then:
      # Run tests
      pytest
 
+### Running against multiple environments
+
+You can also use the excellent [tox](https://tox.readthedocs.io/en/latest/) testing tool to run the tests against all supported versions of Python and Django.  Install `tox` globally, and then simply run:
+
+    tox
+
+
 ### Setup pre-commit
 
 pre-commit hooks is an additional option to check linting and formatting of code independent of


### PR DESCRIPTION
Fixes #861

## Description of the Change

Add pre-commit for editor independent checking of linting and formatting of code before committing changes to git.

I have added a [pre-commit](https://pre-commit.com/#usage) configuration which uses the locally resp. in the virtual environment installed version of flake8, isort and black. pre-commit also has a way of handling the installation of such tools. However PyUp cannot update those version references and we might end up with different version in pre-commit and requirements.txt which we should avoid.  

The only down side to run tools locally is that a virtual env needs to be activated before committing. This needs to be the case anyway to run tests.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
