### PR TITLE
Document how to override DRF generateschema generator_class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ any parts of the framework not mentioned in the documentation should generally b
 * Added support for Django 4.1.
 * Expanded JSONParser API with `parse_data` method
 
+### Changed
+
+* Improved documentation of how to override DRF's generateschema `--generator_class` to generate a proper DJA OAS schema.
+
 ### Removed
 
 * Removed support for Django 2.2.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1085,11 +1085,10 @@ class MySchemaGenerator(JSONAPISchemaGenerator):
 ### Generate a Static Schema on Command Line
 
 See [DRF documentation for generateschema](https://www.django-rest-framework.org/api-guide/schemas/#generating-a-static-schema-with-the-generateschema-management-command)
-To generate an OAS schema document, use something like:
+To generate a static OAS schema document, using the `generateschema` management command, you **must override DRF's default** `generator_class` with the DJA-specific version:
 
 ```text
-$ django-admin generateschema --settings=example.settings \
-                              --generator_class myapp.views.MySchemaGenerator >myschema.yaml
+$ ./manage.py generateschema --generator_class rest_framework_json_api.schemas.openapi.SchemaGenerator
 ```
 
 You can then use any number of OAS tools such as


### PR DESCRIPTION
Fixes #1080 

## Description of the Change

Documents how to override the default DRF `generateschema` `--generator_class` with one that is DJA-specific.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
