### PR TITLE
Added initial issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,15 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Description of the Bug Report
+
+## Checklist
+
+- [ ] Certain that this is a bug (if unsure or you have a question use [discussions](https://github.com/django-json-api/django-rest-framework-json-api/discussions) instead)
+- [ ] Code snippet or unit test added to reproduce bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Please only raise a feature request if you've been advised to do so after discussion.
+  Thanks!
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+## Description of feature request
+
+## Checklist
+
+- [ ] Raised initially as discussion #...
+- [ ] This cannot be dealt with as a third party library. (We prefer new functionality to be in the form of third party libraries where feasible.)
+- [ ] I have reduced the issue to the simplest possible case.


### PR DESCRIPTION
My ideal would be that `Issues` is actually a list of work items with all the details for any contributor who wishes to work on it. All other discussion should happen in discussion. This follows the example of [DRF](https://github.com/encode/django-rest-framework/discussions/7740]

Adding issue templates will be one way forward into this direction to guide users how to report.