### PR TITLE
Added missing error message when no resource name is configured on serializer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,4 @@ Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
 Ulrich Schuster <ulrich.schuster@mailworks.org>
 Yaniv Peer <yanivpeer@gmail.com>
+Jonas Kiefer <https://github.com/jokiefer>

--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Jamie Bliss <astronouth7303@gmail.com>
 Jason Housley <housleyjk@gmail.com>
 Jeppe Fihl-Pearson <jeppe@tenzer.dk>
 Jerel Unruh <mail@unruhdesigns.com>
+Jonas Kiefer <https://github.com/jokiefer>
 Jonas Metzener <jonas.metzener@adfinis.com>
 Jonathan Senecal <contact@jonathansenecal.com>
 Joseba Mendivil <git@jma.email>
@@ -45,4 +46,3 @@ Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
 Ulrich Schuster <ulrich.schuster@mailworks.org>
 Yaniv Peer <yanivpeer@gmail.com>
-Jonas Kiefer <https://github.com/jokiefer>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ any parts of the framework not mentioned in the documentation should generally b
 * Raise comprehensible error when reserved field names `meta` and `results` are used.
 * Use `relationships` in the error object `pointer` when the field is actually a relationship.
 * Added missing inflection to the generated OpenAPI schema.
-* Added error message if AttributeError is raised by `get_resource_type_from_serializer()`
+* Added missing error message when `resource_name` is not properly configured.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ any parts of the framework not mentioned in the documentation should generally b
 * Raise comprehensible error when reserved field names `meta` and `results` are used.
 * Use `relationships` in the error object `pointer` when the field is actually a relationship.
 * Added missing inflection to the generated OpenAPI schema.
+* Added error message if AttributeError is raised by `get_resource_type_from_serializer()`
 
 ### Changed
 

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -322,7 +322,8 @@ def get_resource_type_from_serializer(serializer):
         return get_resource_type_from_model(meta.model)
     raise AttributeError(
         f"can not detect 'resource_name' on serializer '{serializer.__class__.__name__}'"
-        f" in module '{serializer.__class__.__module__}'")
+        f" in module '{serializer.__class__.__module__}'"
+    )
 
 
 def get_included_resources(request, serializer=None):

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -320,7 +320,7 @@ def get_resource_type_from_serializer(serializer):
         return meta.resource_name
     elif hasattr(meta, "model"):
         return get_resource_type_from_model(meta.model)
-    raise AttributeError()
+    raise AttributeError(f"can not detect 'resource_name' on serializer ' {serializer.__class__}'")
 
 
 def get_included_resources(request, serializer=None):

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -320,7 +320,10 @@ def get_resource_type_from_serializer(serializer):
         return meta.resource_name
     elif hasattr(meta, "model"):
         return get_resource_type_from_model(meta.model)
-    raise AttributeError(f"can not detect 'resource_name' on serializer ' {serializer.__class__}'")
+    # inspect.currentframe().f_code.co_firstlineno
+    raise AttributeError(
+        f"can not detect 'resource_name' on serializer '{serializer.__class__.__name__}'" 
+        f" in module '{serializer.__class__.__module__}:{inspect.getsourcelines(serializer.__class__)[-1]}'")
 
 
 def get_included_resources(request, serializer=None):

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -320,10 +320,9 @@ def get_resource_type_from_serializer(serializer):
         return meta.resource_name
     elif hasattr(meta, "model"):
         return get_resource_type_from_model(meta.model)
