### PR TITLE
Added requirements.txt for ReadTheDocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+# RTD only supports one requirements.txt file, therefore this has been created.
+# This file needs to keep in sync with tox testenv docs dependencies.
+
+-r ../requirements/requirements-optionals.txt
+-r ../requirements/requirements-testing.txt
+-r ../requirements/requirements-documentation.txt


### PR DESCRIPTION
## Description of the Change

Flake8 and Spinx cannot be installed together anymore as of a conflict with importlib-metadata package.

As RTD only supports one requirements.txt file we need a separate one where only the dependencies for creation of documentation are installed.

This should solve this RTD [build error](https://readthedocs.org/projects/django-rest-framework-json-api/builds/16152993/).

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
