### PR TITLE
differs correctly between `meta` properties and `attribute` propertie…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST framework policy](https://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
+## [Unreleased] - 2022-x-xx
+
+### Fixed
+
+* differs correctly between `meta` properties and `attribute` properties in component schemas.
+
 ## [5.0.0] - 2022-01-03
 
 This release is not backwards compatible. For easy migration best upgrade first to version

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -648,6 +648,7 @@ class AutoSchema(drf_openapi.AutoSchema):
         required = []
         attributes = {}
         relationships = {}
+        meta = {}
 
         for field in serializer.fields.values():
             if isinstance(field, serializers.HyperlinkedIdentityField):
@@ -683,7 +684,12 @@ class AutoSchema(drf_openapi.AutoSchema):
                 schema["description"] = str(field.help_text)
             self.map_field_validators(field, schema)
 
-            attributes[format_field_name(field.field_name)] = schema
+            if field.field_name in list(
+                getattr(serializer.Meta, "meta_fields", list())
+            ):
+                meta[format_field_name(field.field_name)] = schema
+            else:
+                attributes[format_field_name(field.field_name)] = schema
 
         result = {
             "type": "object",


### PR DESCRIPTION
…s in component schemas.

Fixes #

## Description of the Change

## Checklist

- [x] PR only contains one change (considered splitting up PR)
~- [ ] unit-test added~
~- [ ] documentation updated~
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
