### PR TITLE
Use one GitHub runner per Python version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,17 +5,12 @@ jobs:
   test:
     name: Run test
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.django-rest-framework == 'master' }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9"]
-        django: ["2.2", "3.0", "3.1", "3.2"]
-        django-rest-framework: ["3.12", "master"]
     env:
       PYTHON: ${{ matrix.python-version }}
-      DJANGO: ${{ matrix.django }}
-      DJANGO_REST_FRAMEWORK: ${{ matrix.django-rest-framework }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -25,13 +20,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox tox-gh-actions
-      - name: Test with tox
-        run: tox
+          pip install tox tox-py
+      - name: Run tox targets for ${{ matrix.python-version }}
+        run: tox --py current
       - name: Upload coverage report
         uses: codecov/codecov-action@v2
         with:
-          env_vars: PYTHON,DJANGO,DJANGO_REST_FRAMEWORK
+          env_vars: PYTHON
   check:
     name: Run check
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -3,24 +3,6 @@ envlist =
     py{36,37,38,39}-django{22,30,31,32}-drf{312,master},
     lint,docs
 
-[gh-actions]
-python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
-
-[gh-actions:env]
-DJANGO =
-    2.2: django22
-    3.0: django30
-    3.1: django31
-    3.2: django32
-
-DJANGO_REST_FRAMEWORK =
-    3.12: drf312
-    master: drfmaster
-
 [testenv]
 deps =
     django22: Django>=2.2,<2.3
@@ -61,3 +43,6 @@ deps =
     -rrequirements/requirements-documentation.txt
 commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
+
+[testenv:py{36,37,38,39}-django{22,30,31,32}-drfmaster]
+ignore_outcome = true


### PR DESCRIPTION
## Description of the Change

* Moving from tox-gh-actions to tox-py (the same as DRF is already using)
* Move configuration what tests are allowed to fail into tox instead of GitHub settings
* Simplification of configuration as tox has the lead and no additional configuration is needed for actions.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
