### PR TITLE
Changed all external links to https

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,3 +42,4 @@ Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
 Ulrich Schuster <ulrich.schuster@mailworks.org>
 Yaniv Peer <yanivpeer@gmail.com>
+Swaraj Baral <baralswaraj40@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -37,9 +37,9 @@ Rohith PR <praroh2@gmail.com>
 Safa AlFulaij <safa1996alfulaij@gmail.com>
 santiavenda <santiavenda2@gmail.com>
 Sergey Kolomenkin <https://kolomenkin.com>
+Swaraj Baral <baralswaraj40@gmail.com>
 Stas S. <stas@nerd.ro>
 Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
 Ulrich Schuster <ulrich.schuster@mailworks.org>
 Yaniv Peer <yanivpeer@gmail.com>
-Swaraj Baral <baralswaraj40@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -37,8 +37,8 @@ Rohith PR <praroh2@gmail.com>
 Safa AlFulaij <safa1996alfulaij@gmail.com>
 santiavenda <santiavenda2@gmail.com>
 Sergey Kolomenkin <https://kolomenkin.com>
-Swaraj Baral <baralswaraj40@gmail.com>
 Stas S. <stas@nerd.ro>
+Swaraj Baral <baralswaraj40@gmail.com>
 Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
 Ulrich Schuster <ulrich.schuster@mailworks.org>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Note that in line with [Django REST framework policy](http://www.django-rest-framework.org/topics/release-notes/),
+Note that in line with [Django REST framework policy](https://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
 ## [Unreleased]
@@ -240,7 +240,7 @@ This is the last release supporting Python 2.7, Python 3.4, Django Filter 1.1, D
 * Add testing configuration to `REST_FRAMEWORK` configuration as described in [DRF](https://www.django-rest-framework.org/api-guide/testing/#configuration)
 * Add `HyperlinkedRelatedField` and `SerializerMethodHyperlinkedRelatedField`. See [usage docs](docs/usage.md#related-fields)
 * Add related urls support. See [usage docs](docs/usage.md#related-urls)
-* Add optional [jsonapi-style](http://jsonapi.org/format/) filter backends. See [usage docs](docs/usage.md#filter-backends)
+* Add optional [jsonapi-style](https://jsonapi.org/format/) filter backends. See [usage docs](docs/usage.md#filter-backends)
 
 ### Deprecated
 
@@ -268,7 +268,7 @@ This is the last release supporting Python 2.7, Python 3.4, Django Filter 1.1, D
 * Add `ReadOnlyModelViewSet` extension with prefetch mixins
 * Add support for Django REST framework 3.8.x
 * Introduce `JSON_API_FORMAT_FIELD_NAMES` option replacing `JSON_API_FORMAT_KEYS` but in comparison preserving
-  values from being formatted as attributes can contain any [json value](http://jsonapi.org/format/#document-resource-object-attributes).
+  values from being formatted as attributes can contain any [json value](https://jsonapi.org/format/#document-resource-object-attributes).
 * Allow overwriting of `get_queryset()` in custom `ResourceRelatedField`
 
 ### Deprecated

--- a/README.rst
+++ b/README.rst
@@ -149,9 +149,9 @@ installed and activated:
 
 Browse to
 
-* https://localhost:8000 for the list of available collections (in a non-JSON:API format!),
-* https://localhost:8000/swagger-ui/ for a Swagger user interface to the dynamic schema view, or
-* https://localhost:8000/openapi for the schema view's OpenAPI specification document.
+* http://localhost:8000 for the list of available collections (in a non-JSON:API format!),
+* http://localhost:8000/swagger-ui/ for a Swagger user interface to the dynamic schema view, or
+* http://localhost:8000/openapi for the schema view's OpenAPI specification document.
 
 
 -----

--- a/README.rst
+++ b/README.rst
@@ -21,15 +21,15 @@ Overview
 **JSON:API support for Django REST framework**
 
 * Documentation: https://django-rest-framework-json-api.readthedocs.org/
-* Format specification: http://jsonapi.org/format/
+* Format specification: https://jsonapi.org/format/
 
 
 By default, Django REST framework will produce a response like::
 
     {
         "count": 20,
-        "next": "http://example.com/api/1.0/identities/?page=3",
-        "previous": "http://example.com/api/1.0/identities/?page=1",
+        "next": "https://example.com/api/1.0/identities/?page=3",
+        "previous": "https://example.com/api/1.0/identities/?page=1",
         "results": [{
             "id": 3,
             "username": "john",
@@ -43,9 +43,9 @@ like the following::
 
     {
         "links": {
-            "prev": "http://example.com/api/1.0/identities",
-            "self": "http://example.com/api/1.0/identities?page=2",
-            "next": "http://example.com/api/1.0/identities?page=3",
+            "prev": "https://example.com/api/1.0/identities",
+            "self": "https://example.com/api/1.0/identities?page=2",
+            "next": "https://example.com/api/1.0/identities?page=3",
         },
         "data": [{
             "type": "identities",
@@ -81,7 +81,7 @@ As a Django REST framework JSON:API (short DJA) we are trying to address followi
 
 5. Be performant
 
-.. _JSON:API: http://jsonapi.org
+.. _JSON:API: https://jsonapi.org
 .. _Django REST framework: https://www.django-rest-framework.org/
 
 ------------
@@ -149,9 +149,9 @@ installed and activated:
 
 Browse to
 
-* http://localhost:8000 for the list of available collections (in a non-JSON:API format!),
-* http://localhost:8000/swagger-ui/ for a Swagger user interface to the dynamic schema view, or
-* http://localhost:8000/openapi for the schema view's OpenAPI specification document.
+* https://localhost:8000 for the list of available collections (in a non-JSON:API format!),
+* https://localhost:8000/swagger-ui/ for a Swagger user interface to the dynamic schema view, or
+* https://localhost:8000/openapi for the schema view's OpenAPI specification document.
 
 
 -----
@@ -202,4 +202,4 @@ override ``settings.REST_FRAMEWORK``
 
 This package provides much more including automatic inflection of JSON keys, extra top level data (using nested
 serializers), relationships, links, paginators, filters, and handy shortcuts.
-Read more at http://django-rest-framework-json-api.readthedocs.org/
+Read more at https://django-rest-framework-json-api.readthedocs.org/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://sphinx-doc.org/)
 endif
 
 # Internal variables.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,9 +97,9 @@ and add `rest_framework_json_api` to your `INSTALLED_APPS` setting below `rest_f
 
 
 Browse to
-* [https://localhost:8000](https://localhost:8000) for the list of available collections (in a non-JSON:API format!),
-* [https://localhost:8000/swagger-ui/](https://localhost:8000/swagger-ui/) for a Swagger user interface to the dynamic schema view, or
-* [https://localhost:8000/openapi](https://localhost:8000/openapi) for the schema view's OpenAPI specification document.
+* [http://localhost:8000](http://localhost:8000) for the list of available collections (in a non-JSON:API format!),
+* [http://localhost:8000/swagger-ui/](http://localhost:8000/swagger-ui/) for a Swagger user interface to the dynamic schema view, or
+* [http://localhost:8000/openapi](http://localhost:8000/openapi) for the schema view's OpenAPI specification document.
 
 ## Running Tests
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,8 +9,8 @@ By default, Django REST framework produces a response like:
 ``` js
 {
     "count": 20,
-    "next": "http://example.com/api/1.0/identities/?page=3",
-    "previous": "http://example.com/api/1.0/identities/?page=1",
+    "next": "https://example.com/api/1.0/identities/?page=3",
+    "previous": "https://example.com/api/1.0/identities/?page=1",
     "results": [{
         "id": 3,
         "username": "john",
@@ -25,10 +25,10 @@ like the following:
 ``` js
 {
     "links": {
-        "first": "http://example.com/api/1.0/identities",
-        "last": "http://example.com/api/1.0/identities?page=5",
-        "next": "http://example.com/api/1.0/identities?page=3",
-        "prev": "http://example.com/api/1.0/identities",
+        "first": "https://example.com/api/1.0/identities",
+        "last": "https://example.com/api/1.0/identities?page=5",
+        "next": "https://example.com/api/1.0/identities?page=3",
+        "prev": "https://example.com/api/1.0/identities",
     },
     "data": [{
         "type": "identities",
@@ -97,9 +97,9 @@ and add `rest_framework_json_api` to your `INSTALLED_APPS` setting below `rest_f
 
 
 Browse to
-* [http://localhost:8000](http://localhost:8000) for the list of available collections (in a non-JSON:API format!),
-* [http://localhost:8000/swagger-ui/](http://localhost:8000/swagger-ui/) for a Swagger user interface to the dynamic schema view, or
-* [http://localhost:8000/openapi](http://localhost:8000/openapi) for the schema view's OpenAPI specification document.
+* [https://localhost:8000](https://localhost:8000) for the list of available collections (in a non-JSON:API format!),
+* [https://localhost:8000/swagger-ui/](https://localhost:8000/swagger-ui/) for a Swagger user interface to the dynamic schema view, or
+* [https://localhost:8000/openapi](https://localhost:8000/openapi) for the schema view's OpenAPI specification document.
 
 ## Running Tests
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -65,7 +65,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://sphinx-doc.org/
 	exit /b 1
 )
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,7 +3,7 @@
 The DJA package implements a custom renderer, parser, exception handler, query filter backends, and
 pagination. To get started enable the pieces in `settings.py` that you want to use.
 
-Many features of the [JSON:API](http://jsonapi.org/format) format standard have been implemented using
+Many features of the [JSON:API](https://jsonapi.org/format) format standard have been implemented using
 Mixin classes in `serializers.py`.
 The easiest way to make use of those features is to import ModelSerializer variants
 from `rest_framework_json_api` instead of the usual `rest_framework`
@@ -116,7 +116,7 @@ is used. This can help the client identify misspelled query parameters, for exam
 
 If you want to change the list of valid query parameters, override the `.query_regex` attribute:
 ```python
-# compiled regex that matches the allowed http://jsonapi.org/format/#query-parameters
+# compiled regex that matches the allowed https://jsonapi.org/format/#query-parameters
 # `sort` and `include` stand alone; `filter`, `fields`, and `page` have []'s
 query_regex = re.compile(r'^(sort|include)$|^(filter|fields|page)(\[[\w\.\-]+\])?$')
 ```
@@ -134,7 +134,7 @@ simply don't use this filter backend.
 
 #### OrderingFilter
 
-`OrderingFilter` implements the [JSON:API `sort`](http://jsonapi.org/format/#fetching-sorting) and uses
+`OrderingFilter` implements the [JSON:API `sort`](https://jsonapi.org/format/#fetching-sorting) and uses
 DRF's [ordering filter](https://www.django-rest-framework.org/api-guide/filtering/#orderingfilter).
 
 Per the JSON:API specification, "If the server does not support sorting as specified in the query parameter `sort`,
@@ -159,14 +159,14 @@ If you want to silently ignore bad sort fields, just use `rest_framework.filters
 
 #### DjangoFilterBackend
 
-`DjangoFilterBackend` implements a Django ORM-style [JSON:API `filter`](http://jsonapi.org/format/#fetching-filtering)
+`DjangoFilterBackend` implements a Django ORM-style [JSON:API `filter`](https://jsonapi.org/format/#fetching-filtering)
 using the [django-filter](https://django-filter.readthedocs.io/) package.
 
 This filter is not part of the JSON:API standard per-se, other than the requirement
 to use the `filter` keyword: It is an optional implementation of a style of
 filtering in which each filter is an ORM expression as implemented by
 `DjangoFilterBackend` and seems to be in alignment with an interpretation of the
-[JSON:API _recommendations_](http://jsonapi.org/recommendations/#filtering), including relationship
+[JSON:API _recommendations_](https://jsonapi.org/recommendations/#filtering), including relationship
 chaining.
 
 Filters can be:
@@ -183,7 +183,7 @@ Filters can be:
     `?filter[inventory.item.partNum]=123456` (where `inventory.item` is the relationship path)
 
 The filter returns a `400 Bad Request` error for invalid filter query parameters as in this example
-for `GET http://127.0.0.1:8000/nopage-entries?filter[bad]=1`:
+for `GET https://127.0.0.1:8000/nopage-entries?filter[bad]=1`:
 ```json
 {
     "errors": [
@@ -240,7 +240,7 @@ class MyViewset(ModelViewSet):
 ### Exception handling
 
 For the `exception_handler` class, if the optional `JSON_API_UNIFORM_EXCEPTIONS` is set to True,
-all exceptions will respond with the JSON:API [error format](http://jsonapi.org/format/#error-objects).
+all exceptions will respond with the JSON:API [error format](https://jsonapi.org/format/#error-objects).
 
 When `JSON_API_UNIFORM_EXCEPTIONS` is False (the default), non-JSON:API views will respond
 with the normal DRF error format.
@@ -312,7 +312,7 @@ multiple endpoints. Setting the `resource_name` on views may result in a differe
 
 ### Inflecting object and relation keys
 
-This package includes the ability (off by default) to automatically convert [JSON:API field names](http://jsonapi.org/format/#document-resource-object-fields) of requests and responses from the python/rest_framework's preferred underscore to
+This package includes the ability (off by default) to automatically convert [JSON:API field names](https://jsonapi.org/format/#document-resource-object-fields) of requests and responses from the python/rest_framework's preferred underscore to
 a format of your choice. To hook this up include the following setting in your
 project settings:
 
@@ -551,7 +551,7 @@ class OrderSerializer(serializers.ModelSerializer):
 
 ```
 
-In the [JSON:API spec](http://jsonapi.org/format/#document-resource-objects),
+In the [JSON:API spec](https://jsonapi.org/format/#document-resource-objects),
 relationship objects contain links to related objects. To make this work
 on a serializer we need to tell the `ResourceRelatedField` about the
 corresponding view. Use the `HyperlinkedModelSerializer` and instantiate
@@ -755,12 +755,12 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
 ### RelationshipView
 `rest_framework_json_api.views.RelationshipView` is used to build
 relationship views (see the
-[JSON:API spec](http://jsonapi.org/format/#fetching-relationships)).
+[JSON:API spec](https://jsonapi.org/format/#fetching-relationships)).
 The `self` link on a relationship object should point to the corresponding
 relationship view.
 
 The relationship view is fairly simple because it only serializes
-[Resource Identifier Objects](http://jsonapi.org/format/#document-resource-identifier-objects)
+[Resource Identifier Objects](https://jsonapi.org/format/#document-resource-identifier-objects)
 rather than full resource objects. In most cases the following is sufficient:
 
 ```python
@@ -896,7 +896,7 @@ Related links will be created automatically when using the Relationship View.
 
 JSON:API can include additional resources in a single network request.
 The specification refers to this feature as
-[Compound Documents](http://jsonapi.org/format/#document-compound-documents).
+[Compound Documents](https://jsonapi.org/format/#document-compound-documents).
 Compound Documents can reduce the number of network requests
 which can lead to a better performing web application.
 To accomplish this,
@@ -1059,10 +1059,10 @@ class MySchemaGenerator(JSONAPISchemaGenerator):
         }
         schema['servers'] = [
             {'url': 'https://localhost/v1', 'description': 'local docker'},
-            {'url': 'http://localhost:8000/v1', 'description': 'local dev'},
+            {'url': 'https://localhost:8000/v1', 'description': 'local dev'},
             {'url': 'https://api.example.com/v1', 'description': 'demo server'},
             {'url': '{serverURL}', 'description': 'provide your server URL',
-             'variables': {'serverURL': {'default': 'http://localhost:8000/v1'}}}
+             'variables': {'serverURL': {'default': 'https://localhost:8000/v1'}}}
         ]
         return schema
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1058,11 +1058,11 @@ class MySchemaGenerator(JSONAPISchemaGenerator):
             }
         }
         schema['servers'] = [
-            {'url': 'https://localhost/v1', 'description': 'local docker'},
-            {'url': 'https://localhost:8000/v1', 'description': 'local dev'},
+            {'url': 'http://localhost/v1', 'description': 'local docker'},
+            {'url': 'http://localhost:8000/v1', 'description': 'local dev'},
             {'url': 'https://api.example.com/v1', 'description': 'demo server'},
             {'url': '{serverURL}', 'description': 'provide your server URL',
-             'variables': {'serverURL': {'default': 'https://localhost:8000/v1'}}}
+             'variables': {'serverURL': {'default': 'http://localhost:8000/v1'}}}
         ]
         return schema
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -183,7 +183,7 @@ Filters can be:
     `?filter[inventory.item.partNum]=123456` (where `inventory.item` is the relationship path)
 
 The filter returns a `400 Bad Request` error for invalid filter query parameters as in this example
-for `GET https://127.0.0.1:8000/nopage-entries?filter[bad]=1`:
+for `GET http://127.0.0.1:8000/nopage-entries?filter[bad]=1`:
 ```json
 {
     "errors": [

--- a/rest_framework_json_api/django_filters/backends.py
+++ b/rest_framework_json_api/django_filters/backends.py
@@ -15,7 +15,7 @@ class DjangoFilterBackend(DjangoFilterBackend):
     to use the `filter` keyword: This is an optional implementation of style of
     filtering in which each filter is an ORM expression as implemented by
     DjangoFilterBackend and seems to be in alignment with an interpretation of
-    http://jsonapi.org/recommendations/#filtering, including relationship
+    https://jsonapi.org/recommendations/#filtering, including relationship
     chaining. It also returns a 400 error for invalid filters.
 
     Filters can be:
@@ -58,8 +58,8 @@ class DjangoFilterBackend(DjangoFilterBackend):
     search_param = api_settings.SEARCH_PARAM
 
     # Make this regex check for 'filter' as well as 'filter[...]'
-    # See http://jsonapi.org/format/#document-member-names for allowed characters
-    # and http://jsonapi.org/format/#document-member-names-reserved-characters for reserved
+    # See https://jsonapi.org/format/#document-member-names for allowed characters
+    # and https://jsonapi.org/format/#document-member-names-reserved-characters for reserved
     # characters (for use in paths, lists or as delimiters).
     # regex `\w` matches [a-zA-Z0-9_].
     # TODO: U+0080 and above allowed but not recommended. Leave them out for now.e

--- a/rest_framework_json_api/filters.py
+++ b/rest_framework_json_api/filters.py
@@ -8,7 +8,7 @@ from rest_framework_json_api.utils import undo_format_field_name
 
 class OrderingFilter(OrderingFilter):
     """
-    A backend filter that implements http://jsonapi.org/format/#fetching-sorting and
+    A backend filter that implements https://jsonapi.org/format/#fetching-sorting and
     raises a 400 error if any sort field is invalid.
 
     If you prefer *not* to report 400 errors for invalid sort fields, just use
@@ -74,10 +74,10 @@ class QueryParameterValidationFilter(BaseFilterBackend):
 
     If you want to add some additional non-standard query parameters,
     override :py:attr:`query_regex` adding the new parameters. Make sure to comply with
-    the rules at http://jsonapi.org/format/#query-parameters.
+    the rules at https://jsonapi.org/format/#query-parameters.
     """
 
-    #: compiled regex that matches the allowed http://jsonapi.org/format/#query-parameters:
+    #: compiled regex that matches the allowed https://jsonapi.org/format/#query-parameters:
     #: `sort` and `include` stand alone; `filter`, `fields`, and `page` have []'s
     query_regex = re.compile(
         r"^(sort|include)$|^(?P<type>filter|fields|page)(\[[\w\.\-]+\])?$"


### PR DESCRIPTION
Fixes #984

## Description of the Change
Changed all external links from `http://`  to `https://`.


## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
