### PR TITLE
Made docs/requirements.txt obsolete and install project itself

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,4 +10,7 @@ sphinx:
 
 python:
   install:
-    - requirements: docs/requirements.txt
+    - requirements: requirements/requirements-optionals.txt
+    - requirements: requirements/requirements-documentation.txt
+    - method: pip
+      path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,0 @@
-# RTD only supports one requirements.txt file, therefore this has been created.
-# This file needs to keep in sync with tox testenv docs dependencies.
-
--r ../requirements/requirements-optionals.txt
--r ../requirements/requirements-testing.txt
--r ../requirements/requirements-documentation.txt

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ deps =
 commands = flake8
 
 [testenv:docs]
+# keep in sync with .readthedocs.yml
 basepython = python3.8
 deps =
     -rrequirements/requirements-optionals.txt


### PR DESCRIPTION
## Description of the Change

docs/requirements.txt was only introduced as it was only possible to configure one “requirements.txt” in the web interface. In the yaml file it is possible to add several, therefore removing docs/requirements.txt.

Additionally, this should solve the still persistent build error, as the project itself also needs to be installed.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
