### PR TITLE
Unified tox configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox tox-py
+          pip install tox
       - name: Run tox targets for ${{ matrix.python-version }}
-        run: tox --py current
+        run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d .)
       - name: Upload coverage report
         uses: codecov/codecov-action@v2
         with:
@@ -36,10 +36,10 @@ jobs:
         tox-env: ["black", "lint", "docs"]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/tox.ini
+++ b/tox.ini
@@ -48,5 +48,11 @@ deps =
 commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
 
-[testenv:py{37,38,39,310}-django{32,40,41}-drfmaster]
+[testenv:py{37,38,39,310}-django32-drfmaster]
+ignore_outcome = true
+
+[testenv:py{38,39,310}-django40-drfmaster]
+ignore_outcome = true
+
+[testenv:py{38,39,310,311}-django41-drfmaster]
 ignore_outcome = true

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,9 @@ envlist =
     py{37,38,39,310}-django32-drf{313,314,master},
     py{38,39,310}-django40-drf{313,314,master},
     py{38,39,310,311}-django41-drf{314,master},
-    lint,docs
+    black,
+    docs,
+    lint
 
 [testenv]
 deps =
@@ -24,13 +26,13 @@ commands =
     pytest --cov --no-cov-on-fail --cov-report xml {posargs}
 
 [testenv:black]
-basepython = python3.7
+basepython = python3.8
 deps =
     -rrequirements/requirements-codestyle.txt
 commands = black --check .
 
 [testenv:lint]
-basepython = python3.7
+basepython = python3.8
 deps =
     -rrequirements/requirements-codestyle.txt
     -rrequirements/requirements-testing.txt
@@ -38,7 +40,7 @@ deps =
 commands = flake8
 
 [testenv:docs]
-basepython = python3.7
+basepython = python3.8
 deps =
     -rrequirements/requirements-testing.txt
     -rrequirements/requirements-optionals.txt


### PR DESCRIPTION
## Description of the Change

* Followed example of DRF using -f cmd line of tox v4 instead of tox-py
* For linting jobs updated to Python 3.8 as will be required by future updates of Flake8
* Added missing black job

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
