### PR TITLE
Create security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you've found something in Django REST Framework JSON API which has security implications, please **do not raise the issue in a public forum**.
+
+Send a description of the issue via email to [whatemailaddressshouldweuse@example.net][security-mail].The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.
+
+[security-mail]: mailto:rest-framework-security@googlegroups.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,6 @@
 
 If you believe you've found something in Django REST Framework JSON API which has security implications, please **do not raise the issue in a public forum**.
 
-Send a description of the issue via email to [rest-framework-security@googlegroups.com][security-mail].The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.
+Send a description of the issue via email to [rest-framework-security@googlegroups.com][security-mail]. The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.
 
 [security-mail]: mailto:rest-framework-security@googlegroups.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,6 @@
 
 If you believe you've found something in Django REST Framework JSON API which has security implications, please **do not raise the issue in a public forum**.
 
-Send a description of the issue via email to [whatemailaddressshouldweuse@example.net][security-mail].The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.
+Send a description of the issue via email to [rest-framework-security@googlegroups.com][security-mail].The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.
 
 [security-mail]: mailto:rest-framework-security@googlegroups.com

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -64,7 +64,7 @@ To upload a release (using version 1.2.3 as the example) first setup testing env
 
 ### Add maintainer
 
-In case a new maintainer joins our team we need to consider to what of following services we want to add them our:
+In case a new maintainer joins our team we need to consider to what of following services we want to add them too:
 
 * [Github organization](https://github.com/django-json-api)
 * [Read the Docs project](https://django-rest-framework-json-api.readthedocs.io/)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -52,9 +52,21 @@ To setup pre-commit hooks first create a testing environment as explained above 
 
 ## For maintainers
 
+### Create release
+
 To upload a release (using version 1.2.3 as the example) first setup testing environment as above before running below commands:
 
     python setup.py sdist bdist_wheel
     twine upload dist/*
     git tag -a v1.2.3 -m 'Release 1.2.3'
     git push --tags
+
+
+### Add maintainer
+
+In case a new maintainer joins our team we need to consider to what of following services we want to add them our:
+
+* [Github organization](https://github.com/django-json-api)
+* [Read the Docs project](https://django-rest-framework-json-api.readthedocs.io/)
+* [PyPi project](https://pypi.org/project/djangorestframework-jsonapi/)
+* [Google Groups security mailing list](https://groups.google.com/g/rest-framework-jsonapi-security)


### PR DESCRIPTION
## Description of the Change

We did not have any security issues in the past but there might be so I think it is important to have a security policy so users know how to report such with fully disclosing it in a GitHub issue. After all DJA exposes APIs which could be publicly exposed.

I've copied the policy from Django REST Framework and adjusted it. I recommend to read following [guide](https://github.com/google/oss-vulnerability-guide/blob/main/guide.md) which describes how security vulnerabilities are best addressed.

One question remains though is what means do we wanna use to privately communicate with us? Github has [Security Advisories](https://docs.github.com/en/github/managing-security-vulnerabilities/about-github-security-advisories) which I recommend we use. But only a admin can create security advisories. Currently as it seems GitHub does not provide a way for the initial communication.

DRF uses googlegroups for this. Not my favorite but do not see a alternatives. Or are there any other suggestions?

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
