### PR TITLE
Add a separate parse_data method to JSONParser

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Adam Wróbel <https://adamwrobel.com>
 Adam Ziolkowski <adam@adsized.com>
 Alan Crosswell <alan@columbia.edu>
+Alex Seidmann <alex@leanpnt.de>
 Anton Shutik <shutikanton@gmail.com>
 Ashley Loewen <github@ashleycodes.tech>
 Asif Saif Uddin <auvipy@gmail.com>
@@ -47,4 +48,3 @@ Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
 Ulrich Schuster <ulrich.schuster@mailworks.org>
 Yaniv Peer <yanivpeer@gmail.com>
-Alex Seidmann <alex@leanpnt.de>

--- a/AUTHORS
+++ b/AUTHORS
@@ -47,3 +47,4 @@ Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
 Ulrich Schuster <ulrich.schuster@mailworks.org>
 Yaniv Peer <yanivpeer@gmail.com>
+Alex Seidmann <alex@leanpnt.de>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Added
 
 * Added support for Django 4.1.
+* Expanded JSONParser API with `parse_data` method
 
 ### Removed
 

--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -72,7 +72,7 @@ class JSONParser(parsers.JSONParser):
 
     def parse_data(self, result, parser_context):
         """
-        Formats the output of calling JSONParser to match the JSON:API specification 
+        Formats the output of calling JSONParser to match the JSON:API specification
         and returns the result.
         """
         if not isinstance(result, dict) or "data" not in result:

--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -70,14 +70,11 @@ class JSONParser(parsers.JSONParser):
         else:
             return {}
 
-    def parse(self, stream, media_type=None, parser_context=None):
+    def parse_data(self, result, parser_context):
         """
-        Parses the incoming bytestream as JSON and returns the resulting data
+        Formats the output of calling JSONParser to match the JSON:API specification 
+        and returns the result.
         """
-        result = super().parse(
-            stream, media_type=media_type, parser_context=parser_context
-        )
-
         if not isinstance(result, dict) or "data" not in result:
             raise ParseError("Received document does not contain primary data")
 
@@ -166,3 +163,13 @@ class JSONParser(parsers.JSONParser):
         parsed_data.update(self.parse_relationships(data))
         parsed_data.update(self.parse_metadata(result))
         return parsed_data
+
+    def parse(self, stream, media_type=None, parser_context=None):
+        """
+        Parses the incoming bytestream as JSON and returns the resulting data
+        """
+        result = super().parse(
+            stream, media_type=media_type, parser_context=parser_context
+        )
+
+        return self.parse_data(result, parser_context)


### PR DESCRIPTION
## Description of the Change
This PR separates out the functionality of `parse` from `JSONParser` to a new `parse_data` method to allow parsing JSON data to the JSON:API specification directly, without passing a request byte stream directly. See #1079 

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