-    # inspect.currentframe().f_code.co_firstlineno
     raise AttributeError(
-        f"can not detect 'resource_name' on serializer '{serializer.__class__.__name__}'" 
-        f" in module '{serializer.__class__.__module__}:{inspect.getsourcelines(serializer.__class__)[-1]}'")
+        f"can not detect 'resource_name' on serializer '{serializer.__class__.__name__}'"
+        f" in module '{serializer.__class__.__module__}'")
 
 
 def get_included_resources(request, serializer=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import pytest
-import inspect
 from django.db import models
 from rest_framework import status
 from rest_framework.fields import Field
@@ -381,15 +380,14 @@ def test_get_included_serializers():
 
     assert included_serializers == expected_included_serializers
 
+
 def test_get_resource_type_from_serializer_error_message():
 
     class SerializerWithoutResourceName(serializers.Serializer):
         something = Field()
-    
+
     serializer = SerializerWithoutResourceName()
-        
-    try:
+
+    with pytest.raises(AttributeError) as excinfo:
         get_resource_type_from_serializer(serializer=serializer)
-        raise AssertionError('no AttributeError was raised')
-    except AttributeError as ex:
-        assert str(ex) == f"can not detect 'resource_name' on serializer 'SerializerWithoutResourceName' in module 'tests.test_utils:{inspect.getsourcelines(serializer.__class__)[-1]}'"
+    assert str(excinfo.value) == "can not detect 'resource_name' on serializer 'SerializerWithoutResourceName' in module 'tests.test_utils'"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 from django.db import models
 from rest_framework import status
+from rest_framework.fields import Field
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -15,6 +16,7 @@ from rest_framework_json_api.utils import (
     get_included_serializers,
     get_related_resource_type,
     get_resource_name,
+    get_resource_type_from_serializer,
     undo_format_field_name,
     undo_format_field_names,
     undo_format_link_segment,
@@ -377,3 +379,16 @@ def test_get_included_serializers():
     }
 
     assert included_serializers == expected_included_serializers
+
+def test_get_resource_type_from_serializer_error_message():
+
+    class SerializerWithoutResourceName(serializers.Serializer):
+        something = Field()
+        
+    try:
+        get_resource_type_from_serializer(
+            SerializerWithoutResourceName()
+        )
+        raise AssertionError('no AttributeError was raised')
+    except AttributeError as ex:
+        assert str(ex) == f"can not detect 'resource_name' on serializer 'SerializerWithoutResourceName' in module 'tests.test_utils:385'"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -381,7 +381,7 @@ def test_get_included_serializers():
     assert included_serializers == expected_included_serializers
 
 
-def test_get_resource_type_from_serializer_error_message():
+def test_get_resource_type_from_serializer_without_resource_name_raises_error():
     class SerializerWithoutResourceName(serializers.Serializer):
         something = Field()
 
@@ -389,7 +389,7 @@ def test_get_resource_type_from_serializer_error_message():
 
     with pytest.raises(AttributeError) as excinfo:
         get_resource_type_from_serializer(serializer=serializer)
-    assert (
-        str(excinfo.value)
-        == "can not detect 'resource_name' on serializer 'SerializerWithoutResourceName' in module 'tests.test_utils'"
+    assert str(excinfo.value) == (
+        "can not detect 'resource_name' on serializer "
+        "'SerializerWithoutResourceName' in module 'tests.test_utils'"
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -382,7 +382,6 @@ def test_get_included_serializers():
 
 
 def test_get_resource_type_from_serializer_error_message():
-
     class SerializerWithoutResourceName(serializers.Serializer):
         something = Field()
 
@@ -390,4 +389,7 @@ def test_get_resource_type_from_serializer_error_message():
 
     with pytest.raises(AttributeError) as excinfo:
         get_resource_type_from_serializer(serializer=serializer)
-    assert str(excinfo.value) == "can not detect 'resource_name' on serializer 'SerializerWithoutResourceName' in module 'tests.test_utils'"
+    assert (
+        str(excinfo.value)
+        == "can not detect 'resource_name' on serializer 'SerializerWithoutResourceName' in module 'tests.test_utils'"
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+import inspect
 from django.db import models
 from rest_framework import status
 from rest_framework.fields import Field
@@ -384,11 +385,11 @@ def test_get_resource_type_from_serializer_error_message():
 
     class SerializerWithoutResourceName(serializers.Serializer):
         something = Field()
+    
+    serializer = SerializerWithoutResourceName()
         
     try:
-        get_resource_type_from_serializer(
-            SerializerWithoutResourceName()
-        )
+        get_resource_type_from_serializer(serializer=serializer)
         raise AssertionError('no AttributeError was raised')
     except AttributeError as ex:
-        assert str(ex) == f"can not detect 'resource_name' on serializer 'SerializerWithoutResourceName' in module 'tests.test_utils:385'"
+        assert str(ex) == f"can not detect 'resource_name' on serializer 'SerializerWithoutResourceName' in module 'tests.test_utils:{inspect.getsourcelines(serializer.__class__)[-1]}'"


### PR DESCRIPTION
Partial fix of #1019

## Description of the Change
Enhanced the error message on get_resource type from serializer() to tell the user which serializer in which module is wrong configured.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
