### PR TITLE
Adjusted security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,6 @@
 
 If you believe you've found something in Django REST framework JSON:API which has security implications, please **do not raise the issue in a public forum**.
 
-Send a description of the issue via email to [rest-framework-jsonapi-security@googlegroups.com][security-mail]. The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.
+Use the security advisory to [report a vulnerability](https://github.com/django-json-api/django-rest-framework-json-api/security/advisories/new) instead.
 
-[security-mail]: mailto:rest-framework-jsonapi-security@googlegroups.com
+The project maintainers will then work with you to resolve any issues where required, prior to any public disclosure.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -69,4 +69,3 @@ In case a new maintainer joins our team we need to consider to what of following
 * [Github organization](https://github.com/django-json-api)
 * [Read the Docs project](https://django-rest-framework-json-api.readthedocs.io/)
 * [PyPi project](https://pypi.org/project/djangorestframework-jsonapi/)
-* [Google Groups security mailing list](https://groups.google.com/g/rest-framework-jsonapi-security)


### PR DESCRIPTION
## Description of the Change

Finally, GitHub introduced a way to [report security vulnerability privately](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability). This makes the Google Group obsolete, which I found less than ideal, as it is just another system we need to use.

Adjusted security policy accordingly.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
