### PR TITLE
Adjusted to only use f-strings for slight performance improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST framework policy](https://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
+## [Unreleased]
+
+### Changed
+
+* Adjusted to only use f-strings for slight performance improvement.
+
 ## [4.3.0] - 2021-12-10
 
 ### Added

--- a/example/tests/integration/test_polymorphism.py
+++ b/example/tests/integration/test_polymorphism.py
@@ -64,8 +64,8 @@ def test_polymorphism_on_polymorphic_model_detail_patch(single_art_project, clie
     url = reverse("project-detail", kwargs={"pk": single_art_project.pk})
     response = client.get(url)
     content = response.json()
-    test_topic = "test-{}".format(random.randint(0, 999999))
-    test_artist = "test-{}".format(random.randint(0, 999999))
+    test_topic = f"test-{random.randint(0, 999999)}"
+    test_artist = f"test-{random.randint(0, 999999)}"
     content["data"]["attributes"]["topic"] = test_topic
     content["data"]["attributes"]["artist"] = test_artist
     response = client.patch(url, data=content)
@@ -92,8 +92,8 @@ def test_patch_on_polymorphic_model_without_including_required_field(
 
 
 def test_polymorphism_on_polymorphic_model_list_post(client):
-    test_topic = "New test topic {}".format(random.randint(0, 999999))
-    test_artist = "test-{}".format(random.randint(0, 999999))
+    test_topic = f"New test topic {random.randint(0, 999999)}"
+    test_artist = f"test-{random.randint(0, 999999)}"
     test_project_type = ProjectTypeFactory()
     url = reverse("project-list")
     data = {
@@ -152,8 +152,8 @@ def test_polymorphic_model_without_any_instance(client):
 
 
 def test_invalid_type_on_polymorphic_model(client):
-    test_topic = "New test topic {}".format(random.randint(0, 999999))
-    test_artist = "test-{}".format(random.randint(0, 999999))
+    test_topic = f"New test topic {random.randint(0, 999999)}"
+    test_artist = f"test-{random.randint(0, 999999)}"
     url = reverse("project-list")
     data = {
         "data": {

--- a/example/tests/test_serializers.py
+++ b/example/tests/test_serializers.py
@@ -40,9 +40,9 @@ class TestResourceIdentifierObjectSerializer(TestCase):
             rating=3,
         )
         for i in range(1, 6):
-            name = "some_author{}".format(i)
+            name = f"some_author{i}"
             self.entry.authors.add(
-                Author.objects.create(name=name, email="{}@example.org".format(name))
+                Author.objects.create(name=name, email=f"{name}@example.org")
             )
 
     def test_forward_relationship_not_loaded_when_not_included(self):

--- a/example/tests/test_views.py
+++ b/example/tests/test_views.py
@@ -76,15 +76,13 @@ class TestRelationshipView(APITestCase):
 
     def test_get_entry_relationship_invalid_field(self):
         response = self.client.get(
-            "/entries/{}/relationships/invalid_field".format(self.first_entry.id)
+            f"/entries/{self.first_entry.id}/relationships/invalid_field"
         )
 
         assert response.status_code == 404
 
     def test_get_blog_relationship_entry_set(self):
-        response = self.client.get(
-            "/blogs/{}/relationships/entry_set".format(self.blog.id)
-        )
+        response = self.client.get(f"/blogs/{self.blog.id}/relationships/entry_set")
         expected_data = [
             {"type": format_resource_type("Entry"), "id": str(self.first_entry.id)},
             {"type": format_resource_type("Entry"), "id": str(self.second_entry.id)},
@@ -94,9 +92,7 @@ class TestRelationshipView(APITestCase):
 
     @override_settings(JSON_API_FORMAT_RELATED_LINKS="dasherize")
     def test_get_blog_relationship_entry_set_with_formatted_link(self):
-        response = self.client.get(
-            "/blogs/{}/relationships/entry-set".format(self.blog.id)
-        )
+        response = self.client.get(f"/blogs/{self.blog.id}/relationships/entry-set")
         expected_data = [
             {"type": format_resource_type("Entry"), "id": str(self.first_entry.id)},
             {"type": format_resource_type("Entry"), "id": str(self.second_entry.id)},
@@ -105,17 +101,17 @@ class TestRelationshipView(APITestCase):
         assert response.data == expected_data
 
     def test_put_entry_relationship_blog_returns_405(self):
-        url = "/entries/{}/relationships/blog".format(self.first_entry.id)
+        url = f"/entries/{self.first_entry.id}/relationships/blog"
         response = self.client.put(url, data={})
         assert response.status_code == 405
 
     def test_patch_invalid_entry_relationship_blog_returns_400(self):
-        url = "/entries/{}/relationships/blog".format(self.first_entry.id)
+        url = f"/entries/{self.first_entry.id}/relationships/blog"
         response = self.client.patch(url, data={"data": {"invalid": ""}})
         assert response.status_code == 400
 
     def test_relationship_view_errors_format(self):
-        url = "/entries/{}/relationships/blog".format(self.first_entry.id)
+        url = f"/entries/{self.first_entry.id}/relationships/blog"
         response = self.client.patch(url, data={"data": {"invalid": ""}})
         assert response.status_code == 400
 
@@ -125,14 +121,14 @@ class TestRelationshipView(APITestCase):
         assert "errors" in result
 
     def test_get_empty_to_one_relationship(self):
-        url = "/comments/{}/relationships/author".format(self.first_entry.id)
+        url = f"/comments/{self.first_entry.id}/relationships/author"
         response = self.client.get(url)
         expected_data = None
 
         assert response.data == expected_data
 
     def test_get_to_many_relationship_self_link(self):
-        url = "/authors/{}/relationships/comments".format(self.author.id)
+        url = f"/authors/{self.author.id}/relationships/comments"
 
         response = self.client.get(url)
         expected_data = {
@@ -147,7 +143,7 @@ class TestRelationshipView(APITestCase):
         assert json.loads(response.content.decode("utf-8")) == expected_data
 
     def test_patch_to_one_relationship(self):
-        url = "/entries/{}/relationships/blog".format(self.first_entry.id)
+        url = f"/entries/{self.first_entry.id}/relationships/blog"
         request_data = {
             "data": {
                 "type": format_resource_type("Blog"),
@@ -162,7 +158,7 @@ class TestRelationshipView(APITestCase):
         assert response.data == request_data["data"]
 
     def test_patch_one_to_many_relationship(self):
-        url = "/blogs/{}/relationships/entry_set".format(self.first_entry.id)
+        url = f"/blogs/{self.first_entry.id}/relationships/entry_set"
         request_data = {
             "data": [
                 {"type": format_resource_type("Entry"), "id": str(self.first_entry.id)},
@@ -184,7 +180,7 @@ class TestRelationshipView(APITestCase):
         assert response.data == request_data["data"]
 
     def test_patch_one_to_many_relaitonship_with_none(self):
-        url = "/blogs/{}/relationships/entry_set".format(self.first_entry.id)
+        url = f"/blogs/{self.first_entry.id}/relationships/entry_set"
         request_data = {"data": None}
         response = self.client.patch(url, data=request_data)
         assert response.status_code == 200, response.content.decode()
@@ -194,7 +190,7 @@ class TestRelationshipView(APITestCase):
         assert response.data == []
 
     def test_patch_many_to_many_relationship(self):
-        url = "/entries/{}/relationships/authors".format(self.first_entry.id)
+        url = f"/entries/{self.first_entry.id}/relationships/authors"
         request_data = {
             "data": [
                 {"type": format_resource_type("Author"), "id": str(self.author.id)},
@@ -216,7 +212,7 @@ class TestRelationshipView(APITestCase):
         assert response.data == request_data["data"]
 
     def test_post_to_one_relationship_should_fail(self):
-        url = "/entries/{}/relationships/blog".format(self.first_entry.id)
+        url = f"/entries/{self.first_entry.id}/relationships/blog"
         request_data = {
             "data": {
                 "type": format_resource_type("Blog"),
@@ -227,7 +223,7 @@ class TestRelationshipView(APITestCase):
         assert response.status_code == 405, response.content.decode()
 
     def test_post_to_many_relationship_with_no_change(self):
-        url = "/entries/{}/relationships/comments".format(self.first_entry.id)
+        url = f"/entries/{self.first_entry.id}/relationships/comments"
         request_data = {
             "data": [
                 {
@@ -241,7 +237,7 @@ class TestRelationshipView(APITestCase):
         assert len(response.rendered_content) == 0, response.rendered_content.decode()
 
     def test_post_to_many_relationship_with_change(self):
-        url = "/entries/{}/relationships/comments".format(self.first_entry.id)
+        url = f"/entries/{self.first_entry.id}/relationships/comments"
         request_data = {
             "data": [
                 {
@@ -256,7 +252,7 @@ class TestRelationshipView(APITestCase):
         assert request_data["data"][0] in response.data
 
     def test_delete_to_one_relationship_should_fail(self):
-        url = "/entries/{}/relationships/blog".format(self.first_entry.id)
+        url = f"/entries/{self.first_entry.id}/relationships/blog"
         request_data = {
             "data": {
                 "type": format_resource_type("Blog"),
@@ -267,7 +263,7 @@ class TestRelationshipView(APITestCase):
         assert response.status_code == 405, response.content.decode()
 
     def test_delete_relationship_overriding_with_none(self):
-        url = "/comments/{}".format(self.second_comment.id)
+        url = f"/comments/{self.second_comment.id}"
         request_data = {
             "data": {
                 "type": "comments",
@@ -280,7 +276,7 @@ class TestRelationshipView(APITestCase):
         assert response.data["author"] is None
 
     def test_delete_to_many_relationship_with_no_change(self):
-        url = "/entries/{}/relationships/comments".format(self.first_entry.id)
+        url = f"/entries/{self.first_entry.id}/relationships/comments"
         request_data = {
             "data": [
                 {
@@ -294,7 +290,7 @@ class TestRelationshipView(APITestCase):
         assert len(response.rendered_content) == 0, response.rendered_content.decode()
 
     def test_delete_one_to_many_relationship_with_not_null_constraint(self):
-        url = "/entries/{}/relationships/comments".format(self.first_entry.id)
+        url = f"/entries/{self.first_entry.id}/relationships/comments"
         request_data = {
             "data": [
                 {
@@ -307,7 +303,7 @@ class TestRelationshipView(APITestCase):
         assert response.status_code == 409, response.content.decode()
 
     def test_delete_to_many_relationship_with_change(self):
-        url = "/authors/{}/relationships/comments".format(self.author.id)
+        url = f"/authors/{self.author.id}/relationships/comments"
         request_data = {
             "data": [
                 {
@@ -323,7 +319,7 @@ class TestRelationshipView(APITestCase):
         entry = EntryFactory(blog=self.blog, authors=(self.author,))
         comment = CommentFactory(entry=entry)
 
-        url = "/authors/{}/relationships/comments".format(self.author.id)
+        url = f"/authors/{self.author.id}/relationships/comments"
         request_data = {
             "data": [
                 {"type": format_resource_type("Comment"), "id": str(comment.id)},
@@ -597,7 +593,7 @@ class TestModelViewSet(TestBase):
         self.blog = Blog.objects.create(name="Some Blog", tagline="It's a blog")
 
     def test_no_content_response(self):
-        url = "/blogs/{}".format(self.blog.pk)
+        url = f"/blogs/{self.blog.pk}"
         response = self.client.delete(url)
         assert response.status_code == 204, response.rendered_content.decode()
         assert len(response.rendered_content) == 0, response.rendered_content.decode()
@@ -618,8 +614,8 @@ class TestBlogViewSet(APITestCase):
         expected = {
             "data": {
                 "attributes": {"name": self.blog.name},
-                "id": "{}".format(self.blog.id),
-                "links": {"self": "http://testserver/blogs/{}".format(self.blog.id)},
+                "id": f"{self.blog.id}",
+                "links": {"self": f"http://testserver/blogs/{self.blog.id}"},
                 "meta": {"copyright": datetime.now().year},
                 "relationships": {"tags": {"data": [], "meta": {"count": 0}}},
                 "type": "blogs",
@@ -656,13 +652,13 @@ class TestEntryViewSet(APITestCase):
                     "modDate": self.second_entry.mod_date,
                     "pubDate": self.second_entry.pub_date,
                 },
-                "id": "{}".format(self.second_entry.id),
+                "id": f"{self.second_entry.id}",
                 "meta": {"bodyFormat": "text"},
                 "relationships": {
                     "authors": {"data": [], "meta": {"count": 0}},
                     "blog": {
                         "data": {
-                            "id": "{}".format(self.second_entry.blog_id),
+                            "id": f"{self.second_entry.blog_id}",
                             "type": "blogs",
                         }
                     },

--- a/example/tests/unit/test_default_drf_serializers.py
+++ b/example/tests/unit/test_default_drf_serializers.py
@@ -93,8 +93,8 @@ def test_blog_create(client):
     expected = {
         "data": {
             "attributes": {"name": blog.name, "tags": []},
-            "id": "{}".format(blog.id),
-            "links": {"self": "http://testserver/blogs/{}".format(blog.id)},
+            "id": f"{blog.id}",
+            "links": {"self": f"http://testserver/blogs/{blog.id}"},
             "meta": {"copyright": datetime.now().year},
             "type": "blogs",
         },
@@ -113,8 +113,8 @@ def test_get_object_gives_correct_blog(client, blog, entry):
     expected = {
         "data": {
             "attributes": {"name": blog.name, "tags": []},
-            "id": "{}".format(blog.id),
-            "links": {"self": "http://testserver/blogs/{}".format(blog.id)},
+            "id": f"{blog.id}",
+            "links": {"self": f"http://testserver/blogs/{blog.id}"},
             "meta": {"copyright": datetime.now().year},
             "type": "blogs",
         },
@@ -134,8 +134,8 @@ def test_get_object_patches_correct_blog(client, blog, entry):
     request_data = {
         "data": {
             "attributes": {"name": new_name},
-            "id": "{}".format(blog.id),
-            "links": {"self": "http://testserver/blogs/{}".format(blog.id)},
+            "id": f"{blog.id}",
+            "links": {"self": f"http://testserver/blogs/{blog.id}"},
             "meta": {"copyright": datetime.now().year},
             "relationships": {"tags": {"data": []}},
             "type": "blogs",
@@ -150,8 +150,8 @@ def test_get_object_patches_correct_blog(client, blog, entry):
     expected = {
         "data": {
             "attributes": {"name": new_name, "tags": []},
-            "id": "{}".format(blog.id),
-            "links": {"self": "http://testserver/blogs/{}".format(blog.id)},
+            "id": f"{blog.id}",
+            "links": {"self": f"http://testserver/blogs/{blog.id}"},
             "meta": {"copyright": datetime.now().year},
             "type": "blogs",
         },

--- a/rest_framework_json_api/django_filters/backends.py
+++ b/rest_framework_json_api/django_filters/backends.py
@@ -78,7 +78,7 @@ class DjangoFilterBackend(DjangoFilterBackend):
         """
         for k in keys:
             if (not filterset_class) or (k not in filterset_class.base_filters):
-                raise ValidationError("invalid filter[{}]".format(k))
+                raise ValidationError(f"invalid filter[{k}]")
 
     def get_filterset(self, request, queryset, view):
         """
@@ -111,12 +111,10 @@ class DjangoFilterBackend(DjangoFilterBackend):
                 or m.groupdict()["ldelim"] != "["
                 or m.groupdict()["rdelim"] != "]"
             ):
-                raise ValidationError("invalid query parameter: {}".format(qp))
+                raise ValidationError(f"invalid query parameter: {qp}")
             if m and qp != self.search_param:
                 if not all(val):
-                    raise ValidationError(
-                        "missing value for query parameter {}".format(qp)
-                    )
+                    raise ValidationError(f"missing value for query parameter {qp}")
                 # convert JSON:API relationship path to Django ORM's __ notation
                 key = m.groupdict()["assoc"].replace(".", "__")
                 key = undo_format_field_name(key)

--- a/rest_framework_json_api/filters.py
+++ b/rest_framework_json_api/filters.py
@@ -93,14 +93,12 @@ class QueryParameterValidationFilter(BaseFilterBackend):
         for qp in request.query_params.keys():
             m = self.query_regex.match(qp)
             if not m:
-                raise ValidationError("invalid query parameter: {}".format(qp))
+                raise ValidationError(f"invalid query parameter: {qp}")
             if (
                 not m.group("type") == "filter"
                 and len(request.query_params.getlist(qp)) > 1
             ):
-                raise ValidationError(
-                    "repeated query parameter not allowed: {}".format(qp)
-                )
+                raise ValidationError(f"repeated query parameter not allowed: {qp}")
 
     def filter_queryset(self, request, queryset, view):
         """

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -324,7 +324,7 @@ class PolymorphicResourceRelatedField(ResourceRelatedField):
                 "Incorrect relation type. Expected one of [{relation_type}], "
                 "received {received_type}."
             ),
-        }
+        },
     )
 
     def __init__(self, polymorphic_serializer, *args, **kwargs):
@@ -370,7 +370,7 @@ class SerializerMethodFieldBase(Field):
         super().__init__(**kwargs)
 
     def bind(self, field_name, parent):
-        default_method_name = "get_{field_name}".format(field_name=field_name)
+        default_method_name = f"get_{field_name}"
         if self.method_name is None:
             self.method_name = default_method_name
         super().bind(field_name, parent)

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -442,7 +442,7 @@ class PolymorphicModelSerializer(
             return cls._poly_type_serializer_map[obj_type]
         except KeyError:
             raise NotImplementedError(
-                "No polymorphic serializer has been found for type {}".format(obj_type)
+                f"No polymorphic serializer has been found for type {obj_type}"
             )
 
     @classmethod

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -418,7 +418,7 @@ def format_drf_errors(response, context, exc):
             # pointer can be determined only if there's a serializer.
             if has_serializer:
                 rel = "relationships" if field in relationship_fields else "attributes"
-                pointer = "/data/{}/{}".format(rel, field)
+                pointer = f"/data/{rel}/{field}"
             if isinstance(exc, Http404) and isinstance(error, str):
                 # 404 errors don't have a pointer
                 errors.extend(format_error_object(error, None, response))
@@ -462,13 +462,11 @@ def format_error_object(message, pointer, response):
             errors.append(message)
         else:
             for k, v in message.items():
-                errors.extend(
-                    format_error_object(v, pointer + "/{}".format(k), response)
-                )
+                errors.extend(format_error_object(v, pointer + f"/{k}", response))
     elif isinstance(message, list):
         for num, error in enumerate(message):
             if isinstance(error, (list, dict)):
-                new_pointer = pointer + "/{}".format(num)
+                new_pointer = pointer + f"/{num}"
             else:
                 new_pointer = pointer
             if error:


### PR DESCRIPTION
## Description of the Change

Since we dropped Python 3.5 support let's make use of the new f-string feature in Python 3.6+ for code improvement and readability.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
