### PR TITLE
Django 3.2 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9"]
-        django: ["2.2", "3.0", "3.1"]
+        django: ["2.2", "3.0", "3.1", "3.2"]
         django-rest-framework: ["3.12", "master"]
     env:
       PYTHON: ${{ matrix.python-version }}

--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Felix Viernickel <felix@gedankenspieler.org>
 Greg Aker <greg@gregaker.net>
 Jamie Bliss <astronouth7303@gmail.com>
 Jason Housley <housleyjk@gmail.com>
+Jeppe Fihl-Pearson <jeppe@tenzer.dk>
 Jerel Unruh <mail@unruhdesigns.com>
 Jonathan Senecal <contact@jonathansenecal.com>
 Joseba Mendivil <git@jma.email>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST Framework policy](http://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
+## [Unreleased]
+
+### Added
+
+* Added support for Django 3.2.
+
 ## [4.1.0] - 2021-03-08
 
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Requirements
 ------------
 
 1. Python (3.6, 3.7, 3.8, 3.9)
-2. Django (2.2, 3.0, 3.1)
+2. Django (2.2, 3.0, 3.1, 3.2)
 3. Django REST Framework (3.12)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST Framework series.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ like the following:
 ## Requirements
 
 1. Python (3.6, 3.7, 3.8, 3.9)
-2. Django (2.2, 3.0, 3.1)
+2. Django (2.2, 3.0, 3.1, 3.2)
 3. Django REST Framework (3.12)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST Framework series.

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,8 @@ DJANGO_SETTINGS_MODULE=example.settings.test
 filterwarnings =
     error::DeprecationWarning
     error::PendingDeprecationWarning
+    # Django Debug Toolbar currently (2021-04-07) specifies default_app_config which is deprecated in Django 3.2:
+    ignore:'debug_toolbar' defines default_app_config = 'debug_toolbar.apps.DebugToolbarConfig'. Django now detects this configuration automatically. You can remove default_app_config.:PendingDeprecationWarning
 testpaths =
     example
     tests

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     install_requires=[
         "inflection>=0.3.0",
         "djangorestframework>=3.12,<3.13",
-        "django>=2.2,<3.2",
+        "django>=2.2,<3.3",
     ],
     extras_require={
         "django-polymorphic": ["django-polymorphic>=2.0"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-django{22,30,31}-drf{312,master},
+    py{36,37,38,39}-django{22,30,31,32}-drf{312,master},
     lint,docs
 
 [gh-actions]
@@ -15,6 +15,7 @@ DJANGO =
     2.2: django22
     3.0: django30
     3.1: django31
+    3.2: django32
 
 DJANGO_REST_FRAMEWORK =
     3.12: drf312
@@ -25,6 +26,7 @@ deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
     drf312: djangorestframework>=3.12,<3.13
     drfmaster: https://github.com/encode/django-rest-framework/archive/master.zip
     -rrequirements/requirements-testing.txt


### PR DESCRIPTION
Fixes #907

## Description of the Change

Allows the library to be used with Django 3.2.

I had to ignore a warning from Django related to django-debug-toolbar in order for tests to pass. I felt like that probably would be an acceptable way to work around it the deprecation warning without blocking this library to be upgraded to support Django 3.2, especially since the library doesn't depend directly on django-debug-toolbar.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
