### PR TITLE
Added support for DRF 3.14 and dropping support for DRF 3.12.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Added
 
 * Added support for Django 4.1.
+* Added support for Django REST framework 3.14.
 * Expanded JSONParser API with `parse_data` method
 
 ### Changed
@@ -29,13 +30,14 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Removed
 
 * Removed support for Django 2.2.
+* Removed support for Django REST framework 3.12.
 
 ## [5.0.0] - 2022-01-03
 
 This release is not backwards compatible. For easy migration best upgrade first to version
 4.3.0 and resolve all deprecation warnings before updating to 5.0.0
 
-This is the last release supporting Django 2.2.
+This is the last release supporting Django 2.2 and Django REST framework 3.12.
 
 ### Added
 

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Requirements
 
 1. Python (3.7, 3.8, 3.9, 3.10)
 2. Django (3.2, 4.0, 4.1)
-3. Django REST framework (3.12, 3.13)
+3. Django REST framework (3.13, 3.14)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ like the following:
 
 1. Python (3.7, 3.8, 3.9, 3.10)
 2. Django (3.2, 4.0, 4.1)
-3. Django REST framework (3.12, 3.13)
+3. Django REST framework (3.13, 3.14)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.
 

--- a/rest_framework_json_api/compat.py
+++ b/rest_framework_json_api/compat.py
@@ -1,0 +1,15 @@
+# Django REST framework 3.14 removed NullBooleanField
+# can be removed once support for DRF 3.13 is dropped.
+try:
+    from rest_framework.serializers import NullBooleanField
+except ImportError:  # pragma: no cover
+    NullBooleanField = object()
+
+
+# Django REST framework 3.14 deprecates usage of `_get_reference`.
+# can be removed once support for DRF 3.13 is dropped.
+def get_reference(schema, serializer):
+    try:
+        return schema.get_reference(serializer)
+    except AttributeError:  # pragma: no cover
+        return schema._get_reference(serializer)

--- a/rest_framework_json_api/metadata.py
+++ b/rest_framework_json_api/metadata.py
@@ -7,6 +7,7 @@ from rest_framework.metadata import SimpleMetadata
 from rest_framework.settings import api_settings
 from rest_framework.utils.field_mapping import ClassLookupDict
 
+from rest_framework_json_api.compat import NullBooleanField
 from rest_framework_json_api.utils import format_field_name, get_related_resource_type
 
 
@@ -23,7 +24,7 @@ class JSONAPIMetadata(SimpleMetadata):
             serializers.Field: "GenericField",
             serializers.RelatedField: "Relationship",
             serializers.BooleanField: "Boolean",
-            serializers.NullBooleanField: "Boolean",
+            NullBooleanField: "Boolean",
             serializers.CharField: "String",
             serializers.URLField: "URL",
             serializers.EmailField: "Email",

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -7,6 +7,7 @@ from rest_framework.schemas import openapi as drf_openapi
 from rest_framework.schemas.utils import is_list_view
 
 from rest_framework_json_api import serializers, views
+from rest_framework_json_api.compat import get_reference
 from rest_framework_json_api.utils import format_field_name
 
 
@@ -515,10 +516,10 @@ class AutoSchema(drf_openapi.AutoSchema):
         if collection:
             data = {
                 "type": "array",
-                "items": self._get_reference(self.view.get_serializer()),
+                "items": get_reference(self, self.view.get_serializer()),
             }
         else:
-            data = self._get_reference(self.view.get_serializer())
+            data = get_reference(self, self.view.get_serializer())
 
         return {
             "description": operation["operationId"],

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     ],
     install_requires=[
         "inflection>=0.5.0",
-        "djangorestframework>=3.12,<3.14",
+        "djangorestframework>=3.13,<3.15",
         "django>=3.2,<4.2",
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    py{37,38,39,310}-django32-drf{312,313,master},
-    py{38,39,310}-django{40,41}-drf{313,master},
+    py{37,38,39,310}-django32-drf{313,314,master},
+    py{38,39,310}-django40-drf{313,314,master},
+    py{38,39,310}-django41-drf{314,master},
     lint,docs
 
 [testenv]
@@ -9,8 +10,8 @@ deps =
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
-    drf312: djangorestframework>=3.12,<3.13
     drf313: djangorestframework>=3.13,<3.14
+    drf314: djangorestframework>=3.14,<3.15
     drfmaster: https://github.com/encode/django-rest-framework/archive/master.zip
     -rrequirements/requirements-testing.txt
     -rrequirements/requirements-optionals.txt


### PR DESCRIPTION
## Description of the Change

As per our policy, adding support for DRF 3.14 and dropping support for DRF 3.12 as we support the two last releases.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
