### PR TITLE
Replaced OrderedDict with dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Added support to overwrite serializer methods in customized schema class
 * Adjusted some still old formatted strings to f-strings.
+* Replaced `OrderedDict` with `dict` which is also ordered since Python 3.7.
 
 ### Fixed
 

--- a/rest_framework_json_api/metadata.py
+++ b/rest_framework_json_api/metadata.py
@@ -91,10 +91,8 @@ class JSONAPIMetadata(SimpleMetadata):
         serializer.fields.pop(api_settings.URL_FIELD_NAME, None)
 
         return {
-            [
-                (format_field_name(field_name), self.get_field_info(field))
-                for field_name, field in serializer.fields.items()
-            ]
+            format_field_name(field_name): self.get_field_info(field)
+            for field_name, field in serializer.fields.items()
         }
 
     def get_field_info(self, field):

--- a/rest_framework_json_api/metadata.py
+++ b/rest_framework_json_api/metadata.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from django.db.models.fields import related
 from django.utils.encoding import force_str
 from rest_framework import serializers
@@ -65,7 +63,7 @@ class JSONAPIMetadata(SimpleMetadata):
         )
 
     def determine_metadata(self, request, view):
-        metadata = OrderedDict()
+        metadata = {}
         metadata["name"] = view.get_view_name()
         metadata["description"] = view.get_view_description()
         metadata["renders"] = [
@@ -92,19 +90,19 @@ class JSONAPIMetadata(SimpleMetadata):
         # Remove the URL field if present
         serializer.fields.pop(api_settings.URL_FIELD_NAME, None)
 
-        return OrderedDict(
+        return {
             [
                 (format_field_name(field_name), self.get_field_info(field))
                 for field_name, field in serializer.fields.items()
             ]
-        )
+        }
 
     def get_field_info(self, field):
         """
         Given an instance of a serializer field, return a dictionary
         of metadata about it.
         """
-        field_info = OrderedDict()
+        field_info = {}
         serializer = field.parent
 
         if isinstance(field, serializers.ManyRelatedField):

--- a/rest_framework_json_api/pagination.py
+++ b/rest_framework_json_api/pagination.py
@@ -1,7 +1,6 @@
 """
 Pagination fields
 """
-from collections import OrderedDict
 
 from rest_framework.pagination import LimitOffsetPagination, PageNumberPagination
 from rest_framework.utils.urls import remove_query_param, replace_query_param
@@ -36,22 +35,22 @@ class JsonApiPageNumberPagination(PageNumberPagination):
             {
                 "results": data,
                 "meta": {
-                    "pagination": OrderedDict(
+                    "pagination": {
                         [
                             ("page", self.page.number),
                             ("pages", self.page.paginator.num_pages),
                             ("count", self.page.paginator.count),
                         ]
-                    )
+                    }
                 },
-                "links": OrderedDict(
+                "links": {
                     [
                         ("first", self.build_link(1)),
                         ("last", self.build_link(self.page.paginator.num_pages)),
                         ("next", self.build_link(next)),
                         ("prev", self.build_link(previous)),
                     ]
-                ),
+                },
             }
         )
 
@@ -97,21 +96,21 @@ class JsonApiLimitOffsetPagination(LimitOffsetPagination):
             {
                 "results": data,
                 "meta": {
-                    "pagination": OrderedDict(
+                    "pagination": {
                         [
                             ("count", self.count),
                             ("limit", self.limit),
                             ("offset", self.offset),
                         ]
-                    )
+                    }
                 },
-                "links": OrderedDict(
+                "links": {
                     [
                         ("first", self.get_first_link()),
                         ("last", self.get_last_link()),
                         ("next", self.get_next_link()),
                         ("prev", self.get_previous_link()),
                     ]
-                ),
+                },
             }
         )

--- a/rest_framework_json_api/pagination.py
+++ b/rest_framework_json_api/pagination.py
@@ -36,20 +36,16 @@ class JsonApiPageNumberPagination(PageNumberPagination):
                 "results": data,
                 "meta": {
                     "pagination": {
-                        [
-                            ("page", self.page.number),
-                            ("pages", self.page.paginator.num_pages),
-                            ("count", self.page.paginator.count),
-                        ]
+                        "page": self.page.number,
+                        "pages": self.page.paginator.num_pages,
+                        "count": self.page.paginator.count,
                     }
                 },
                 "links": {
-                    [
-                        ("first", self.build_link(1)),
-                        ("last", self.build_link(self.page.paginator.num_pages)),
-                        ("next", self.build_link(next)),
-                        ("prev", self.build_link(previous)),
-                    ]
+                    "first": self.build_link(1),
+                    "last": self.build_link(self.page.paginator.num_pages),
+                    "next": self.build_link(next),
+                    "prev": self.build_link(previous),
                 },
             }
         )
