### PR TITLE
Calculate copyright date as it changes

### DIFF
--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -88,7 +89,7 @@ class TestResourceIdentifierObjectSerializer(TestCase):
                         [
                             ("name", "Some Blog"),
                             ("tags", []),
-                            ("copyright", 2020),
+                            ("copyright", datetime.now().year),
                             ("url", "http://testserver/blogs/1"),
                         ]
                     ),


### PR DESCRIPTION
## Description of the Change

A test failed as it relied on a fix copyright year. Adjusted to calculate the year.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
