### PR TITLE
Adjusted to use same Python and Ubuntu version for RDT

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,6 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"


### PR DESCRIPTION
## Description of the Change

In Github Actions to test the docs we use Python 3.8 and Ubuntu 22.04 so we should do the same on RDT.

This fixes current [failing build](https://readthedocs.org/projects/django-rest-framework-json-api/builds/19548118/) (new Sphinx version needs Python 3.8)


## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
