### PR TITLE
Render meta fields of included resource

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Matt Layman <https://www.mattlayman.com>
 Michael Haselton <icereval@gmail.com>
 Mohammed Ali Zubair <mazg1493@gmail.com>
 Nathanael Gordon <nathanael.l.gordon@gmail.com>
+Nick Kozhenin <kozhenin.nick@gmail.com>
 Ola Tarkowska <ola@red-aries.com>
 Oliver Sauder <os@esite.ch>
 Raphael Cohen <raphael.cohen.utt@gmail.com>
@@ -36,4 +37,3 @@ Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
 Ulrich Schuster <ulrich.schuster@mailworks.org>
 Yaniv Peer <yanivpeer@gmail.com>
-Nick Kozhenin <kozhenin.nick@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -36,3 +36,4 @@ Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
 Ulrich Schuster <ulrich.schuster@mailworks.org>
 Yaniv Peer <yanivpeer@gmail.com>
+Nick Kozhenin <kozhenin.nick@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Ability for the user to select `included_serializers` to apply when using `BrowsableAPI`, based on available `included_serializers` defined for the current endpoint.
 * Ability for the user to format serializer properties in URL segments using the `JSON_API_FORMAT_RELATED_LINKS` setting.
+* Ability to render meta_fields of included resources
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Ability for the user to select `included_serializers` to apply when using `BrowsableAPI`, based on available `included_serializers` defined for the current endpoint.
 * Ability for the user to format serializer properties in URL segments using the `JSON_API_FORMAT_RELATED_LINKS` setting.
-* Ability to render meta_fields of included resources
 
 ### Fixed
 
 * Allow users to overwrite a view's `get_serializer_class()` method when using [related urls](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html#related-urls)
 * Correctly resolve the resource type of `ResourceRelatedField(many=True)` fields on plain serializers
+* Render `meta_fields` in included resources
 
 
 ## [4.0.0] - 2020-10-31

--- a/example/models.py
+++ b/example/models.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 from __future__ import unicode_literals
 
+from datetime import datetime
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -129,6 +130,9 @@ class Comment(BaseModel):
 
     class Meta:
         ordering = ("id",)
+
+    def modified_days_ago(self):
+        return (datetime.now() - self.modified_at).days
 
 
 class ProjectType(BaseModel):

--- a/example/models.py
+++ b/example/models.py
@@ -1,7 +1,6 @@
 # -*- encoding: utf-8 -*-
 from __future__ import unicode_literals
 
-from datetime import datetime
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -130,9 +129,6 @@ class Comment(BaseModel):
 
     class Meta:
         ordering = ("id",)
-
-    def modified_days_ago(self):
-        return (datetime.now() - self.modified_at).days
 
 
 class ProjectType(BaseModel):

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -251,6 +251,7 @@ class AuthorSerializer(serializers.ModelSerializer):
         write_only=True,
         help_text="help for defaults",
     )
+    initials = serializers.SerializerMethodField()
     included_serializers = {"bio": AuthorBioSerializer, "type": AuthorTypeSerializer}
     related_serializers = {
         "bio": "example.serializers.AuthorBioSerializer",
@@ -272,10 +273,15 @@ class AuthorSerializer(serializers.ModelSerializer):
             "type",
             "secrets",
             "defaults",
+            "initials",
         )
+        meta_fields = ("initials",)
 
     def get_first_entry(self, obj):
         return obj.entries.first()
+
+    def get_initials(self, obj):
+        return ' '.join([word[0] for word in [obj.name]])
 
 
 class AuthorListSerializer(AuthorSerializer):
@@ -298,6 +304,7 @@ class WriterSerializer(serializers.ModelSerializer):
 class CommentSerializer(serializers.ModelSerializer):
     # testing remapping of related name
     writer = relations.ResourceRelatedField(source="author", read_only=True)
