### PR TITLE
Fixed invalid relationship pointer in error object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST framework policy](https://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
+## [Unreleased]
+
+### Fixed
+
+* Fixed invalid relationship pointer in error objects when field naming formatting is used.
+
 ## [5.0.0] - 2022-01-03
 
 This release is not backwards compatible. For easy migration best upgrade first to version

--- a/example/tests/__snapshots__/test_errors.ambr
+++ b/example/tests/__snapshots__/test_errors.ambr
@@ -47,14 +47,66 @@
     ]),
   })
 # ---
-# name: test_relationship_errors_has_correct_pointers
+# name: test_relationship_errors_has_correct_pointers_with_camelize
   dict({
     'errors': list([
       dict({
         'code': 'incorrect_type',
         'detail': 'Incorrect type. Expected resource identifier object, received str.',
         'source': dict({
-          'pointer': '/data/relationships/author',
+          'pointer': '/data/relationships/authors',
+        }),
+        'status': '400',
+      }),
+      dict({
+        'code': 'incorrect_type',
+        'detail': 'Incorrect type. Expected resource identifier object, received str.',
+        'source': dict({
+          'pointer': '/data/relationships/mainAuthor',
+        }),
+        'status': '400',
+      }),
+    ]),
+  })
+# ---
+# name: test_relationship_errors_has_correct_pointers_with_dasherize
+  dict({
+    'errors': list([
+      dict({
+        'code': 'incorrect_type',
+        'detail': 'Incorrect type. Expected resource identifier object, received str.',
+        'source': dict({
+          'pointer': '/data/relationships/authors',
+        }),
+        'status': '400',
+      }),
+      dict({
+        'code': 'incorrect_type',
+        'detail': 'Incorrect type. Expected resource identifier object, received str.',
+        'source': dict({
+          'pointer': '/data/relationships/main-author',
+        }),
+        'status': '400',
+      }),
+    ]),
+  })
+# ---
+# name: test_relationship_errors_has_correct_pointers_with_no_formatting
+  dict({
+    'errors': list([
+      dict({
+        'code': 'incorrect_type',
+        'detail': 'Incorrect type. Expected resource identifier object, received str.',
+        'source': dict({
+          'pointer': '/data/relationships/authors',
+        }),
+        'status': '400',
+      }),
+      dict({
+        'code': 'incorrect_type',
+        'detail': 'Incorrect type. Expected resource identifier object, received str.',
+        'source': dict({
+          'pointer': '/data/relationships/main_author',
         }),
         'status': '400',
       }),

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -380,7 +380,9 @@ def format_drf_errors(response, context, exc):
             serializer = context["view"].get_serializer()
             fields = get_serializer_fields(serializer) or dict()
             relationship_fields = [
-                name for name, field in fields.items() if is_relationship_field(field)
+                format_field_name(name)
+                for name, field in fields.items()
+                if is_relationship_field(field)
             ]
 
         for field, error in response.data.items():


### PR DESCRIPTION
Fixes #1069

## Description of the Change

- Add failing tests for misformed relationship pointers in error payloads
- Properly format relationship pointers in error payloads

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- ~documentation updated~ N/A
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
    - Dunno if relevant, only fixes an expected behavior and no-one complained so far…
- [x] author name in `AUTHORS`
