### PR TITLE
Avoid calling get_serializer during error handling

### DIFF
--- a/example/tests/__snapshots__/test_errors.ambr
+++ b/example/tests/__snapshots__/test_errors.ambr
@@ -61,6 +61,17 @@
     ],
   }
 ---
+# name: test_404_during_serializer_context
+  <class 'dict'> {
+    'errors': <class 'list'> [
+      <class 'dict'> {
+        'code': 'not_found',
+        'detail': 'Not found.',
+        'status': '404',
+      },
+    ],
+  }
+---
 # name: test_second_level_array_error
   <class 'dict'> {
     'errors': <class 'list'> [

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -377,8 +377,12 @@ def format_drf_errors(response, context, exc):
 
         has_serializer = isinstance(context["view"], generics.GenericAPIView)
         if has_serializer:
-            serializer = context["view"].get_serializer()
-            fields = get_serializer_fields(serializer) or dict()
+            try:
+                serializer_class = context["view"].get_serializer_class()
+                serializer = serializer_class()
+                fields = get_serializer_fields(serializer) or dict()
+            except Exception:
+                fields = []
             relationship_fields = [
                 name for name, field in fields.items() if is_relationship_field(field)
             ]


### PR DESCRIPTION
`get_serializer` can be a complex method that is allowed to throw errors both itself and in `get_serializer_context` that it depends on, e.g. query a database and throw `Http404`. `format_drf_errors` will attempt to call it again potentially raising the same issue or even a new one due to for example missing required argument (a view may implement `def get_serializer(instance)` while `format_drf_errors` always calls it as `get_serializer()`).

This patch does two things:
1. Uses `get_serializer_class` instead of `get_serializer` to find relationship fields. The reasoning is that `get_serializer_class` should give us the field information that we need while avoiding the additional custom view logic potentially contained in `get_serializer` or `get_serializer_context`.
2. Surrounds the code that computes `relationship_fields` in `format_drf_errors` in a try-except block to attempt to continue formatting the errors without knowing relationship fields instead of causing 500 error.

## Description of the Change

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