@@ -97,20 +93,16 @@ class JsonApiLimitOffsetPagination(LimitOffsetPagination):
                 "results": data,
                 "meta": {
                     "pagination": {
-                        [
-                            ("count", self.count),
-                            ("limit", self.limit),
-                            ("offset", self.offset),
-                        ]
+                        "count": self.count,
+                        "limit": self.limit,
+                        "offset": self.offset,
                     }
                 },
                 "links": {
-                    [
-                        ("first", self.get_first_link()),
-                        ("last", self.get_last_link()),
-                        ("next", self.get_next_link()),
-                        ("prev", self.get_previous_link()),
-                    ]
+                    "first": self.get_first_link(),
+                    "last": self.get_last_link(),
+                    "next": self.get_next_link(),
+                    "prev": self.get_previous_link(),
                 },
             }
         )

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -256,7 +256,7 @@ class ResourceRelatedField(HyperlinkedMixin, PrimaryKeyRelatedField):
         if resource_type is None or not self._skip_polymorphic_optimization:
             resource_type = get_resource_type_from_instance(value)
 
-        return {[("type", resource_type), ("id", str(pk))]}
+        return {"type": resource_type, "id": str(pk)}
 
     def get_resource_type_from_included_serializer(self):
         """
@@ -301,10 +301,8 @@ class ResourceRelatedField(HyperlinkedMixin, PrimaryKeyRelatedField):
             queryset = queryset[:cutoff]
 
         return {
-            [
-                (json.dumps(self.to_representation(item)), self.display_value(item))
-                for item in queryset
-            ]
+            json.dumps(self.to_representation(item)): self.display_value(item)
+            for item in queryset
         }
 
 

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -1,5 +1,4 @@
 import json
-from collections import OrderedDict
 
 import inflection
 from django.core.exceptions import ImproperlyConfigured
@@ -104,7 +103,7 @@ class HyperlinkedMixin:
     def get_links(self, obj=None, lookup_field="pk"):
         request = self.context.get("request", None)
         view = self.context.get("view", None)
-        return_data = OrderedDict()
+        return_data = {}
 
         kwargs = {
             lookup_field: getattr(obj, lookup_field)
@@ -257,7 +256,7 @@ class ResourceRelatedField(HyperlinkedMixin, PrimaryKeyRelatedField):
         if resource_type is None or not self._skip_polymorphic_optimization:
             resource_type = get_resource_type_from_instance(value)
 
-        return OrderedDict([("type", resource_type), ("id", str(pk))])
+        return {[("type", resource_type), ("id", str(pk))]}
 
     def get_resource_type_from_included_serializer(self):
         """
@@ -301,12 +300,12 @@ class ResourceRelatedField(HyperlinkedMixin, PrimaryKeyRelatedField):
         if cutoff is not None:
             queryset = queryset[:cutoff]
 
-        return OrderedDict(
+        return {
             [
                 (json.dumps(self.to_representation(item)), self.display_value(item))
                 for item in queryset
             ]
-        )
+        }
 
 
 class PolymorphicResourceRelatedField(ResourceRelatedField):

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable
 import inflection
 from django.db.models import Manager
 from django.template import loader
-from django.utils import encoding
+from django.utils.encoding import force_str
 from rest_framework import relations, renderers
 from rest_framework.fields import SkipField, get_attribute
 from rest_framework.relations import PKOnlyObject
@@ -125,14 +125,10 @@ class JSONRenderer(renderers.JSONRenderer):
                     relation_instance if relation_instance is not None else list()
                 )
 
