### PR TITLE
Align overwriting of get_queryset in example app and documentation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -620,14 +620,14 @@ class LineItemViewSet(viewsets.ModelViewSet):
     serializer_class = LineItemSerializer
 
     def get_queryset(self):
-        queryset = super(LineItemViewSet, self).get_queryset()
+        queryset = super().get_queryset()
 
         # if this viewset is accessed via the 'order-lineitems-list' route,
         # it wll have been passed the `order_pk` kwarg and the queryset
         # needs to be filtered accordingly; if it was accessed via the
         # unnested '/lineitems' route, the queryset should include all LineItems
-        if 'order_pk' in self.kwargs:
-            order_pk = self.kwargs['order_pk']
+        order_pk = self.kwargs.get('order_pk')
+        if order_pk is not None:
             queryset = queryset.filter(order__pk=order_pk)
 
         return queryset

--- a/example/views.py
+++ b/example/views.py
@@ -243,11 +243,13 @@ class CommentViewSet(ModelViewSet):
     }
 
     def get_queryset(self, *args, **kwargs):
+        queryset = super().get_queryset()
+
         entry_pk = self.kwargs.get("entry_pk", None)
         if entry_pk is not None:
-            return self.queryset.filter(entry_id=entry_pk)
+            queryset = queryset.filter(entry_id=entry_pk)
 
-        return super(CommentViewSet, self).get_queryset()
+        return queryset
 
 
 class CompanyViewset(ModelViewSet):


### PR DESCRIPTION
Fixes #487

## Description of the Change

Make sure that in example app local queryset is used for filtering.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
