### PR TITLE
Use correct security email address

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,6 @@
 
 If you believe you've found something in Django REST Framework JSON API which has security implications, please **do not raise the issue in a public forum**.
 
-Send a description of the issue via email to [rest-framework-security@googlegroups.com][security-mail]. The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.
+Send a description of the issue via email to [rest-framework-jsonapi-security@googlegroups.com][security-mail]. The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.
 
-[security-mail]: mailto:rest-framework-security@googlegroups.com
+[security-mail]: mailto:rest-framework-jsonapi-security@googlegroups.com


### PR DESCRIPTION
## Description of the Change

Not sure how this happened but the DRF security email address was used instead of our newly created one.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
