### PR TITLE
Added missing tests folder to MAINIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include AUTHORS
 include LICENSE
 include README.rst
 recursive-include example *
-recursive-exclude example *.pyc *.pyo
+recursive-include tests *
 
 global-exclude __pycache__
 global-exclude *.py[co]


### PR DESCRIPTION
## Description of the Change

This was missed when introducing new tests folder. Removed obsolete exclude of pyc and pyo as there is already a global exclude with those extensions.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
