### PR TITLE
Remove invalid validation of default included_resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST Framework policy](http://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
-## Unreleased
+## [Unreleased]
 
 ### Fixed
 
 * Include `PreloadIncludesMixin` in `ReadOnlyModelViewSet` to enable the usage of [performance utilities](https://django-rest-framework-json-api.readthedocs.io/en/stable/usage.html#performance-improvements) on read only views (regression since 2.8.0)
+* Remove invalid validation of default `included_resources` (regression since 4.2.0)
 
 ## [4.2.0] - 2021-05-12
 

--- a/example/serializers.py
+++ b/example/serializers.py
@@ -321,6 +321,9 @@ class CommentSerializer(serializers.ModelSerializer):
         # fields = ('entry', 'body', 'author',)
         meta_fields = ("modified_days_ago",)
 
+    class JSONAPIMeta:
+        included_resources = ("writer",)
+
     def get_modified_days_ago(self, obj):
         return (datetime.now() - obj.modified_at).days
 

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -198,7 +198,25 @@ class TestModelSerializer(object):
                 "meta": {
                     "modifiedDaysAgo": (datetime.now() - comment.modified_at).days
                 },
-            }
+            },
+            "included": [
+                {
+                    "attributes": {
+                        "email": comment.author.email,
+                        "name": comment.author.name,
+                    },
+                    "id": str(comment.author.pk),
+                    "relationships": {
+                        "bio": {
+                            "data": {
+                                "id": str(comment.author.bio.pk),
+                                "type": "authorBios",
+                            }
+                        }
+                    },
+                    "type": "writers",
+                }
+            ],
         }
 
         response = client.get(reverse("comment-detail", kwargs={"pk": comment.pk}))

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -137,7 +137,7 @@ class IncludedResourcesValidationMixin(object):
                 validate_path(this_included_serializer, new_included_field_path, path)
 
         if request and view:
-            included_resources = get_included_resources(request, self)
+            included_resources = get_included_resources(request)
             for included_field_name in included_resources:
                 included_field_path = included_field_name.split(".")
                 if "related_field" in view.kwargs:


### PR DESCRIPTION
Fixes #949 

## Description of the Change

#900 inadvertently introduced validation of default included_resources which does not work properly with nested included resources (such as when a default included resources also defines its own included resources).

This PR reverts this validation but leaving the default prefetching of default included resources as intended in PR #900. 

This is a quick fix to get this regression solved. In the long run we need to think whether it makes sense at all to do validation of include in init of the serializer anyway. But can be discussed later.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
