### PR TITLE
Check for reserved field names in serializer meta class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ any parts of the framework not mentioned in the documentation should generally b
 
 ### Fixed
 
-* Adjusted error messages to correctly use capitial "JSON:API" abbreviation as used in the specification.
+* Adjusted error messages to correctly use capital "JSON:API" abbreviation as used in the specification.
 * Avoid error when `parser_context` is `None` while parsing.
+* Raise comprehensible error when reserved field names `meta` and `results` are used.
 
 ### Changed
 

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -184,6 +184,25 @@ class LazySerializersDict(Mapping):
 
 
 class SerializerMetaclass(SerializerMetaclass):
+
+    _reserved_field_names = {"meta", "results"}
+
+    @classmethod
+    def _get_declared_fields(cls, bases, attrs):
+        fields = super()._get_declared_fields(bases, attrs)
+
+        found_reserved_field_names = cls._reserved_field_names.intersection(
+            fields.keys()
+        )
+        if found_reserved_field_names:
+            raise AttributeError(
+                f"Serializer class {attrs['__module__']}.{attrs['__qualname__']} uses "
+                f"following reserved field name(s) which is not allowed: "
+                f"{', '.join(sorted(found_reserved_field_names))}"
+            )
+
+        return fields
+
     def __new__(cls, name, bases, attrs):
         serializer = super().__new__(cls, name, bases, attrs)
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,3 +1,4 @@
+import pytest
 from django.db import models
 
 from rest_framework_json_api import serializers
@@ -33,3 +34,17 @@ def test_get_included_serializers():
     }
 
     assert included_serializers == expected_included_serializers
+
+
+def test_reserved_field_names():
+    with pytest.raises(AttributeError) as e:
+
+        class ReservedFieldNamesSerializer(serializers.Serializer):
+            meta = serializers.CharField()
+            results = serializers.CharField()
+
+    assert str(e.value) == (
+        "Serializer class tests.test_serializers.test_reserved_field_names.<locals>."
+        "ReservedFieldNamesSerializer uses following reserved field name(s) which is "
+        "not allowed: meta, results"
+    )


### PR DESCRIPTION
Fixes #518
Fixes #710

## Description of the Change

This is to avoid an incomprehensible exception during runtime when either meta or results is used as a field name.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
