### PR TITLE
Support many related fields on plain Serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Fixed
 
 * Allow users to overwrite a view's `get_serializer_class()` method when using [related urls](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html#related-urls)
+* Fix issue preventing resolving the resource type of `ResourceRelatedField(many=True)` fields on plain serializers
 
 
 ## [4.0.0] - 2020-10-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST Framework policy](http://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
-## [Unreleased] - TBD
+## [Unreleased]
 
 ### Added
 
@@ -17,7 +17,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Fixed
 
 * Allow users to overwrite a view's `get_serializer_class()` method when using [related urls](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html#related-urls)
-* Fix issue preventing resolving the resource type of `ResourceRelatedField(many=True)` fields on plain serializers
+* Correctly resolve the resource type of `ResourceRelatedField(many=True)` fields on plain serializers
 
 
 ## [4.0.0] - 2020-10-31

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -16,7 +16,6 @@ from django.utils.module_loading import import_string as import_class_from_dotte
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions
 from rest_framework.exceptions import APIException
-from rest_framework.serializers import ManyRelatedField
 
 from .settings import json_api_settings
 

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -16,6 +16,7 @@ from django.utils.module_loading import import_string as import_class_from_dotte
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions
 from rest_framework.exceptions import APIException
+from rest_framework.serializers import ManyRelatedField
 
 from .settings import json_api_settings
 
@@ -215,6 +216,11 @@ def get_related_resource_type(relation):
                 return get_related_resource_type(parent_model_relation)
 
     if relation_model is None:
+        # For ManyRelatedFields on plain Serializers the resource_type
+        # cannot be determined from a model, so we must get it from the
+        # child_relation
+        if hasattr(relation, "child_relation"):
+            return get_related_resource_type(relation.child_relation)
         raise APIException(
             _("Could not resolve resource type for relation %s" % relation)
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -243,6 +243,27 @@ def test_get_related_resource_type(model_class, field, output):
     assert get_related_resource_type(field) == output
 
 
+@pytest.mark.parametrize(
+    "related_field_kwargs,output",
+    [
+        ({"queryset": BasicModel.objects}, "BasicModel"),
+        ({"queryset": BasicModel.objects, "model": BasicModel}, "BasicModel"),
+        ({"model": BasicModel, "read_only": True}, "BasicModel"),
+    ],
+)
+def test_get_related_resource_type_from_plain_serializer_class(
+    related_field_kwargs, output
+):
+    class PlainRelatedResourceTypeSerializer(serializers.Serializer):
+        basic_models = serializers.ResourceRelatedField(
+            many=True, **related_field_kwargs
+        )
+
+    serializer = PlainRelatedResourceTypeSerializer()
+    field = serializer.fields["basic_models"]
+    assert get_related_resource_type(field) == output
+
+
 class ManyToManyTargetSerializer(serializers.ModelSerializer):
     class Meta:
         model = ManyToManyTarget


### PR DESCRIPTION
Fixes #704 

## Description of the Change

Fix issue preventing resolving the resource type of `ResourceRelatedField(many=True)` fields on plain serializers

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [n/a] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
