### PR TITLE
Unified usage of JSON:API abbreviation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
 Ulrich Schuster <ulrich.schuster@mailworks.org>
 Yaniv Peer <yanivpeer@gmail.com>
+Mansi Dhruv <mansi.p.dhruv@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ Kevin Partington <platinumazure@gmail.com>
 Kieran Evans <keyz182@gmail.com>
 Léo S. <leo@naeka.fr>
 Luc Cary <luc.cary@gmail.com>
+Mansi Dhruv <mansi.p.dhruv@gmail.com>
 Matt Layman <https://www.mattlayman.com>
 Michael Haselton <icereval@gmail.com>
 Mohammed Ali Zubair <mazg1493@gmail.com>
@@ -40,4 +41,3 @@ Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
 Ulrich Schuster <ulrich.schuster@mailworks.org>
 Yaniv Peer <yanivpeer@gmail.com>
-Mansi Dhruv <mansi.p.dhruv@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,10 +104,10 @@ This is the last release supporting Django 1.11, Django 2.1, Django REST Framewo
 ### Added
 
 * Added support for serializing nested serializers as attribute json value introducing setting `JSON_API_SERIALIZE_NESTED_SERIALIZERS_AS_ATTRIBUTE`
- * Note: As keys of nested serializers are not json:api spec field names they are not inflected by format field names option.
+ * Note: As keys of nested serializers are not JSON:API spec field names they are not inflected by format field names option.
 * Added `rest_framework_json_api.serializer.Serializer` class to support initial JSON:API views without models.
   * Note that serializers derived from this class need to define `resource_name` in their `Meta` class.
-  * This fix might be a **BREAKING CHANGE** if you use `rest_framework_json_api.serializers.Serializer` for non json:api spec views (usually `APIView`). You need to change those serializers classes to use `rest_framework.serializers.Serializer` instead.
+  * This fix might be a **BREAKING CHANGE** if you use `rest_framework_json_api.serializers.Serializer` for non JSON:API spec views (usually `APIView`). You need to change those serializers classes to use `rest_framework.serializers.Serializer` instead.
 
 ### Fixed
 
@@ -202,7 +202,7 @@ This is the last release supporting Python 2.7, Python 3.4, Django Filter 1.1, D
 * Don't swallow `filter[]` params when there are several
 * Fix DeprecationWarning regarding collections.abc import in Python 3.7
 * Allow OPTIONS request to be used on RelationshipView
-* Remove non-JSONAPI methods (PUT and TRACE) from ModelViewSet and RelationshipView.
+* Remove non-JSON:API methods (PUT and TRACE) from ModelViewSet and RelationshipView.
   This fix might be a **BREAKING CHANGE** if your clients are incorrectly using PUT instead of PATCH.
 * Avoid validation error for missing fields on a PATCH request using polymorphic serializers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ any parts of the framework not mentioned in the documentation should generally b
 
 ## [Unreleased]
 
+### Fixed
+
+* Adjusted error messages to correctly use capitial "JSON:API" abbreviation as used in the specification.
+
 ### Changed
 
 * Moved resolving of `included_serialzers` and `related_serializers` classes to serializer's meta class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ This is the last release supporting Django 1.11, Django 2.1, Django REST Framewo
 
 * Added support for serializing nested serializers as attribute json value introducing setting `JSON_API_SERIALIZE_NESTED_SERIALIZERS_AS_ATTRIBUTE`
  * Note: As keys of nested serializers are not json:api spec field names they are not inflected by format field names option.
-* Added `rest_framework_json_api.serializer.Serializer` class to support initial JSON API views without models.
+* Added `rest_framework_json_api.serializer.Serializer` class to support initial JSON:API views without models.
   * Note that serializers derived from this class need to define `resource_name` in their `Meta` class.
   * This fix might be a **BREAKING CHANGE** if you use `rest_framework_json_api.serializers.Serializer` for non json:api spec views (usually `APIView`). You need to change those serializers classes to use `rest_framework.serializers.Serializer` instead.
 

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ like the following::
 Goals
 -----
 