+    modified_days_ago = serializers.IntegerField(read_only=True)
 
     included_serializers = {
         "entry": EntrySerializer,
@@ -312,6 +319,7 @@ class CommentSerializer(serializers.ModelSerializer):
             "modified_at",
         )
         # fields = ('entry', 'body', 'author',)
+        meta_fields = ("modified_days_ago",)
 
 
 class ProjectTypeSerializer(serializers.ModelSerializer):

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -281,7 +281,7 @@ class AuthorSerializer(serializers.ModelSerializer):
         return obj.entries.first()
 
     def get_initials(self, obj):
-        return ' '.join([word[0] for word in [obj.name]])
+        return " ".join([word[0] for word in [obj.name]])
 
 
 class AuthorListSerializer(AuthorSerializer):

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -281,7 +281,7 @@ class AuthorSerializer(serializers.ModelSerializer):
         return obj.entries.first()
 
     def get_initials(self, obj):
-        return " ".join([word[0] for word in [obj.name]])
+        return "".join([word[0] for word in obj.name.split(" ")])
 
 
 class AuthorListSerializer(AuthorSerializer):
@@ -304,7 +304,7 @@ class WriterSerializer(serializers.ModelSerializer):
 class CommentSerializer(serializers.ModelSerializer):
     # testing remapping of related name
     writer = relations.ResourceRelatedField(source="author", read_only=True)
-    modified_days_ago = serializers.IntegerField(read_only=True)
+    modified_days_ago = serializers.SerializerMethodField()
 
     included_serializers = {
         "entry": EntrySerializer,
@@ -320,6 +320,9 @@ class CommentSerializer(serializers.ModelSerializer):
         )
         # fields = ('entry', 'body', 'author',)
         meta_fields = ("modified_days_ago",)
+
+    def get_modified_days_ago(self, obj):
+        return (datetime.now() - obj.modified_at).days
 
 
 class ProjectTypeSerializer(serializers.ModelSerializer):

--- a/example/tests/integration/test_includes.py
+++ b/example/tests/integration/test_includes.py
@@ -261,3 +261,20 @@ def test_data_resource_not_included_again(single_comment, client):
     # The comment in the data attribute must not be included again.
     expected_comment_count -= 1
     assert comment_count == expected_comment_count, "Comment count incorrect"
+
+
+def test_meta_object_added_to_included_resource_on_list(single_entry, client):
+    # Add metadata to included object
+    response = client.get(
+        reverse("entry-detail", kwargs={"pk": single_entry.pk})
+        + "?include=comments"
+    )
+    meta = response.json()['included'][0].get('meta', False)
+    assert meta, 'list has no meta object'
+
+    response = client.get(
+        reverse("entry-detail", kwargs={"pk": single_entry.pk})
+        + "?include=comments.author"
+    )
+    meta = response.json()['included'][0].get('meta', False)
+    assert meta, 'detail has no meta object'

--- a/example/tests/integration/test_includes.py
+++ b/example/tests/integration/test_includes.py
@@ -263,17 +263,15 @@ def test_data_resource_not_included_again(single_comment, client):
     assert comment_count == expected_comment_count, "Comment count incorrect"
 
 
-def test_meta_object_added_to_included_resource_on_list(single_entry, client):
-    # Add metadata to included object
+def test_meta_object_added_to_included_resources(single_entry, client):
     response = client.get(
         reverse("entry-detail", kwargs={"pk": single_entry.pk}) + "?include=comments"
     )
-    meta = response.json()["included"][0].get("meta", False)
-    assert meta, "list has no meta object"
+    assert response.json()["included"][0].get("meta")
 
     response = client.get(
         reverse("entry-detail", kwargs={"pk": single_entry.pk})
         + "?include=comments.author"
     )
-    meta = response.json()["included"][0].get("meta", False)
-    assert meta, "detail has no meta object"
+    assert response.json()["included"][0].get("meta")
+    assert response.json()["included"][1].get("meta")

