### PR TITLE
Removed support for Python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:
@@ -36,10 +36,10 @@ jobs:
         tox-env: ["black", "lint", "docs"]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,11 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Removed support for Django 3.0.
 * Removed support for Django 3.1.
+* Removed support for Python 3.6.
 
 ## [4.3.0] - 2021-12-10
 
-This is the last release supporting Django 3.0 and Django 3.1.
+This is the last release supporting Django 3.0, Django 3.1 and Python 3.6.
 
 ### Added
 

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ As a Django REST framework JSON:API (short DJA) we are trying to address followi
 Requirements
 ------------
 
-1. Python (3.6, 3.7, 3.8, 3.9, 3.10)
+1. Python (3.7, 3.8, 3.9, 3.10)
 2. Django (2.2, 3.2, 4.0)
 3. Django REST framework (3.12, 3.13)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ like the following:
 
 ## Requirements
 
-1. Python (3.6, 3.7, 3.8, 3.9, 3.10)
+1. Python (3.7, 3.8, 3.9, 3.10)
 2. Django (2.2, 3.2, 4.0)
 3. Django REST framework (3.12, 3.13)
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(*paths):
     """
     Build a file path from paths and return the contents.
     """
-    with open(os.path.join(*paths), "r") as f:
+    with open(os.path.join(*paths)) as f:
         return f.read()
 
 
@@ -86,7 +86,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -106,6 +105,6 @@ setup(
         "openapi": ["pyyaml>=5.4", "uritemplate>=3.0.1"],
     },
     setup_requires=wheel,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-django{22,32}-drf{312,313,master},
+    py{37,38,39,310}-django{22,32}-drf{312,313,master},
     py{38,39,310}-django40-drf{313,master},
     lint,docs
 
@@ -23,13 +23,13 @@ commands =
     pytest --cov --no-cov-on-fail --cov-report xml {posargs}
 
 [testenv:black]
-basepython = python3.6
+basepython = python3.7
 deps =
     -rrequirements/requirements-codestyle.txt
 commands = black --check .
 
 [testenv:lint]
-basepython = python3.6
+basepython = python3.7
 deps =
     -rrequirements/requirements-codestyle.txt
     -rrequirements/requirements-testing.txt
@@ -37,7 +37,7 @@ deps =
 commands = flake8
 
 [testenv:docs]
-basepython = python3.6
+basepython = python3.7
 deps =
     -rrequirements/requirements-testing.txt
     -rrequirements/requirements-optionals.txt
@@ -45,5 +45,5 @@ deps =
 commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
 
-[testenv:py{36,37,38,39,310}-django{22,32,40}-drfmaster]
+[testenv:py{37,38,39,310}-django{22,32,40}-drfmaster]
 ignore_outcome = true


### PR DESCRIPTION
## Description of the Change

Removing Python 3.6 support as it is [end of life](https://endoflife.date/python).

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
