### PR TITLE
Removed support for Django 3.0 and 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST framework policy](https://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
+## [Unreleased]
+
+### Removed
+
+* Removed support for Django 3.0.
+* Removed support for Django 3.1.
+
 ## [4.3.0] - 2021-12-10
+
+This is the last release supporting Django 3.0 and Django 3.1.
 
 ### Added
 

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Requirements
 ------------
 
 1. Python (3.6, 3.7, 3.8, 3.9, 3.10)
-2. Django (2.2, 3.0, 3.1, 3.2, 4.0)
+2. Django (2.2, 3.2, 4.0)
 3. Django REST framework (3.12)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ like the following:
 ## Requirements
 
 1. Python (3.6, 3.7, 3.8, 3.9, 3.10)
-2. Django (2.2, 3.0, 3.1, 3.2, 4.0)
+2. Django (2.2, 3.2, 4.0)
 3. Django REST framework (3.12)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-django{22,30,31,32}-drf{312,master},
+    py{36,37,38,39}-django{22,32}-drf{312,master},
     py{38,39}-django40-drf{312,master},
     py310-django{32,40}-drf{312,master},
     lint,docs
@@ -8,8 +8,6 @@ envlist =
 [testenv]
 deps =
     django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<5.0
     drf312: djangorestframework>=3.12,<3.13
@@ -47,5 +45,5 @@ deps =
 commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
 
-[testenv:py{36,37,38,39}-django{22,30,31,32}-drfmaster]
+[testenv:py{36,37,38,39,310}-django{22,32}-drfmaster]
 ignore_outcome = true


### PR DESCRIPTION
## Description of the Change

Removed end of life Django version 3.0 and 3.1.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