-As a Django REST Framework JSON API (short DJA) we are trying to address following goals:
+As a Django REST Framework JSON:API (short DJA) we are trying to address following goals:
 
 1. Support the `JSON:API`_ spec to compliance
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ==================================
-JSON API and Django Rest Framework
+JSON:API and Django Rest Framework
 ==================================
 
 .. image:: https://github.com/django-json-api/django-rest-framework-json-api/workflows/Tests/badge.svg
@@ -18,7 +18,7 @@ JSON API and Django Rest Framework
 Overview
 --------
 
-**JSON API support for Django REST Framework**
+**JSON:API support for Django REST Framework**
 
 * Documentation: https://django-rest-framework-json-api.readthedocs.org/
 * Format specification: http://jsonapi.org/format/
@@ -38,7 +38,7 @@ By default, Django REST Framework will produce a response like::
     }
 
 
-However, for an ``identity`` model in JSON API format the response should look
+However, for an ``identity`` model in JSON:API format the response should look
 like the following::
 
     {
@@ -69,7 +69,7 @@ Goals
 
 As a Django REST Framework JSON API (short DJA) we are trying to address following goals:
 
-1. Support the `JSON API`_ spec to compliance
+1. Support the `JSON:API`_ spec to compliance
 
 2. Be as compatible with `Django REST Framework`_ as possible
 
@@ -81,7 +81,7 @@ As a Django REST Framework JSON API (short DJA) we are trying to address followi
 
 5. Be performant
 
-.. _JSON API: http://jsonapi.org
+.. _JSON:API: http://jsonapi.org
 .. _Django REST Framework: https://www.django-rest-framework.org/
 
 ------------

--- a/README.rst
+++ b/README.rst
@@ -149,7 +149,7 @@ installed and activated:
 
 Browse to
 
-* http://localhost:8000 for the list of available collections (in a non-JSONAPI format!),
+* http://localhost:8000 for the list of available collections (in a non-JSON:API format!),
 * http://localhost:8000/swagger-ui/ for a Swagger user interface to the dynamic schema view, or
 * http://localhost:8000/openapi for the schema view's OpenAPI specification document.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you believe you've found something in Django REST Framework JSON API which has security implications, please **do not raise the issue in a public forum**.
+If you believe you've found something in Django REST Framework JSON:API which has security implications, please **do not raise the issue in a public forum**.
 
 Send a description of the issue via email to [rest-framework-jsonapi-security@googlegroups.com][security-mail]. The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,7 +11,7 @@ if the proposed change makes sense for the project.
 
 ### Clone
 
-To start developing on Django REST Framework JSON:APIJSON API you need to first clone the repository:
+To start developing on Django REST Framework JSON:API you need to first clone the repository:
 
     git clone https://github.com/django-json-api/django-rest-framework-json-api.git
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Django REST Framework JSON API (aka DJA)  should be easy to contribute to.
+Django REST Framework JSON:API (aka DJA)  should be easy to contribute to.
 If anything is unclear about how to contribute,
 please submit an issue on GitHub so that we can fix it!
 
@@ -11,7 +11,7 @@ if the proposed change makes sense for the project.
 
 ### Clone
 
-To start developing on Django REST Framework JSON API you need to first clone the repository:
+To start developing on Django REST Framework JSON:APIJSON API you need to first clone the repository:
 
     git clone https://github.com/django-json-api/django-rest-framework-json-api.git
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Django REST Framework JSON API documentation build configuration file, created by
+# Django REST Framework JSON:API documentation build configuration file, created by
 # sphinx-quickstart on Fri Jul 24 23:31:15 2015.
 #
 # This file is execfile()d with the current directory set to its
@@ -59,10 +59,10 @@ source_suffix = [".rst", ".md"]
 master_doc = "index"
 
 # General information about the project.
-project = "Django REST Framework JSON API"
+project = "Django REST Framework JSON:API"
 year = datetime.date.today().year
-copyright = "{}, Django REST Framework JSON API contributors".format(year)
-author = "Django REST Framework JSON API contributors"
+copyright = "{}, Django REST Framework JSON:API contributors".format(year)
+author = "Django REST Framework JSON:API contributors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -244,8 +244,8 @@ latex_documents = [
     (
         master_doc,
         "DjangoRESTFrameworkJSONAPI.tex",
-        "Django REST Framework JSON API Documentation",
-        "Django REST Framework JSON API contributors",
+        "Django REST Framework JSON:API Documentation",
+        "Django REST Framework JSON:API contributors",
         "manual",
     ),
 ]