--- a/example/tests/integration/test_includes.py
+++ b/example/tests/integration/test_includes.py
@@ -266,15 +266,14 @@ def test_data_resource_not_included_again(single_comment, client):
 def test_meta_object_added_to_included_resource_on_list(single_entry, client):
     # Add metadata to included object
     response = client.get(
-        reverse("entry-detail", kwargs={"pk": single_entry.pk})
-        + "?include=comments"
+        reverse("entry-detail", kwargs={"pk": single_entry.pk}) + "?include=comments"
     )
-    meta = response.json()['included'][0].get('meta', False)
-    assert meta, 'list has no meta object'
+    meta = response.json()["included"][0].get("meta", False)
+    assert meta, "list has no meta object"
 
     response = client.get(
         reverse("entry-detail", kwargs={"pk": single_entry.pk})
         + "?include=comments.author"
     )
-    meta = response.json()['included'][0].get('meta', False)
-    assert meta, 'detail has no meta object'
+    meta = response.json()["included"][0].get("meta", False)
+    assert meta, "detail has no meta object"

--- a/example/tests/test_format_keys.py
+++ b/example/tests/test_format_keys.py
@@ -63,6 +63,6 @@ def test_options_format_field_names(db, client):
         "comments",
         "secrets",
         "defaults",
-        "initials"
+        "initials",
     }
     assert expected_keys == data["actions"]["POST"].keys()

--- a/example/tests/test_format_keys.py
+++ b/example/tests/test_format_keys.py
@@ -63,5 +63,6 @@ def test_options_format_field_names(db, client):
         "comments",
         "secrets",
         "defaults",
+        "initials"
     }
     assert expected_keys == data["actions"]["POST"].keys()

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -195,7 +195,9 @@ class TestModelSerializer(object):
                         "data": {"type": "writers", "id": str(comment.author.pk)}
                     },
                 },
-                "meta": {"modifiedDaysAgo": (datetime.now() - comment.modified_at).days}
+                "meta": {
+                    "modifiedDaysAgo": (datetime.now() - comment.modified_at).days
+                },
             }
         }
 

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -195,6 +195,7 @@ class TestModelSerializer(object):
                         "data": {"type": "writers", "id": str(comment.author.pk)}
                     },
                 },
+                "meta": {"modifiedDaysAgo": (datetime.now() - comment.modified_at).days}
             }
         }
 

--- a/example/tests/unit/test_renderer_class_methods.py
+++ b/example/tests/unit/test_renderer_class_methods.py
@@ -3,6 +3,7 @@ from django.contrib.auth import get_user_model
 
 from rest_framework_json_api import serializers
 from rest_framework_json_api.renderers import JSONRenderer
+from rest_framework_json_api.utils import get_serializer_fields
 
 pytestmark = pytest.mark.django_db
 
@@ -20,10 +21,7 @@ class ResourceSerializer(serializers.ModelSerializer):
 
 
 def test_build_json_resource_obj():
-    resource = {
-        "pk": 1,
-        "username": "Alice",
-    }
+    resource = {"username": "Alice", "version": "1.0.0"}
 
     serializer = ResourceSerializer(data={"username": "Alice"})
     serializer.is_valid()
@@ -33,11 +31,16 @@ def test_build_json_resource_obj():
         "type": "user",
         "id": "1",
         "attributes": {"username": "Alice"},
+        "meta": {"version": "1.0.0"},
     }
 
     assert (
         JSONRenderer.build_json_resource_obj(
-            serializer.fields, resource, resource_instance, "user"
+            get_serializer_fields(serializer),
+            resource,
+            resource_instance,
+            "user",
+            serializer,
         )
         == output
     )
@@ -47,11 +50,8 @@ def test_can_override_methods():
     """
     Make sure extract_attributes and extract_relationships can be overriden.
     """
-    resource = {
-        "pk": 1,
-        "username": "Alice",
-    }
 
+    resource = {"username": "Alice", "version": "1.0.0"}
     serializer = ResourceSerializer(data={"username": "Alice"})
     serializer.is_valid()
     resource_instance = serializer.save()