-                for related_object in relation_queryset:
-                    relation_data.append(
-                        {
-                            "type": relation_type,
-                            "id": encoding.force_str(related_object.pk),
-                        }
-                    )
-
+                relation_data = [
+                    {"type": relation_type, "id": force_str(related_object.pk)}
+                    for related_object in relation_queryset
+                ]
                 data.update(
                     {
                         field_name: {
@@ -173,7 +169,7 @@ class JSONRenderer(renderers.JSONRenderer):
                 if relation_id is not None:
                     relation_data["data"] = {
                         "type": relation_type,
-                        "id": encoding.force_str(relation_id),
+                        "id": force_str(relation_id),
                     }
 
                 if isinstance(
@@ -227,7 +223,7 @@ class JSONRenderer(renderers.JSONRenderer):
                     relation_data.append(
                         {
                             "type": nested_resource_instance_type,
-                            "id": encoding.force_str(nested_resource_instance.pk),
+                            "id": force_str(nested_resource_instance.pk),
                         }
                     )
                 data.update(
@@ -447,9 +443,7 @@ class JSONRenderer(renderers.JSONRenderer):
         # Determine type from the instance if the underlying model is polymorphic
         if force_type_resolution:
             resource_name = utils.get_resource_type_from_instance(resource_instance)
-        resource_id = (
-            encoding.force_str(resource_instance.pk) if resource_instance else None
-        )
+        resource_id = force_str(resource_instance.pk) if resource_instance else None
         resource_data = {
             "type": resource_name,
             "id": resource_id,

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from collections.abc import Mapping
 
 import inflection
@@ -95,7 +94,7 @@ class SparseFieldsetsMixin:
                 pass
             else:
                 fieldset = request.query_params.get(param_name).split(",")
-                # iterate over a *copy* of self.fields' underlying OrderedDict, because we may
+                # iterate over a *copy* of self.fields' underlying dict, because we may
                 # modify the original during the iteration.
                 # self.fields is a `rest_framework.utils.serializer_helpers.BindingDict`
                 for field_name, _field in self.fields.fields.copy().items():
@@ -305,7 +304,7 @@ class ModelSerializer(
         """
         meta_fields = getattr(self.Meta, "meta_fields", [])
 
-        declared = OrderedDict()
+        declared = {}
         for field_name in set(declared_fields.keys()):
             field = declared_fields[field_name]
             if field_name not in meta_fields:

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -1,6 +1,5 @@
 import inspect
 import operator
-from collections import OrderedDict
 
 import inflection
 from django.conf import settings
@@ -107,11 +106,7 @@ def format_field_names(obj, format_type=None):
         format_type = json_api_settings.FORMAT_FIELD_NAMES
 
     if isinstance(obj, dict):
-        formatted = OrderedDict()
-        for key, value in obj.items():
-            key = format_value(key, format_type)
-            formatted[key] = value
-        return formatted
+        return {format_value(key, format_type): value for key, value in obj.items()}
 
     return obj
 

--- a/rest_framework_json_api/views.py
+++ b/rest_framework_json_api/views.py
@@ -23,7 +23,6 @@ from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.serializers import ResourceIdentifierObjectSerializer
 from rest_framework_json_api.utils import (
     Hyperlink,
-    OrderedDict,
     get_included_resources,
     get_resource_type_from_instance,
     undo_format_link_segment,
@@ -275,7 +274,7 @@ class RelationshipView(generics.GenericAPIView):
         return Hyperlink(url, name)
 
     def get_links(self):
-        return_data = OrderedDict()
+        return_data = {}
         self_link = self.get_url(
             "self", self.self_link_view_name, self.kwargs, self.request
         )
@@ -284,9 +283,9 @@ class RelationshipView(generics.GenericAPIView):
             "related", self.related_link_view_name, related_kwargs, self.request
         )
         if self_link:
-            return_data.update({"self": self_link})
+            return_data["self"] = self_link
         if related_link:
-            return_data.update({"related": related_link})
+            return_data["related"] = related_link
         return return_data
 
     def get(self, request, *args, **kwargs):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from rest_framework.request import Request
 
 from rest_framework_json_api.pagination import JsonApiLimitOffsetPagination
@@ -27,28 +25,18 @@ class TestLimitOffsetPagination:
 
         expected_content = {
             "results": list(range(11, 16)),
-            "links": OrderedDict(
-                [
-                    ("first", "http://testserver/?page%5Blimit%5D=5"),
-                    (
-                        "last",
-                        "http://testserver/?page%5Blimit%5D=5&page%5Boffset%5D=100",
-                    ),
-                    (
-                        "next",
-                        "http://testserver/?page%5Blimit%5D=5&page%5Boffset%5D=15",
-                    ),
-                    ("prev", "http://testserver/?page%5Blimit%5D=5&page%5Boffset%5D=5"),
-                ]
-            ),
+            "links": {
+                "first": "http://testserver/?page%5Blimit%5D=5",
+                "last": "http://testserver/?page%5Blimit%5D=5&page%5Boffset%5D=100",
+                "next": "http://testserver/?page%5Blimit%5D=5&page%5Boffset%5D=15",
+                "prev": "http://testserver/?page%5Blimit%5D=5&page%5Boffset%5D=5",
+            },
             "meta": {
-                "pagination": OrderedDict(
-                    [
-                        ("count", count),
-                        ("limit", limit),
-                        ("offset", offset),
-                    ]
-                )
+                "pagination": {
+                    "count": count,
+                    "limit": limit,
+                    "offset": offset,
+                }
             },
         }
 


### PR DESCRIPTION
Fixes #1094

## Description of the Change

As Python 3.7+ now ensures that dicts are ordered, there is no need to use `OrderedDict` anymore.

See in-depth explanation at https://github.com/django-json-api/django-rest-framework-json-api/pull/1094#issuecomment-1438038120

Using regular dicts also make the code more readable and easier debuggable.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
