### PR TITLE
fix: serialization of non-model dict objects (fixes #155 #722 #1126)

### DIFF
--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -459,10 +459,7 @@ class JSONRenderer(renderers.JSONRenderer):
             resource_name = utils.get_resource_type_from_instance(resource_instance)
         resource_data = [
             ("type", resource_name),
-            (
-                "id",
-                encoding.force_str(resource_instance.pk) if resource_instance else None,
-            ),
+            ("id", utils.get_resource_id_from_instance(resource_instance)),
             ("attributes", cls.extract_attributes(fields, resource)),
         ]
         relationships = cls.extract_relationships(fields, resource, resource_instance)

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -308,6 +308,19 @@ def get_resource_type_from_serializer(serializer):
     )
 
 
+def get_resource_id_from_instance(instance):
+    """Returns the resource identifier for a given instance (`id` takes priority over `pk`)."""
+    if not instance:
+        return None
+    elif hasattr(instance, "id"):
+        return encoding.force_str(instance.id)
+    elif hasattr(instance, "pk"):
+        return encoding.force_str(instance.pk)
+    elif isinstance(instance, dict):
+        return instance.get("id", instance.get("pk", None))
+    return None
+
+
 def get_included_resources(request, serializer=None):
     """Build a list of included resources."""
     include_resources_param = request.query_params.get("include") if request else None

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -183,6 +183,28 @@ class TestAPIView:
             }
         }
 
+    @pytest.mark.urls(__name__)
+    def test_post_with_missing_id(self, client):
+        data = {
+            "data": {
+                "id": None,
+                "type": "custom",
+                "attributes": {"body": "hello"},
+            }
+        }
+
+        url = reverse("custom")
+
+        response = client.post(url, data=data)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            "data": {
+                "type": "custom",
+                "id": None,
+                "attributes": {"body": "hello"},
+            }
+        }
+
 
 # Routing setup
 
@@ -209,6 +231,10 @@ class CustomAPIView(APIView):
 
     def patch(self, request, *args, **kwargs):
         serializer = CustomModelSerializer(CustomModel(request.data))
+        return Response(status=status.HTTP_200_OK, data=serializer.data)
+
+    def post(self, request, *args, **kwargs):
+        serializer = CustomModelSerializer(request.data)
         return Response(status=status.HTTP_200_OK, data=serializer.data)
 
 


### PR DESCRIPTION
Fixes #155 #722 #1126

## Description of the Change

Redirect logic used to extract the resource identifier from a serializer instance to a utility method. This utility method handles the edge-case where there is no model backing the serializer resulting in a "`dict` object has no attribute `pk`".

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
