### PR TITLE
Add codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%
+    project: false
+comment: false


### PR DESCRIPTION
## Description of the Change

* Ensure that PR covers 100% of diff (codecov/patch check)
* Disable project coverage as it may be misleading. (See #976 as an example where codecov/project fails as overall coverage is lower but actually in this case it is lower because code got removed).
* Disable GitHub comments to avoid notifications

Once this is merged we can make codecov/patch a requirement so PR won't be mergeable if diff is not covered. In the rare cases where a code bit cannot be tested it should be marked as `# pragma: no cover` in the code to make it clear.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
