### PR TITLE
Rename primary branch from master to main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '33 5 * * 6'
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1054,7 +1054,7 @@ class MySchemaGenerator(JSONAPISchemaGenerator):
             },
             'license': {
                 'name': 'BSD 2 clause',
-                'url': 'https://github.com/django-json-api/django-rest-framework-json-api/blob/master/LICENSE',
+                'url': 'https://github.com/django-json-api/django-rest-framework-json-api/blob/main/LICENSE',
             }
         }
         schema['servers'] = [


### PR DESCRIPTION
## Description of the Change

This is now the standard naming of git repositories and Django has also moved to `main` naming.

What needs to be done besides this PR:
- [ ] Update primary branch in GitHub settings
- [ ] Update to main branch in ReadTheDocs
- [ ] Check CodeCov integration

Add more TODOs in case I am missing anything.

For our local setup each of us will need to run the following:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```