### PR TITLE
Support many related field

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ Adam Wróbel <https://adamwrobel.com>
 Adam Ziolkowski <adam@adsized.com>
 Alan Crosswell <alan@columbia.edu>
 Anton Shutik <shutikanton@gmail.com>
+Ashley Loewen <github@ashleycodes.tech>
 Asif Saif Uddin <auvipy@gmail.com>
 Beni Keller <beni@matraxi.ch>
 Boris Pleshakov <koordinator.kun@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Fixed
 
 * Fixed invalid relationship pointer in error objects when field naming formatting is used.
+* Properly resolved related resource type when nested source field is defined.
 
 ## [5.0.0] - 2022-01-03
 

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -219,6 +219,12 @@ def get_related_resource_type(relation):
         # For ManyToMany relationships, get the model from the child
         # serializer of the list serializer
         relation_model = relation.child.Meta.model
+    elif (
+        hasattr(relation, "child_relation")
+        and hasattr(relation.child_relation, "model")
+    ):
+        # For ManyRelatedField relationships, get the model from the child relationship
+        relation_model = relation.child_relation.model
     else:
         parent_serializer = relation.parent
         parent_model = None

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -211,21 +211,15 @@ def get_related_resource_type(relation):
         relation_model = relation.model
     elif hasattr(relation, "get_queryset") and relation.get_queryset() is not None:
         relation_model = relation.get_queryset().model
-    elif (
-        getattr(relation, "many", False)
-        and hasattr(relation.child, "Meta")
-        and hasattr(relation.child.Meta, "model")
-    ):
-        # For ManyToMany relationships, get the model from the child
-        # serializer of the list serializer
-        relation_model = relation.child.Meta.model
-    elif (
-        hasattr(relation, "child_relation")
-        and hasattr(relation.child_relation, "model")
-    ):
+    elif hasattr(relation, "child_relation"):
         # For ManyRelatedField relationships, get the model from the child relationship
-        relation_model = relation.child_relation.model
-    else:
+        try:
+            return get_related_resource_type(relation.child_relation)
+        except AttributeError:
+            # Some read only relationships fail to get it directly, fall through to
+            # get via the parent
+            pass
+    if not relation_model:
         parent_serializer = relation.parent
         parent_model = None
         if isinstance(parent_serializer, PolymorphicModelSerializer):

--- a/tests/models.py
+++ b/tests/models.py
@@ -39,3 +39,14 @@ class ForeignKeySource(DJAModel):
     target = models.ForeignKey(
         ForeignKeyTarget, related_name="sources", on_delete=models.CASCADE
     )
+
+
+class NestedRelationshipSource(DJAModel):
+    m2m_source = models.ManyToManyField(ManyToManySource, related_name="nested_source")
+    fk_source = models.ForeignKey(
+        ForeignKeySource, related_name="nested_source", on_delete=models.CASCADE
+    )
+    m2m_target = models.ManyToManyField(ManyToManySource, related_name="nested_source")
+    fk_target = models.ForeignKey(
+        ForeignKeySource, related_name="nested_source", on_delete=models.CASCADE
+    )

--- a/tests/models.py
+++ b/tests/models.py
@@ -41,7 +41,7 @@ class ForeignKeySource(DJAModel):
     )
 
 
-class NestedRelationshipSource(DJAModel):
+class NestedRelatedSource(DJAModel):
     m2m_source = models.ManyToManyField(ManyToManySource, related_name="nested_source")
     fk_source = models.ForeignKey(
         ForeignKeySource, related_name="nested_source", on_delete=models.CASCADE

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,7 @@ from tests.models import (
     ForeignKeyTarget,
     ManyToManySource,
     ManyToManyTarget,
-    NestedRelationshipSource,
+    NestedRelatedSource,
 )
 from tests.serializers import BasicModelSerializer
 
@@ -315,48 +315,44 @@ def test_get_related_resource_type(model_class, field, output):
 
 
 @pytest.mark.parametrize(
-    "model_class,field,output,related_field_kwargs",
+    "field,output,related_field_kwargs",
     [
         (
-            NestedRelationshipSource,
             "m2m_source.targets",
             "ManyToManyTarget",
             {"many": True, "queryset": ManyToManyTarget.objects.all()},
         ),
         (
-            NestedRelationshipSource,
             "m2m_target.sources.",
             "ManyToManySource",
             {"many": True, "queryset": ManyToManySource.objects.all()},
         ),
         (
-            NestedRelationshipSource,
             "fk_source.target",
             "ForeignKeyTarget",
             {"many": True, "queryset": ForeignKeyTarget.objects.all()},
         ),
         (
-            NestedRelationshipSource,
             "fk_target.source",
             "ForeignKeySource",
             {"many": True, "queryset": ForeignKeySource.objects.all()},
         ),
     ],
 )
-def test_get_related_resource_type_nested_source(
-    model_class, field, output, related_field_kwargs
+def test_get_related_resource_type_from_nested_source(
+    db, field, output, related_field_kwargs
 ):
     class RelatedResourceTypeSerializer(serializers.ModelSerializer):
-        relationship = serializers.ResourceRelatedField(
+        relation = serializers.ResourceRelatedField(
             source=field, **related_field_kwargs
         )
 
         class Meta:
-            model = model_class
-            fields = ("relationship",)
+            model = NestedRelatedSource
+            fields = ("relation",)
 
     serializer = RelatedResourceTypeSerializer()
-    field = serializer.fields["relationship"]
+    field = serializer.fields["relation"]
     assert get_related_resource_type(field) == output
 
 


### PR DESCRIPTION
Fixes #912 

## Description of the Change

I'm not sure if this specifically fixes the entirety of the first issue linked, I haven't had any problems with nested relationships that aren't M2M. However, this solves nesting for M2M on non declared fields. (Requires workaround for DRF in `ModelSerializer.build_field` to handle dotted field sources. Separate bug in that repo)

Slightly contrived example documenting equivalent structure to my local issue
```
class CourseSectionSerializer(ModelSerializer):
    class Meta:
        model = Student
        fields = ("students",)  # M2M on "course" related field
        extra_kwargs = {
            "students": {"source": "course.students"}
        }
```

Currently, this crashes on the line highlighted in the issue linked. It appears that somewhere along the line DRF updated how many relationships work and the previous `elif` above the code I specified doesn't lookup the current attributes properly. I'm not sure if there is a version/edge case that still can flow through it or not so I left it as is.

It's my first time adding something to this repo, so please direct me for where an appropriate unit test should live or any docs to update. Right now this is a quick in browser edit to fix a bug I'm having in development.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
