### PR TITLE
Added support to overwrite serializer methods in schema class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Added support for Python 3.11.
 
+### Changed
+
+* Added support to overwrite serializer methods in customized schema class
+
 ## [6.0.0] - 2022-09-24
 
 ### Fixed


### PR DESCRIPTION
## Description of the Change

This change makes the DJA schema class compatible with the DRF change introduced with https://github.com/encode/django-rest-framework/pull/7424

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
