### PR TITLE
Avoid overwriting of pointer when formatting error object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Fixed invalid relationship pointer in error objects when field naming formatting is used.
 * Properly resolved related resource type when nested source field is defined.
+* Prevented overwriting of pointer in custom error object
 
 ### Added
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -237,13 +237,28 @@ class MyViewset(ModelViewSet):
 
 ```
 
-### Exception handling
+### Error objects / Exception handling
 
 For the `exception_handler` class, if the optional `JSON_API_UNIFORM_EXCEPTIONS` is set to True,
 all exceptions will respond with the JSON:API [error format](https://jsonapi.org/format/#error-objects).
 
 When `JSON_API_UNIFORM_EXCEPTIONS` is False (the default), non-JSON:API views will respond
 with the normal DRF error format.
+
+In case you need a custom error object you can simply raise an `rest_framework.serializers.ValidationError` like the following:
+
+```python
+raise serializers.ValidationError(
+    {
+        "id": "your-id",
+        "detail": "your detail message",
+        "source": {
+            "pointer": "/data/attributes/your-pointer",
+        }
+
+    }
+)
+```
 
 ### Performance Testing
 

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -417,21 +417,20 @@ def format_error_object(message, pointer, response):
     if isinstance(message, dict):
 
         # as there is no required field in error object we check that all fields are string
-        # except links and source which might be a dict
+        # except links, source or meta which might be a dict
         is_custom_error = all(
             [
                 isinstance(value, str)
                 for key, value in message.items()
-                if key not in ["links", "source"]
+                if key not in ["links", "source", "meta"]
             ]
         )
 
         if is_custom_error:
             if "source" not in message:
                 message["source"] = {}
-            message["source"] = {
-                "pointer": pointer,
-            }
+            if "pointer" not in message["source"]:
+                message["source"]["pointer"] = pointer
             errors.append(message)
         else:
             for k, v in message.items():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ from rest_framework.views import APIView
 
 from rest_framework_json_api import serializers
 from rest_framework_json_api.utils import (
+    format_error_object,
     format_field_name,
     format_field_names,
     format_link_segment,
@@ -389,3 +390,45 @@ def test_get_resource_type_from_serializer_without_resource_name_raises_error():
         "can not detect 'resource_name' on serializer "
         "'SerializerWithoutResourceName' in module 'tests.test_utils'"
     )
+
+
+@pytest.mark.parametrize(
+    "message,pointer,response,result",
+    [
+        # Test that pointer does not get overridden in custom error
+        (
+            {
+                "status": "400",
+                "source": {
+                    "pointer": "/data/custom-pointer",
+                },
+                "meta": {"key": "value"},
+            },
+            "/data/default-pointer",
+            Response(status.HTTP_400_BAD_REQUEST),
+            [
+                {
+                    "status": "400",
+                    "source": {"pointer": "/data/custom-pointer"},
+                    "meta": {"key": "value"},
+                }
+            ],
+        ),
+        # Test that pointer gets added to custom error
+        (
+            {
+                "detail": "custom message",
+            },
+            "/data/default-pointer",
+            Response(status.HTTP_400_BAD_REQUEST),
+            [
+                {
+                    "detail": "custom message",
+                    "source": {"pointer": "/data/default-pointer"},
+                }
+            ],
+        ),
+    ],
+)
+def test_format_error_object(message, pointer, response, result):
+    assert result == format_error_object(message, pointer, response)


### PR DESCRIPTION
Fixes #399

Do not overwrite source.pointer field if it's already there; even if our pointer is calculated differently. Sorry for not updating the tests; tested it manually and it works for me and existing tests pass

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
