### PR TITLE
Refactored sort query parameter handling in schema generation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ Jonas Kiefer <https://github.com/jokiefer>
 Jonas Metzener <jonas.metzener@adfinis.com>
 Jonathan Senecal <contact@jonathansenecal.com>
 Joseba Mendivil <git@jma.email>
+Kal <kal+oss@tedspot.com>
 Kevin Partington <platinumazure@gmail.com>
 Kieran Evans <keyz182@gmail.com>
 Léo S. <leo@naeka.fr>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Added support to overwrite serializer methods in customized schema class
 
+### Fixed
+
+* Refactored handling of the `sort` query parameter to fix duplicate declaration in the generated schema definition
+
 ## [6.0.0] - 2022-09-24
 
 ### Fixed

--- a/example/tests/__snapshots__/test_openapi.ambr
+++ b/example/tests/__snapshots__/test_openapi.ambr
@@ -273,10 +273,7 @@
         "$ref": "#/components/parameters/fields"
       },
       {
-        "$ref": "#/components/parameters/sort"
-      },
-      {
-        "description": "Which field to use when ordering the results.",
+        "description": "[list of fields to sort by](https://jsonapi.org/format/#fetching-sorting)",
         "in": "query",
         "name": "sort",
         "required": false,
@@ -392,9 +389,6 @@
         "$ref": "#/components/parameters/fields"
       },
       {
-        "$ref": "#/components/parameters/sort"
-      },
-      {
         "description": "A page number within the paginated result set.",
         "in": "query",
         "name": "page[number]",
@@ -413,7 +407,7 @@
         }
       },
       {
-        "description": "Which field to use when ordering the results.",
+        "description": "[list of fields to sort by](https://jsonapi.org/format/#fetching-sorting)",
         "in": "query",
         "name": "sort",
         "required": false,

--- a/example/tests/unit/test_filter_schema_params.py
+++ b/example/tests/unit/test_filter_schema_params.py
@@ -72,7 +72,8 @@ def test_filters_get_schema_params():
                     "name": "sort",
                     "required": False,
                     "in": "query",
-                    "description": "Which field to use when ordering the results.",
+                    "description": "[list of fields to sort by]"
+                    "(https://jsonapi.org/format/#fetching-sorting)",
                     "schema": {"type": "string"},
                 }
             ],

--- a/rest_framework_json_api/filters.py
+++ b/rest_framework_json_api/filters.py
@@ -22,6 +22,9 @@ class OrderingFilter(OrderingFilter):
     #: override :py:attr:`rest_framework.filters.OrderingFilter.ordering_param`
     #: with JSON:API-compliant query parameter name.
     ordering_param = "sort"
+    ordering_description = (
+        "[list of fields to sort by]" "(https://jsonapi.org/format/#fetching-sorting)"
+    )
 
     def remove_invalid_fields(self, queryset, fields, view, request):
         """

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -248,15 +248,6 @@ class SchemaGenerator(drf_openapi.SchemaGenerator):
                 },
                 "explode": True,
             },
-            "sort": {
-                "name": "sort",
-                "in": "query",
-                "description": "[list of fields to sort by]"
-                "(https://jsonapi.org/format/#fetching-sorting)",
-                "required": False,
-                "style": "form",
-                "schema": {"type": "string"},
-            },
         },
     }
 
@@ -422,7 +413,6 @@ class AutoSchema(drf_openapi.AutoSchema):
         if method in ["GET", "HEAD"]:
             parameters += self._get_include_parameters(path, method)
             parameters += self._get_fields_parameters(path, method)
-            parameters += self._get_sort_parameters(path, method)
             parameters += self.get_pagination_parameters(path, method)
             parameters += self.get_filter_parameters(path, method)
         operation["parameters"] = parameters
@@ -484,12 +474,6 @@ class AutoSchema(drf_openapi.AutoSchema):
         #       type: string  # noqa F821
         # explode: true
         return [{"$ref": "#/components/parameters/fields"}]
-
-    def _get_sort_parameters(self, path, method):
-        """
-        sort parameter: https://jsonapi.org/format/#fetching-sorting
-        """
-        return [{"$ref": "#/components/parameters/sort"}]
 
     def _add_get_collection_response(self, operation, path):
         """


### PR DESCRIPTION
Fixes #1120 

## Description of the Change

Refactored `sort` query parameter handling in order to avoid duplicate declarations in the generated schema for each endpoint.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