@@ -60,6 +60,7 @@ def test_can_override_methods():
         "type": "user",
         "id": "1",
         "attributes": {"username": "Alice"},
+        "meta": {"version": "1.0.0"},
     }
 
     class CustomRenderer(JSONRenderer):
@@ -80,7 +81,11 @@ def test_can_override_methods():
 
     assert (
         CustomRenderer.build_json_resource_obj(
-            serializer.fields, resource, resource_instance, "user"
+            get_serializer_fields(serializer),
+            resource,
+            resource_instance,
+            "user",
+            serializer,
         )
         == output
     )

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -373,14 +373,11 @@ class JSONRenderer(renderers.JSONRenderer):
                             serializer_resource,
                             nested_resource_instance,
                             resource_type,
+                            serializer,
                             getattr(serializer, "_poly_force_type_resolution", False),
                         )
-                        included_cache[new_item["type"]][
-                            new_item["id"]
-                        ] = utils.format_field_names(new_item)
-                        cls.add_meta_to_included(
-                            included_cache, field, serializer_resource, new_item
-                        )
+                        included_cache[new_item["type"]][new_item["id"]] = new_item
+
                         cls.extract_included(
                             serializer_fields,
                             serializer_resource,
@@ -400,14 +397,11 @@ class JSONRenderer(renderers.JSONRenderer):
                         serializer_data,
                         relation_instance,
                         relation_type,
+                        field,
                         getattr(field, "_poly_force_type_resolution", False),
                     )
-                    included_cache[new_item["type"]][
-                        new_item["id"]
-                    ] = utils.format_field_names(new_item)
-                    cls.add_meta_to_included(
-                        included_cache, field, serializer_data, new_item
-                    )
+                    included_cache[new_item["type"]][new_item["id"]] = new_item
+
                     cls.extract_included(
                         serializer_fields,
                         serializer_data,
@@ -415,14 +409,6 @@ class JSONRenderer(renderers.JSONRenderer):
                         new_included_resources,
                         included_cache,
                     )
-
-    @classmethod
-    def add_meta_to_included(cls, included_cache, field, resource, new_item):
-        meta = cls.extract_meta(field, resource)
-        if meta:
-            included_cache[new_item["type"]][new_item["id"]][
-                "meta"
-            ] = utils.format_field_names(meta)
 
     @classmethod
     def extract_meta(cls, serializer, resource):
@@ -464,6 +450,7 @@ class JSONRenderer(renderers.JSONRenderer):
         resource,
         resource_instance,
         resource_name,
