### PR TITLE
Added support for Django REST framework 3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ any parts of the framework not mentioned in the documentation should generally b
 
 ## [Unreleased]
 
+### Added
+
+* Added support for Django REST framework 3.13.
+
 ### Changed
 
 * Adjusted to only use f-strings for slight performance improvement.

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Requirements
 
 1. Python (3.6, 3.7, 3.8, 3.9, 3.10)
 2. Django (2.2, 3.2, 4.0)
-3. Django REST framework (3.12)
+3. Django REST framework (3.12, 3.13)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ like the following:
 
 1. Python (3.6, 3.7, 3.8, 3.9, 3.10)
 2. Django (2.2, 3.2, 4.0)
-3. Django REST framework (3.12)
+3. Django REST framework (3.12, 3.13)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.
 

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -6,8 +6,3 @@ pytest-cov==3.0.0
 pytest-django==4.5.1
 pytest-factoryboy==2.1.0
 syrupy==1.5.0
-# TODO remove pytz dep again once DRF higher than 3.12.4 is released
-# Django 4.0 removed dependency on pytz and made it optional but
-# DRF requires it and will define it as dependency in future versions
-# only adding this to testing though as DJA does not directly use pytz
-pytz==2021.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,8 +58,6 @@ DJANGO_SETTINGS_MODULE=example.settings.test
 filterwarnings =
     error::DeprecationWarning
     error::PendingDeprecationWarning
-    # TODO remove again once DRF higher than 3.12.4 has been released
-    ignore:'rest_framework' defines default_app_config
     # TODO remove in next major version of DJA 5.0.0
     # this deprecation warning filter needs to be added as AuthorSerializer is used in
     # too many tests which introduced the type field name in tests

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     ],
     install_requires=[
         "inflection>=0.3.0",
-        "djangorestframework>=3.12,<3.13",
+        "djangorestframework>=3.12,<3.14",
         "django>=2.2,<4.1",
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
-    py{36,37,38,39}-django{22,32}-drf{312,master},
-    py{38,39}-django40-drf{312,master},
-    py310-django{32,40}-drf{312,master},
+    py{36,37,38,39,310}-django{22,32}-drf{312,313,master},
+    py{38,39,310}-django40-drf{313,master},
     lint,docs
 
 [testenv]
@@ -11,6 +10,7 @@ deps =
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<5.0
     drf312: djangorestframework>=3.12,<3.13
+    drf313: djangorestframework>=3.13,<3.14
     drfmaster: https://github.com/encode/django-rest-framework/archive/master.zip
     -rrequirements/requirements-testing.txt
     -rrequirements/requirements-optionals.txt
@@ -45,5 +45,5 @@ deps =
 commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
 
-[testenv:py{36,37,38,39,310}-django{22,32}-drfmaster]
+[testenv:py{36,37,38,39,310}-django{22,32,40}-drfmaster]
 ignore_outcome = true


### PR DESCRIPTION
## Description of the Change

Added support for Django REST framework 3.13

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
