### PR TITLE
Avoided using same related name twice in tests models

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -46,7 +46,7 @@ class NestedRelatedSource(DJAModel):
     fk_source = models.ForeignKey(
         ForeignKeySource, related_name="nested_source", on_delete=models.CASCADE
     )
-    m2m_target = models.ManyToManyField(ManyToManySource, related_name="nested_source")
+    m2m_target = models.ManyToManyField(ManyToManySource, related_name="nested_target")
     fk_target = models.ForeignKey(
-        ForeignKeySource, related_name="nested_source", on_delete=models.CASCADE
+        ForeignKeySource, related_name="nested_target", on_delete=models.CASCADE
     )


### PR DESCRIPTION
## Description of the Change

When calling makemigrations errors were raised as of conflict with related names. No test actually relied on this naming, so this PR cleans it up. I bumped into this when working on #1048 and could not create a migration without this change.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
