### PR TITLE
Executed pyupgrade with --py3-only

### DIFF
--- a/example/tests/integration/test_includes.py
+++ b/example/tests/integration/test_includes.py
@@ -21,7 +21,7 @@ def test_included_data_on_list(multiple_entries, client):
     comment_count = len(
         [resource for resource in included if resource["type"] == "comments"]
     )
-    expected_comment_count = sum([entry.comments.count() for entry in multiple_entries])
+    expected_comment_count = sum(entry.comments.count() for entry in multiple_entries)
     assert comment_count == expected_comment_count, "List comment count is incorrect"
 
 
@@ -135,17 +135,15 @@ def test_deep_included_data_on_list(multiple_entries, client):
     comment_count = len(
         [resource for resource in included if resource["type"] == "comments"]
     )
-    expected_comment_count = sum([entry.comments.count() for entry in multiple_entries])
+    expected_comment_count = sum(entry.comments.count() for entry in multiple_entries)
     assert comment_count == expected_comment_count, "List comment count is incorrect"
 
     author_count = len(
         [resource for resource in included if resource["type"] == "authors"]
     )
     expected_author_count = sum(
-        [
-            entry.comments.filter(author__isnull=False).count()
-            for entry in multiple_entries
-        ]
+        entry.comments.filter(author__isnull=False).count()
+        for entry in multiple_entries
     )
     assert author_count == expected_author_count, "List author count is incorrect"
 
@@ -153,10 +151,8 @@ def test_deep_included_data_on_list(multiple_entries, client):
         [resource for resource in included if resource["type"] == "authorBios"]
     )
     expected_author_bio_count = sum(
-        [
-            entry.comments.filter(author__bio__isnull=False).count()
-            for entry in multiple_entries
-        ]
+        entry.comments.filter(author__bio__isnull=False).count()
+        for entry in multiple_entries
     )
     assert (
         author_bio_count == expected_author_bio_count
@@ -166,10 +162,8 @@ def test_deep_included_data_on_list(multiple_entries, client):
         [resource for resource in included if resource["type"] == "writers"]
     )
     expected_writer_count = sum(
-        [
-            entry.comments.filter(author__isnull=False).count()
-            for entry in multiple_entries
-        ]
+        entry.comments.filter(author__isnull=False).count()
+        for entry in multiple_entries
     )
     assert writer_count == expected_writer_count, "List writer count is incorrect"
 

--- a/example/tests/integration/test_polymorphism.py
+++ b/example/tests/integration/test_polymorphism.py
@@ -24,12 +24,10 @@ def test_polymorphism_on_detail_relations(single_company, client):
         content["data"]["relationships"]["currentProject"]["data"]["type"]
         == "artProjects"
     )
-    assert set(
-        [
-            rel["type"]
-            for rel in content["data"]["relationships"]["futureProjects"]["data"]
-        ]
-    ) == set(["researchProjects", "artProjects"])
+    assert {
+        rel["type"]
+        for rel in content["data"]["relationships"]["futureProjects"]["data"]
+    } == {"researchProjects", "artProjects"}
 
 
 def test_polymorphism_on_included_relations(single_company, client):
@@ -47,15 +45,15 @@ def test_polymorphism_on_included_relations(single_company, client):
         == "artProjects"
     )
     assert content["data"]["relationships"]["currentResearchProject"]["data"] is None
-    assert set(
-        [
-            rel["type"]
-            for rel in content["data"]["relationships"]["futureProjects"]["data"]
-        ]
-    ) == set(["researchProjects", "artProjects"])
-    assert set([x.get("type") for x in content.get("included")]) == set(
-        ["artProjects", "artProjects", "researchProjects"]
-    ), "Detail included types are incorrect"
+    assert {
+        rel["type"]
+        for rel in content["data"]["relationships"]["futureProjects"]["data"]
+    } == {"researchProjects", "artProjects"}
+    assert {x.get("type") for x in content.get("included")} == {
+        "artProjects",
+        "artProjects",
+        "researchProjects",
+    }, "Detail included types are incorrect"
     # Ensure that the child fields are present.
     assert content.get("included")[0].get("attributes").get("artist") is not None
     assert content.get("included")[1].get("attributes").get("artist") is not None

--- a/example/tests/test_filters.py
+++ b/example/tests/test_filters.py
@@ -600,7 +600,7 @@ class DJATestFilters(APITestCase):
             expected_ids = set.intersection(*union)
             expected_len = len(expected_ids)
             self.assertEqual(len(dja_response["data"]), expected_len)
-            returned_ids = set([k["id"] for k in dja_response["data"]])
+            returned_ids = {k["id"] for k in dja_response["data"]}
             self.assertEqual(returned_ids, expected_ids)
 
     def test_param_invalid(self):


### PR DESCRIPTION
## Description of the Change

Removes some old Python 2 literals

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