@@ -279,7 +279,7 @@ man_pages = [
     (
         master_doc,
         "djangorestframeworkjsonapi",
-        "Django REST Framework JSON API Documentation",
+        "Django REST Framework JSON:API Documentation",
         [author],
         1,
     )
@@ -298,7 +298,7 @@ texinfo_documents = [
     (
         master_doc,
         "DjangoRESTFrameworkJSONAPI",
-        "Django REST Framework JSON API Documentation",
+        "Django REST Framework JSON:API Documentation",
         author,
         "DjangoRESTFrameworkJSONAPI",
         "One line description of project.",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 
 # Getting Started
 
-*Note: this package is named Django REST Framework JSON API to follow the naming
+*Note: this package is named Django REST Framework JSON:API to follow the naming
 convention of other Django REST Framework packages. Since that's quite a bit
 to say or type this package will be referred to as DJA elsewhere in these docs.*
 
@@ -20,7 +20,7 @@ By default, Django REST Framework produces a response like:
 ```
 
 
-However, for the same `identity` model in JSON API format the response should look
+However, for the same `identity` model in JSON:APIJSON API format the response should look
 like the following:
 ``` js
 {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,7 +97,7 @@ and add `rest_framework_json_api` to your `INSTALLED_APPS` setting below `rest_f
 
 
 Browse to
-* [http://localhost:8000](http://localhost:8000) for the list of available collections (in a non-JSONAPI format!),
+* [http://localhost:8000](http://localhost:8000) for the list of available collections (in a non-JSON:API format!),
 * [http://localhost:8000/swagger-ui/](http://localhost:8000/swagger-ui/) for a Swagger user interface to the dynamic schema view, or
 * [http://localhost:8000/openapi](http://localhost:8000/openapi) for the schema view's OpenAPI specification document.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,7 +20,7 @@ By default, Django REST Framework produces a response like:
 ```
 
 
-However, for the same `identity` model in JSON:APIJSON API format the response should look
+However, for the same `identity` model in JSON:API format the response should look
 like the following:
 ``` js
 {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,9 @@
-.. Django REST Framework JSON API documentation master file, created by
+.. Django REST Framework JSON:API documentation master file, created by
    sphinx-quickstart on Fri Jul 24 23:31:15 2015.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Django REST Framework JSON API
+Welcome to Django REST Framework JSON:API
 ==========================================================
 
 Contents:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -312,8 +312,7 @@ multiple endpoints. Setting the `resource_name` on views may result in a differe
 
 ### Inflecting object and relation keys
 
-This package includes the ability (off by default) to automatically convert [json
-api field names](http://jsonapi.org/format/#document-resource-object-fields) of requests and responses from the python/rest_framework's preferred underscore to
+This package includes the ability (off by default) to automatically convert [json:api field names](http://jsonapi.org/format/#document-resource-object-fields) of requests and responses from the python/rest_framework's preferred underscore to
 a format of your choice. To hook this up include the following setting in your
 project settings:
 
@@ -524,8 +523,7 @@ The relationship name is formatted by the `JSON_API_FORMAT_FIELD_NAMES` setting,
 
 #### ResourceRelatedField
 
-Because of the additional structure needed to represent relationships in JSON
-API, this package provides the `ResourceRelatedField` for serializers, which
+Because of the additional structure needed to represent relationships in JSON:API, this package provides the `ResourceRelatedField` for serializers, which
 works similarly to `PrimaryKeyRelatedField`. By default,
 `rest_framework_json_api.serializers.ModelSerializer` will use this for
 related fields automatically. It can be instantiated explicitly as in the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -312,7 +312,7 @@ multiple endpoints. Setting the `resource_name` on views may result in a differe
 
 ### Inflecting object and relation keys
 
-This package includes the ability (off by default) to automatically convert [json:api field names](http://jsonapi.org/format/#document-resource-object-fields) of requests and responses from the python/rest_framework's preferred underscore to
+This package includes the ability (off by default) to automatically convert [JSON:API field names](http://jsonapi.org/format/#document-resource-object-fields) of requests and responses from the python/rest_framework's preferred underscore to
 a format of your choice. To hook this up include the following setting in your
 project settings:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -240,9 +240,9 @@ class MyViewset(ModelViewSet):
 ### Exception handling
 
 For the `exception_handler` class, if the optional `JSON_API_UNIFORM_EXCEPTIONS` is set to True,
-all exceptions will respond with the JSON API [error format](http://jsonapi.org/format/#error-objects).
+all exceptions will respond with the JSON:API [error format](http://jsonapi.org/format/#error-objects).
 
-When `JSON_API_UNIFORM_EXCEPTIONS` is False (the default), non-JSON API views will respond
+When `JSON_API_UNIFORM_EXCEPTIONS` is False (the default), non-JSON:API views will respond
 with the normal DRF error format.
 
 ### Performance Testing
@@ -896,7 +896,7 @@ Related links will be created automatically when using the Relationship View.
 
 ### Included
 
-JSON API can include additional resources in a single network request.
+JSON:API can include additional resources in a single network request.
 The specification refers to this feature as
 [Compound Documents](http://jsonapi.org/format/#document-compound-documents).
 Compound Documents can reduce the number of network requests

--- a/example/tests/test_filters.py
+++ b/example/tests/test_filters.py
@@ -104,7 +104,7 @@ class DJATestFilters(APITestCase):
 
     def test_sort_related(self):
         """
-        test sort via related field using jsonapi path `.` and django orm `__` notation.
+        test sort via related field using JSON:API path `.` and django orm `__` notation.
         ORM relations must be predefined in the View's .ordering_fields attr
         """
         for datum in ("blog__id", "blog.id"):

--- a/example/tests/test_generic_viewset.py
+++ b/example/tests/test_generic_viewset.py
@@ -55,7 +55,7 @@ class GenericViewSet(TestBase):
 
     def test_default_validation_exceptions(self):
         """
-        Default validation exceptions should conform to json api spec
+        Default validation exceptions should conform to json:api spec
         """
         expected = {
             "errors": [

--- a/example/tests/test_generic_viewset.py
+++ b/example/tests/test_generic_viewset.py
@@ -55,7 +55,7 @@ class GenericViewSet(TestBase):
 
     def test_default_validation_exceptions(self):
         """
-        Default validation exceptions should conform to json:api spec
+        Default validation exceptions should conform to JSON:API spec
         """
         expected = {
             "errors": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# The base set of requirements for Django REST framework JSON API is actually
+# The base set of requirements for Django REST framework JSON:API is actually
 # fairly small, but for the purposes of development and testing
 # there are a number of packages that are useful to install.
 

--- a/rest_framework_json_api/django_filters/backends.py
+++ b/rest_framework_json_api/django_filters/backends.py
@@ -11,7 +11,7 @@ class DjangoFilterBackend(DjangoFilterBackend):
     """
     A Django-style ORM filter implementation, using `django-filter`.
 
-    This is not part of the jsonapi standard per-se, other than the requirement
+    This is not part of the JSON:API standard per-se, other than the requirement
     to use the `filter` keyword: This is an optional implementation of style of
     filtering in which each filter is an ORM expression as implemented by
     DjangoFilterBackend and seems to be in alignment with an interpretation of
@@ -50,7 +50,7 @@ class DjangoFilterBackend(DjangoFilterBackend):
     the name of the query parameter for searching to make sure it doesn't conflict
     with a field name defined in the filterset.
     The recommended value is: `search_param="filter[search]"` but just make sure it's
-    `filter[<something>]` to comply with the jsonapi spec requirement to use the filter
+    `filter[<something>]` to comply with the JSON:API spec requirement to use the filter
     keyword. The default is "search" unless overriden but it's used here just to make sure
     we don't complain about it being an invalid filter.
     """
@@ -117,7 +117,7 @@ class DjangoFilterBackend(DjangoFilterBackend):
                     raise ValidationError(
                         "missing value for query parameter {}".format(qp)
                     )
-                # convert jsonapi relationship path to Django ORM's __ notation
+                # convert JSON:API relationship path to Django ORM's __ notation
                 key = m.groupdict()["assoc"].replace(".", "__")
                 key = undo_format_field_name(key)
                 data.setlist(key, val)

--- a/rest_framework_json_api/exceptions.py
+++ b/rest_framework_json_api/exceptions.py
@@ -29,16 +29,16 @@ def exception_handler(exc, context):
     if not response:
         return response
 
-    # Use regular DRF format if not rendered by DRF JSON API and not uniform
+    # Use regular DRF format if not rendered by DRF JSON:API and not uniform
     is_json_api_view = rendered_with_json_api(context["view"])
     is_uniform = json_api_settings.UNIFORM_EXCEPTIONS
     if not is_json_api_view and not is_uniform:
         return response
 
-    # Convert to DRF JSON API error format
+    # Convert to DRF JSON:API error format
     response = utils.format_drf_errors(response, context, exc)
 
-    # Add top-level 'errors' object when not rendered by DRF JSON API
+    # Add top-level 'errors' object when not rendered by DRF JSON:API
     if not is_json_api_view:
         response.data = utils.format_errors(response.data)
 

--- a/rest_framework_json_api/filters.py
+++ b/rest_framework_json_api/filters.py
@@ -90,7 +90,7 @@ class QueryParameterValidationFilter(BaseFilterBackend):
 
         :raises ValidationError: if not.
         """
-        # TODO: For jsonapi error object conformance, must set jsonapi errors "parameter" for
+        # TODO: For JSON:API error object conformance, must set JSON:API errors "parameter" for
         # the ValidationError. This requires extending DRF/DJA Exceptions.
         for qp in request.query_params.keys():
             m = self.query_regex.match(qp)

--- a/rest_framework_json_api/pagination.py
+++ b/rest_framework_json_api/pagination.py
@@ -10,7 +10,7 @@ from rest_framework.views import Response
 
 class JsonApiPageNumberPagination(PageNumberPagination):
     """
-    A json-api compatible pagination format.
+    A json:api compatible pagination format.
     """
 
     page_query_param = "page[number]"

--- a/rest_framework_json_api/pagination.py
+++ b/rest_framework_json_api/pagination.py
@@ -10,7 +10,7 @@ from rest_framework.views import Response
 
 class JsonApiPageNumberPagination(PageNumberPagination):
     """
-    A json:api compatible pagination format.
+    A JSON:API compatible pagination format.
     """
 
     page_query_param = "page[number]"

--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -13,7 +13,7 @@ class JSONParser(parsers.JSONParser):
     Similar to `JSONRenderer`, the `JSONParser` you may override the following methods if you
     need highly custom parsing control.
 
-    A JSON API client will send a payload that looks like this:
+    A JSON:API client will send a payload that looks like this:
 
     .. code:: json
 

--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -87,7 +87,7 @@ class JSONParser(parsers.JSONParser):
         from rest_framework_json_api.views import RelationshipView
 
         if isinstance(view, RelationshipView):
-            # We skip parsing the object as JSONAPI Resource Identifier Object and not a regular
+            # We skip parsing the object as JSON:API Resource Identifier Object and not a regular
             # Resource Object
             if isinstance(data, list):
                 for resource_identifier_object in data:
@@ -96,12 +96,12 @@ class JSONParser(parsers.JSONParser):
                         and resource_identifier_object.get("type")
                     ):
                         raise ParseError(
-                            "Received data contains one or more malformed JSONAPI "
+                            "Received data contains one or more malformed JSON:API "
                             "Resource Identifier Object(s)"
                         )
             elif not (data.get("id") and data.get("type")):
                 raise ParseError(
-                    "Received data is not a valid JSONAPI Resource Identifier Object"
+                    "Received data is not a valid JSON:API Resource Identifier Object"
                 )
 
             return data
@@ -111,7 +111,7 @@ class JSONParser(parsers.JSONParser):
         # Sanity check
         if not isinstance(data, dict):
             raise ParseError(
-                "Received data is not a valid JSONAPI Resource Identifier Object"
+                "Received data is not a valid JSON:API Resource Identifier Object"
             )
 
         # Check for inconsistencies

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -58,7 +58,7 @@ class JSONRenderer(renderers.JSONRenderer):
         """
         data = OrderedDict()
         for field_name, field in iter(fields.items()):
-            # ID is always provided in the root of JSON API so remove it from attributes
+            # ID is always provided in the root of JSON:API so remove it from attributes
             if field_name == "id":
                 continue
             # don't output a key for write only fields

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -29,7 +29,7 @@ class JSONRenderer(renderers.JSONRenderer):
     The `JSONRenderer` exposes a number of methods that you may override if you need highly
     custom rendering control.
 
-    Render a JSON response per the JSON API spec:
+    Render a JSON response per the JSON:API spec:
 
     .. code-block:: json
 
@@ -54,7 +54,7 @@ class JSONRenderer(renderers.JSONRenderer):
     @classmethod
     def extract_attributes(cls, fields, resource):
         """
-        Builds the `attributes` object of the JSON API resource object.
+        Builds the `attributes` object of the JSON:API resource object.
         """
         data = OrderedDict()
         for field_name, field in iter(fields.items()):

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -11,10 +11,10 @@ from rest_framework_json_api import serializers, views
 
 class SchemaGenerator(drf_openapi.SchemaGenerator):
     """
-    Extend DRF's SchemaGenerator to implement jsonapi-flavored generateschema command.
+    Extend DRF's SchemaGenerator to implement JSON:API flavored generateschema command.
     """
 
-    #: These JSONAPI component definitions are referenced by the generated OAS schema.
+    #: These JSON:API component definitions are referenced by the generated OAS schema.
     #: If you need to add more or change these static component definitions, extend this dict.
     jsonapi_components = {
         "schemas": {
@@ -258,7 +258,7 @@ class SchemaGenerator(drf_openapi.SchemaGenerator):
 
     def get_schema(self, request=None, public=False):
         """
-        Generate a JSONAPI OpenAPI schema.
+        Generate a JSON:API OpenAPI schema.
         Overrides upstream DRF's get_schema.
         """
         # TODO: avoid copying so much of upstream get_schema()
@@ -393,15 +393,15 @@ class SchemaGenerator(drf_openapi.SchemaGenerator):
 
 class AutoSchema(drf_openapi.AutoSchema):
     """
-    Extend DRF's openapi.AutoSchema for JSONAPI serialization.
+    Extend DRF's openapi.AutoSchema for JSON:API serialization.
     """
 
-    #: ignore all the media types and only generate a JSONAPI schema.
+    #: ignore all the media types and only generate a JSON:API schema.
     content_types = ["application/vnd.api+json"]
 
     def get_operation(self, path, method):
         """
-        JSONAPI adds some standard fields to the API response that are not in upstream DRF:
+        JSON:API adds some standard fields to the API response that are not in upstream DRF:
         - some that only apply to GET/HEAD methods.
         - collections
         - special handling for POST, PATCH, DELETE
@@ -505,7 +505,7 @@ class AutoSchema(drf_openapi.AutoSchema):
 
     def _get_toplevel_200_response(self, operation, collection=True):
         """
-        return top-level JSONAPI GET 200 response
+        return top-level JSON:API GET 200 response
 
         :param collection: True for collections; False for individual items.
 
@@ -587,7 +587,7 @@ class AutoSchema(drf_openapi.AutoSchema):
 
     def get_request_body(self, path, method):
         """
-        A request body is required by jsonapi for POST, PATCH, and DELETE methods.
+        A request body is required by JSON:API for POST, PATCH, and DELETE methods.
         """
         serializer = self.get_serializer(path, method)
         if not isinstance(serializer, (serializers.BaseSerializer,)):
@@ -595,7 +595,7 @@ class AutoSchema(drf_openapi.AutoSchema):
         is_relationship = isinstance(self.view, views.RelationshipView)
 
         # DRF uses a $ref to the component schema definition, but this
-        # doesn't work for jsonapi due to the different required fields based on
+        # doesn't work for JSON:API due to the different required fields based on
         # the method, so make those changes and inline another copy of the schema.
         # TODO: A future improvement could make this DRYer with multiple component schemas:
         #   A base schema for each viewset that has no required fields
@@ -640,7 +640,7 @@ class AutoSchema(drf_openapi.AutoSchema):
 
     def map_serializer(self, serializer):
         """
-        Custom map_serializer that serializes the schema using the jsonapi spec.
+        Custom map_serializer that serializes the schema using the JSON:API spec.
         Non-attributes like related and identity fields, are move to 'relationships' and 'links'.
         """
         # TODO: remove attributes, etc. for relationshipView??

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -214,9 +214,9 @@ class Serializer(
 ):
     """
     A `Serializer` is a model-less serializer class with additional
-    support for json:api spec features.
+    support for JSON:API spec features.
 
-    As in json:api specification a type is always required you need to
+    As in JSON:API specification a type is always required you need to
     make sure that you define `resource_name` in your `Meta` class
     when deriving from this class.
 

--- a/rest_framework_json_api/settings.py
+++ b/rest_framework_json_api/settings.py
@@ -1,6 +1,6 @@
 """
 This module provides the `json_api_settings` object that is used to access
-JSON API REST framework settings, checking for user settings first, then falling back to
+JSON:API REST framework settings, checking for user settings first, then falling back to
 the defaults.
 """
 

--- a/rest_framework_json_api/settings.py
+++ b/rest_framework_json_api/settings.py
@@ -20,7 +20,7 @@ DEFAULTS = {
 
 class JSONAPISettings(object):
     """
-    A settings object that allows json api settings to be access as
+    A settings object that allows json:api settings to be access as
     properties.
     """
 
@@ -30,7 +30,7 @@ class JSONAPISettings(object):
 
     def __getattr__(self, attr):
         if attr not in self.defaults:
-            raise AttributeError("Invalid JSON API setting: '%s'" % attr)
+            raise AttributeError("Invalid JSON:API setting: '%s'" % attr)
 
         value = getattr(
             self.user_settings, JSON_API_SETTINGS_PREFIX + attr, self.defaults[attr]

--- a/rest_framework_json_api/settings.py
+++ b/rest_framework_json_api/settings.py
@@ -20,7 +20,7 @@ DEFAULTS = {
 
 class JSONAPISettings(object):
     """
-    A settings object that allows json:api settings to be access as
+    A settings object that allows JSON:API settings to be access as
     properties.
     """
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     version=get_version("rest_framework_json_api"),
     url="https://github.com/django-json-api/django-rest-framework-json-api",
     license="BSD",
-    description="A Django REST framework API adapter for the JSON API spec.",
+    description="A Django REST framework API adapter for the JSON:API spec.",
     long_description=read("README.rst"),
     author="Jerel Unruh",
     author_email="",

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -110,8 +110,9 @@ class TestJSONParser:
         with pytest.raises(ParseError) as excinfo:
             parse(data)
 
-        assert "Received data is not a valid JSONAPI Resource Identifier Object" == str(
-            excinfo.value
+        assert (
+            "Received data is not a valid JSON:API Resource Identifier Object"
+            == str(excinfo.value)
         )
 
     def test_parse_fails_when_id_is_missing_on_patch(self, rf, parse, parser_context):


### PR DESCRIPTION
Fixes #940

## Description of the Change
Update JSON: API from JSON API in the docs. 
Test the updated docs at [Read the JSON: API](https://django-rest-framework-json-api-modify.readthedocs.io/en/docs-update/)