### PR TITLE
Properly support formatting of link segments in related urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Allow `get_serializer_class` to be overwritten when using related urls without defining `serializer_class` fallback
 * Preserve field names when no formatting is configured.
+* Properly support `JSON_API_FORMAT_RELATED_LINKS` setting in related urls. In case you want to use `dasherize` for formatting links make sure that your url pattern matches dashes as well like following example:
+  ```
+  url(r'^orders/(?P<pk>[^/.]+)/(?P<related_field>[-\w]+)/$',
+      OrderViewSet.as_view({'get': 'retrieve_related'}),
+      name='order-related'),
+  ```
+
 
 ### Deprecated
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -515,6 +515,11 @@ For example, with a serializer property `created_by` and with `'dasherize'` form
 
 The relationship name is formatted by the `JSON_API_FORMAT_FIELD_NAMES` setting, but the URL segments are formatted by the `JSON_API_FORMAT_RELATED_LINKS` setting.
 
+<div class="warning">
+    <strong>Note:</strong>
+    When using this setting make sure that your url pattern matches the formatted url segement.
+</div>
+
 ### Related fields
 
 #### ResourceRelatedField
@@ -702,7 +707,7 @@ All you need is just add to `urls.py`:
 url(r'^orders/(?P<pk>[^/.]+)/$',
         OrderViewSet.as_view({'get': 'retrieve'}),
         name='order-detail'),
-url(r'^orders/(?P<pk>[^/.]+)/(?P<related_field>\w+)/$',
+url(r'^orders/(?P<pk>[^/.]+)/(?P<related_field>[-\w]+)/$',
         OrderViewSet.as_view({'get': 'retrieve_related'}),
         name='order-related'),
 ```
@@ -775,7 +780,7 @@ The urlconf would need to contain a route like the following:
 
 ```python
 url(
-    regex=r'^orders/(?P<pk>[^/.]+)/relationships/(?P<related_field>[^/.]+)$',
+    regex=r'^orders/(?P<pk>[^/.]+)/relationships/(?P<related_field>[-/w]+)$',
     view=OrderRelationshipView.as_view(),
     name='order-relationships'
 )

--- a/example/urls_test.py
+++ b/example/urls_test.py
@@ -78,17 +78,17 @@ urlpatterns = [
         name="entry-featured",
     ),
     re_path(
-        r"^authors/(?P<pk>[^/.]+)/(?P<related_field>\w+)/$",
+        r"^authors/(?P<pk>[^/.]+)/(?P<related_field>[-\w]+)/$",
         AuthorViewSet.as_view({"get": "retrieve_related"}),
         name="author-related",
     ),
     re_path(
-        r"^entries/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)$",
+        r"^entries/(?P<pk>[^/.]+)/relationships/(?P<related_field>[\-\w]+)$",
         EntryRelationshipView.as_view(),
         name="entry-relationships",
     ),
     re_path(
-        r"^blogs/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)$",
+        r"^blogs/(?P<pk>[^/.]+)/relationships/(?P<related_field>[^/.]+)$",
         BlogRelationshipView.as_view(),
         name="blog-relationships",
     ),

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -157,7 +157,7 @@ class RelatedMixin(object):
         parent_serializer_class = self.get_serializer_class()
 
         if "related_field" in self.kwargs:
-            field_name = self.kwargs["related_field"]
+            field_name = self.get_related_field_name()
 
             # Try get the class from related_serializers
             if hasattr(parent_serializer_class, "related_serializers"):
@@ -402,6 +402,8 @@ class RelationshipView(generics.GenericAPIView):
 
     def get_related_field_name(self):
         field_name = self.kwargs["related_field"]
+        field_name = undo_format_link_segment(field_name)
+
         if field_name in self.field_name_mapping:
             return self.field_name_mapping[field_name]
         return field_name


### PR DESCRIPTION
## Description of the Change

Add logic to RelatedMixin (related views) and RelationshipView (relationship views) to make sure related field kwarg is properly converted to underscore format.

I don't have a test yet. Would appreciate some guidance on how to proceed. Basically I need to test the view action and make sure the related serializer is found based on the underscore-converted kwarg.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated (no need)
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