+        serializer,
         force_type_resolution=False,
     ):
         """
@@ -490,6 +477,11 @@ class JSONRenderer(renderers.JSONRenderer):
             resource_data.append(
                 ("links", {"self": resource[api_settings.URL_FIELD_NAME]})
             )
+
+        meta = cls.extract_meta(serializer, resource)
+        if meta:
+            resource_data.append(("meta", utils.format_field_names(meta)))
+
         return OrderedDict(resource_data)
 
     def render_relationship_view(
@@ -596,13 +588,9 @@ class JSONRenderer(renderers.JSONRenderer):
                         resource,
                         resource_instance,
                         resource_name,
+                        serializer,
                         force_type_resolution,
                     )
-                    meta = self.extract_meta(serializer, resource)
-                    if meta:
-                        json_resource_obj.update(
-                            {"meta": utils.format_field_names(meta)}
-                        )
                     json_api_data.append(json_resource_obj)
 
                     self.extract_included(
@@ -624,12 +612,9 @@ class JSONRenderer(renderers.JSONRenderer):
                     serializer_data,
                     resource_instance,
                     resource_name,
+                    serializer,
                     force_type_resolution,
                 )
-
-                meta = self.extract_meta(serializer, serializer_data)
-                if meta:
-                    json_api_data.update({"meta": utils.format_field_names(meta)})
 
                 self.extract_included(
                     fields,

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -380,8 +380,9 @@ class JSONRenderer(renderers.JSONRenderer):
                         ] = utils.format_field_names(new_item)
                         meta = cls.extract_meta(field, serializer_resource)
                         if meta:
-                            included_cache[new_item['type']][new_item['id']]['meta'] = \
-                                utils.format_field_names(meta)
+                            included_cache[new_item["type"]][new_item["id"]][
+                                "meta"
+                            ] = utils.format_field_names(meta)
                         cls.extract_included(
                             serializer_fields,
                             serializer_resource,
@@ -408,8 +409,9 @@ class JSONRenderer(renderers.JSONRenderer):
                     ] = utils.format_field_names(new_item)
                     meta = cls.extract_meta(field, serializer_data)
                     if meta:
-                        included_cache[new_item['type']][new_item['id']]['meta'] = \
-                            utils.format_field_names(meta)
+                        included_cache[new_item["type"]][new_item["id"]][
+                            "meta"
+                        ] = utils.format_field_names(meta)
                     cls.extract_included(
                         serializer_fields,
                         serializer_data,

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -378,11 +378,9 @@ class JSONRenderer(renderers.JSONRenderer):
                         included_cache[new_item["type"]][
                             new_item["id"]
                         ] = utils.format_field_names(new_item)
-                        meta = cls.extract_meta(field, serializer_resource)
-                        if meta:
-                            included_cache[new_item["type"]][new_item["id"]][
-                                "meta"
-                            ] = utils.format_field_names(meta)
+                        cls.add_meta_to_included(
+                            included_cache, field, serializer_resource, new_item
+                        )
                         cls.extract_included(
                             serializer_fields,
                             serializer_resource,
@@ -407,11 +405,9 @@ class JSONRenderer(renderers.JSONRenderer):
                     included_cache[new_item["type"]][
                         new_item["id"]
                     ] = utils.format_field_names(new_item)
-                    meta = cls.extract_meta(field, serializer_data)
-                    if meta:
-                        included_cache[new_item["type"]][new_item["id"]][
-                            "meta"
-                        ] = utils.format_field_names(meta)
+                    cls.add_meta_to_included(
+                        included_cache, field, serializer_data, new_item
+                    )
                     cls.extract_included(
                         serializer_fields,
                         serializer_data,
@@ -419,6 +415,14 @@ class JSONRenderer(renderers.JSONRenderer):
                         new_included_resources,
                         included_cache,
                     )
+
+    @classmethod
+    def add_meta_to_included(cls, included_cache, field, resource, new_item):
+        meta = cls.extract_meta(field, resource)
+        if meta:
+            included_cache[new_item["type"]][new_item["id"]][
+                "meta"
+            ] = utils.format_field_names(meta)
 
     @classmethod
     def extract_meta(cls, serializer, resource):

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -378,6 +378,10 @@ class JSONRenderer(renderers.JSONRenderer):
                         included_cache[new_item["type"]][
                             new_item["id"]
                         ] = utils.format_field_names(new_item)
+                        meta = cls.extract_meta(field, serializer_resource)
+                        if meta:
+                            included_cache[new_item['type']][new_item['id']]['meta'] = \
+                                utils.format_field_names(meta)
                         cls.extract_included(
                             serializer_fields,
                             serializer_resource,
@@ -402,6 +406,10 @@ class JSONRenderer(renderers.JSONRenderer):
                     included_cache[new_item["type"]][
                         new_item["id"]
                     ] = utils.format_field_names(new_item)
+                    meta = cls.extract_meta(field, serializer_data)
+                    if meta:
+                        included_cache[new_item['type']][new_item['id']]['meta'] = \
+                            utils.format_field_names(meta)
                     cls.extract_included(
                         serializer_fields,
                         serializer_data,


### PR DESCRIPTION
## Description of the Change

When adding serializer as a field the meta fields are not rendered, This change provides the rendering capability, test and some fixes of related tests. 
## Checklist

- [X] PR only contains one change (considered splitting up PR)
- [X] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
