### PR TITLE
Removed support for Django 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,16 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Fixed invalid relationship pointer in error objects when field naming formatting is used.
 
+### Removed
+
+* Removed support for Django 2.2.
+
 ## [5.0.0] - 2022-01-03
 
 This release is not backwards compatible. For easy migration best upgrade first to version
 4.3.0 and resolve all deprecation warnings before updating to 5.0.0
+
+This is the last release supporting Django 2.2.
 
 ### Added
 

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Requirements
 ------------
 
 1. Python (3.7, 3.8, 3.9, 3.10)
-2. Django (2.2, 3.2, 4.0)
+2. Django (3.2, 4.0)
 3. Django REST framework (3.12, 3.13)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ like the following:
 ## Requirements
 
 1. Python (3.7, 3.8, 3.9, 3.10)
-2. Django (2.2, 3.2, 4.0)
+2. Django (3.2, 4.0)
 3. Django REST framework (3.12, 3.13)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     install_requires=[
         "inflection>=0.5.0",
         "djangorestframework>=3.12,<3.14",
-        "django>=2.2,<4.1",
+        "django>=3.2,<4.1",
     ],
     extras_require={
         "django-polymorphic": ["django-polymorphic>=3.0"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist =
-    py{37,38,39,310}-django{22,32}-drf{312,313,master},
+    py{37,38,39,310}-django32-drf{312,313,master},
     py{38,39,310}-django40-drf{313,master},
     lint,docs
 
 [testenv]
 deps =
-    django22: Django>=2.2,<2.3
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<5.0
     drf312: djangorestframework>=3.12,<3.13
@@ -45,5 +44,5 @@ deps =
 commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
 
-[testenv:py{37,38,39,310}-django{22,32,40}-drfmaster]
+[testenv:py{37,38,39,310}-django{32,40}-drfmaster]
 ignore_outcome = true


### PR DESCRIPTION
## Description of the Change

Removed obsolete Django 2.2 support which is end of life since more than 3 months.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
