### PR TITLE
Prefetch default included resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ any parts of the framework not mentioned in the documentation should generally b
       OrderViewSet.as_view({'get': 'retrieve_related'}),
       name='order-related'),
   ```
+* Ensure default `included_resources` are considered when calculating prefetches.
 
 
 ### Deprecated

--- a/example/tests/test_performance.py
+++ b/example/tests/test_performance.py
@@ -80,5 +80,7 @@ class PerformanceTestCase(APITestCase):
         3. Comments prefetched
         """
         with self.assertNumQueries(3):
-            response = self.client.get("/entries?fields[entry]=comments&page[size]=25")
+            response = self.client.get(
+                "/entries?fields[entries]=comments&page[size]=25"
+            )
             self.assertEqual(len(response.data["results"]), 25)

--- a/example/tests/test_performance.py
+++ b/example/tests/test_performance.py
@@ -72,8 +72,8 @@ class PerformanceTestCase(APITestCase):
             response = self.client.get("/comments?include=writer&page[size]=25")
             self.assertEqual(len(response.data["results"]), 25)
 
-    def test_query_prefetch_related_resources(self):
-        """We expect a list view with related_resources have three queries:
+    def test_query_prefetch_uses_included_resources(self):
+        """We expect a list view with `included_resources` to have three queries:
 
         1. Primary resource COUNT query
         2. Primary resource SELECT

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -137,7 +137,7 @@ class IncludedResourcesValidationMixin(object):
                 validate_path(this_included_serializer, new_included_field_path, path)
 
         if request and view:
-            included_resources = get_included_resources(request)
+            included_resources = get_included_resources(request, self)
             for included_field_name in included_resources:
                 included_field_path = included_field_name.split(".")
                 if "related_field" in view.kwargs:

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -63,7 +63,9 @@ class PreloadIncludesMixin(object):
     def get_queryset(self, *args, **kwargs):
         qs = super(PreloadIncludesMixin, self).get_queryset(*args, **kwargs)
 
-        included_resources = get_included_resources(self.request, self.get_serializer_class())
+        included_resources = get_included_resources(
+            self.request, self.get_serializer_class()
+        )
         for included in included_resources + ["__all__"]:
 
             select_related = self.get_select_related(included)
@@ -82,7 +84,9 @@ class AutoPrefetchMixin(object):
         """ This mixin adds automatic prefetching for OneToOne and ManyToMany fields. """
         qs = super(AutoPrefetchMixin, self).get_queryset(*args, **kwargs)
 
-        included_resources = get_included_resources(self.request, self.get_serializer_class())
+        included_resources = get_included_resources(
+            self.request, self.get_serializer_class()
+        )
 
         for included in included_resources + ["__all__"]:
             # If include was not defined, trying to resolve it automatically

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -63,7 +63,7 @@ class PreloadIncludesMixin(object):
     def get_queryset(self, *args, **kwargs):
         qs = super(PreloadIncludesMixin, self).get_queryset(*args, **kwargs)
 
-        included_resources = get_included_resources(self.request)
+        included_resources = get_included_resources(self.request, self.get_serializer_class())
         for included in included_resources + ["__all__"]:
 
             select_related = self.get_select_related(included)
@@ -82,7 +82,7 @@ class AutoPrefetchMixin(object):
         """ This mixin adds automatic prefetching for OneToOne and ManyToMany fields. """
         qs = super(AutoPrefetchMixin, self).get_queryset(*args, **kwargs)
 
-        included_resources = get_included_resources(self.request)
+        included_resources = get_included_resources(self.request, self.get_serializer_class())
 
         for included in included_resources + ["__all__"]:
             # If include was not defined, trying to resolve it automatically


### PR DESCRIPTION
## Description of the Change
Pass the serializer to `select_related` and `prefetch_related` default `included_resources`. Without this, only resources specified by `?include` are used.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
