### PR TITLE
 Removed unnecessary test dependencies when building docs 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,6 @@ commands = flake8
 [testenv:docs]
 basepython = python3.8
 deps =
-    -rrequirements/requirements-testing.txt
     -rrequirements/requirements-optionals.txt
     -rrequirements/requirements-documentation.txt
 commands =


### PR DESCRIPTION
## Description of the Change

There is no need to install test dependencies when building docs.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
