### PR TITLE
Use assert when checking for reserved field names

### DIFF
--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -165,12 +165,11 @@ class ReservedFieldNamesMixin:
         found_reserved_field_names = self._reserved_field_names.intersection(
             fields.keys()
         )
-        if found_reserved_field_names:
-            raise AttributeError(
-                f"Serializer class {self.__class__.__module__}.{self.__class__.__qualname__} "
-                f"uses following reserved field name(s) which is not allowed: "
-                f"{', '.join(sorted(found_reserved_field_names))}"
-            )
+        assert not found_reserved_field_names, (
+            f"Serializer class {self.__class__.__module__}.{self.__class__.__qualname__} "
+            f"uses following reserved field name(s) which is not allowed: "
+            f"{', '.join(sorted(found_reserved_field_names))}"
+        )
 
         if "type" in fields:
             # see https://jsonapi.org/format/#document-resource-object-fields

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -37,7 +37,7 @@ def test_get_included_serializers():
 
 
 def test_reserved_field_names():
-    with pytest.raises(AttributeError) as e:
+    with pytest.raises(AssertionError) as e:
 
         class ReservedFieldNamesSerializer(serializers.Serializer):
             meta = serializers.CharField()


### PR DESCRIPTION
Follow up of #992 

## Description of the Change

This check is for development purposes to verify that the source code is well configured but not needed during production. Therefore a assert is more appropriate.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
