### PR TITLE
Use consistent naming for Django REST framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Note that in line with [Django REST Framework policy](http://www.django-rest-framework.org/topics/release-notes/),
+Note that in line with [Django REST framework policy](http://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
 ## [Unreleased]
@@ -103,7 +103,7 @@ This release is not backwards compatible. For easy migration best upgrade first 
 
 ## [3.2.0] - 2020-08-26
 
-This is the last release supporting Django 1.11, Django 2.1, Django REST Framework 3.10, Django REST Framework 3.11 and Python 3.5.
+This is the last release supporting Django 1.11, Django 2.1, Django REST framework 3.10, Django REST framework 3.11 and Python 3.5.
 
 ### Added
 
@@ -171,7 +171,7 @@ This release is not backwards compatible. For easy migration best upgrade first 
 * Removed support for Python 2.7 and 3.4.
 * Removed support for Django Filter 1.1.
 * Removed obsolete dependency six.
-* Removed support for Django REST Framework <=3.9.
+* Removed support for Django REST framework <=3.9.
 * Removed support for Django 2.0.
 * Removed obsolete mixins `MultipleIDMixin` and `PrefetchForIncludesHelperMixin`
 * Removed obsolete settings `JSON_API_FORMAT_KEYS`, `JSON_API_FORMAT_RELATION_KEYS` and
@@ -188,7 +188,7 @@ This release is not backwards compatible. For easy migration best upgrade first 
 
 ## [2.8.0] - 2019-06-13
 
-This is the last release supporting Python 2.7, Python 3.4, Django Filter 1.1, Django REST Framework <=3.9 and Django 2.0.
+This is the last release supporting Python 2.7, Python 3.4, Django Filter 1.1, Django REST framework <=3.9 and Django 2.0.
 
 ### Added
 
@@ -265,7 +265,7 @@ This is the last release supporting Python 2.7, Python 3.4, Django Filter 1.1, D
 * Add new pagination classes based on JSON:API query parameter *recommendations*:
   * `JsonApiPageNumberPagination` and `JsonApiLimitOffsetPagination`. See [usage docs](docs/usage.md#pagination).
 * Add `ReadOnlyModelViewSet` extension with prefetch mixins
-* Add support for Django REST Framework 3.8.x
+* Add support for Django REST framework 3.8.x
 * Introduce `JSON_API_FORMAT_FIELD_NAMES` option replacing `JSON_API_FORMAT_KEYS` but in comparison preserving
   values from being formatted as attributes can contain any [json value](http://jsonapi.org/format/#document-resource-object-attributes).
 * Allow overwriting of `get_queryset()` in custom `ResourceRelatedField`
@@ -293,13 +293,13 @@ This is the last release supporting Python 2.7, Python 3.4, Django Filter 1.1, D
 
 ### Added
 
-* Add support for Django REST Framework 3.7.x.
+* Add support for Django REST framework 3.7.x.
 * Add support for Django 2.0.
 
 ### Removed
 
 * Drop support for Django 1.8 - 1.10 (EOL)
-* Drop support for Django REST Framework < 3.6.3
+* Drop support for Django REST framework < 3.6.3
   (3.6.3 is the first to support Django 1.11)
 * Drop support for Python 3.3 (EOL)
 
@@ -326,7 +326,7 @@ This is the last release supporting Python 2.7, Python 3.4, Django Filter 1.1, D
 
 ### Added
 
-* Add support for Django REST Framework 3.5 and 3.6
+* Add support for Django REST framework 3.5 and 3.6
 * Add support for Django 1.11
 * Add support for Python 3.6
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ==================================
-JSON:API and Django Rest Framework
+JSON:API and Django REST framework
 ==================================
 
 .. image:: https://github.com/django-json-api/django-rest-framework-json-api/workflows/Tests/badge.svg
@@ -18,13 +18,13 @@ JSON:API and Django Rest Framework
 Overview
 --------
 
-**JSON:API support for Django REST Framework**
+**JSON:API support for Django REST framework**
 
 * Documentation: https://django-rest-framework-json-api.readthedocs.org/
 * Format specification: http://jsonapi.org/format/
 
 
-By default, Django REST Framework will produce a response like::
+By default, Django REST framework will produce a response like::
 
     {
         "count": 20,
@@ -67,13 +67,13 @@ like the following::
 Goals
 -----
 
-As a Django REST Framework JSON:API (short DJA) we are trying to address following goals:
+As a Django REST framework JSON:API (short DJA) we are trying to address following goals:
 
 1. Support the `JSON:API`_ spec to compliance
 
-2. Be as compatible with `Django REST Framework`_ as possible
+2. Be as compatible with `Django REST framework`_ as possible
 
-   e.g. issues in Django REST Framework should be fixed upstream and not worked around in DJA
+   e.g. issues in Django REST framework should be fixed upstream and not worked around in DJA
 
 3. Have sane defaults to be as easy to pick up as possible
 
@@ -82,7 +82,7 @@ As a Django REST Framework JSON:API (short DJA) we are trying to address followi
 5. Be performant
 
 .. _JSON:API: http://jsonapi.org
-.. _Django REST Framework: https://www.django-rest-framework.org/
+.. _Django REST framework: https://www.django-rest-framework.org/
 
 ------------
 Requirements
@@ -90,11 +90,11 @@ Requirements
 
 1. Python (3.6, 3.7, 3.8, 3.9)
 2. Django (2.2, 3.0, 3.1, 3.2)
-3. Django REST Framework (3.12)
+3. Django REST framework (3.12)
 
-We **highly** recommend and only officially support the latest patch release of each Python, Django and REST Framework series.
+We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.
 
-Generally Python and Django series are supported till the official end of life. For Django REST Framework the last two series are supported.
+Generally Python and Django series are supported till the official end of life. For Django REST framework the last two series are supported.
 
 ------------
 Installation
@@ -160,7 +160,7 @@ Usage
 
 
 ``rest_framework_json_api`` assumes you are using class-based views in Django
-Rest Framework.
+REST framework.
 
 
 Settings

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you believe you've found something in Django REST Framework JSON:API which has security implications, please **do not raise the issue in a public forum**.
+If you believe you've found something in Django REST framework JSON:API which has security implications, please **do not raise the issue in a public forum**.
 
 Send a description of the issue via email to [rest-framework-jsonapi-security@googlegroups.com][security-mail]. The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Django REST Framework JSON:API (aka DJA)  should be easy to contribute to.
+Django REST framework JSON:API (aka DJA)  should be easy to contribute to.
 If anything is unclear about how to contribute,
 please submit an issue on GitHub so that we can fix it!
 
@@ -11,7 +11,7 @@ if the proposed change makes sense for the project.
 
 ### Clone
 
-To start developing on Django REST Framework JSON:API you need to first clone the repository:
+To start developing on Django REST framework JSON:API you need to first clone the repository:
 
     git clone https://github.com/django-json-api/django-rest-framework-json-api.git
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Django REST Framework JSON:API documentation build configuration file, created by
+# Django REST framework JSON:API documentation build configuration file, created by
 # sphinx-quickstart on Fri Jul 24 23:31:15 2015.
 #
 # This file is execfile()d with the current directory set to its
@@ -59,10 +59,10 @@ source_suffix = [".rst", ".md"]
 master_doc = "index"
 
 # General information about the project.
-project = "Django REST Framework JSON:API"
+project = "Django REST framework JSON:API"
 year = datetime.date.today().year
-copyright = "{}, Django REST Framework JSON:API contributors".format(year)
-author = "Django REST Framework JSON:API contributors"
+copyright = "{}, Django REST framework JSON:API contributors".format(year)
+author = "Django REST framework JSON:API contributors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -244,8 +244,8 @@ latex_documents = [
     (
         master_doc,
         "DjangoRESTFrameworkJSONAPI.tex",
-        "Django REST Framework JSON:API Documentation",
-        "Django REST Framework JSON:API contributors",
+        "Django REST framework JSON:API Documentation",
+        "Django REST framework JSON:API contributors",
         "manual",
     ),
 ]
@@ -279,7 +279,7 @@ man_pages = [
     (
         master_doc,
         "djangorestframeworkjsonapi",
-        "Django REST Framework JSON:API Documentation",
+        "Django REST framework JSON:API Documentation",
         [author],
         1,
     )
@@ -298,7 +298,7 @@ texinfo_documents = [
     (
         master_doc,
         "DjangoRESTFrameworkJSONAPI",
-        "Django REST Framework JSON:API Documentation",
+        "Django REST framework JSON:API Documentation",
         author,
         "DjangoRESTFrameworkJSONAPI",
         "One line description of project.",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,11 +1,11 @@
 
 # Getting Started
 
-*Note: this package is named Django REST Framework JSON:API to follow the naming
-convention of other Django REST Framework packages. Since that's quite a bit
+*Note: this package is named Django REST framework JSON:API to follow the naming
+convention of other Django REST framework packages. Since that's quite a bit
 to say or type this package will be referred to as DJA elsewhere in these docs.*
 
-By default, Django REST Framework produces a response like:
+By default, Django REST framework produces a response like:
 ``` js
 {
     "count": 20,
@@ -53,11 +53,11 @@ like the following:
 
 1. Python (3.6, 3.7, 3.8, 3.9)
 2. Django (2.2, 3.0, 3.1, 3.2)
-3. Django REST Framework (3.12)
+3. Django REST framework (3.12)
 
-We **highly** recommend and only officially support the latest patch release of each Python, Django and REST Framework series.
+We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.
 
-Generally Python and Django series are supported till the official end of life. For Django REST Framework the last two series are supported.
+Generally Python and Django series are supported till the official end of life. For Django REST framework the last two series are supported.
 
 ## Installation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,9 @@
-.. Django REST Framework JSON:API documentation master file, created by
+.. Django REST framework JSON:API documentation master file, created by
    sphinx-quickstart on Fri Jul 24 23:31:15 2015.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Django REST Framework JSON:API
+Welcome to Django REST framework JSON:API
 ==========================================================
 
 Contents:

--- a/rest_framework_json_api/settings.py
+++ b/rest_framework_json_api/settings.py
@@ -1,6 +1,6 @@
 """
 This module provides the `json_api_settings` object that is used to access
-JSON:API REST framework settings, checking for user settings first, then falling back to
+Django REST framework JSON:API settings, checking for user settings first, then falling back to
 the defaults.
 """
 


### PR DESCRIPTION
## Description of the Change

This follows the naming DRF uses in its own [documentation](https://www.django-rest-framework.org/) with an uppercase `REST` and all lowercase `framework`.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
