### PR TITLE
Bump to newer codecov action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Test with tox
         run: tox
       - name: Upload coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           env_vars: PYTHON,DJANGO,DJANGO_REST_FRAMEWORK
   check:


### PR DESCRIPTION
## Description of the Change

Codecov Action v1 is deprecated and will be removed, therefore updating to newest runner v2. See [here](https://github.com/codecov/codecov-action) for more details.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
