### PR TITLE
Use /data as the pointer for non-field serializer errors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@ Adam Ziolkowski <adam@adsized.com>
 Alan Crosswell <alan@columbia.edu>
 Alex Seidmann <alex@leanpnt.de>
 Anton Shutik <shutikanton@gmail.com>
+Arttu Perälä <arttu@perala.me>
 Ashley Loewen <github@ashleycodes.tech>
 Asif Saif Uddin <auvipy@gmail.com>
 Beni Keller <beni@matraxi.ch>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Fixed
 
 * Refactored handling of the `sort` query parameter to fix duplicate declaration in the generated schema definition
+* Non-field serializer errors are given a source.pointer value of "/data".
 
 ## [6.0.0] - 2022-09-24
 

--- a/example/api/serializers/identity.py
+++ b/example/api/serializers/identity.py
@@ -23,6 +23,13 @@ class IdentitySerializer(serializers.ModelSerializer):
             )
         return data
 
+    def validate(self, data):
+        if data["first_name"] == data["last_name"]:
+            raise serializers.ValidationError(
+                "First name cannot be the same as last name!"
+            )
+        return data
+
     class Meta:
         model = auth_models.User
         fields = (

--- a/example/tests/test_generic_viewset.py
+++ b/example/tests/test_generic_viewset.py
@@ -129,3 +129,35 @@ class GenericViewSet(TestBase):
         )
 
         assert expected == response.json()
+
+    def test_nonfield_validation_exceptions(self):
+        """
+        Non-field errors should be attributed to /data source.pointer.
+        """
+        expected = {
+            "errors": [
+                {
+                    "status": "400",
+                    "source": {
+                        "pointer": "/data",
+                    },
+                    "detail": "First name cannot be the same as last name!",
+                    "code": "invalid",
+                },
+            ]
+        }
+        response = self.client.post(
+            "/identities",
+            {
+                "data": {
+                    "type": "users",
+                    "attributes": {
+                        "email": "miles@example.com",
+                        "first_name": "Miles",
+                        "last_name": "Miles",
+                    },
+                }
+            },
+        )
+
+        assert expected == response.json()

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -155,7 +155,12 @@ class IncludedResourcesValidationMixin:
 class ReservedFieldNamesMixin:
     """Ensures that reserved field names are not used and an error raised instead."""
 
-    _reserved_field_names = {"meta", "results", "type"}
+    _reserved_field_names = {
+        "meta",
+        "results",
+        "type",
+        api_settings.NON_FIELD_ERRORS_KEY,
+    }
 
     def get_fields(self):
         fields = super().get_fields()

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -13,6 +13,7 @@ from django.utils import encoding
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, relations
 from rest_framework.exceptions import APIException
+from rest_framework.settings import api_settings
 
 from .settings import json_api_settings
 
@@ -381,10 +382,14 @@ def format_drf_errors(response, context, exc):
             ]
 
         for field, error in response.data.items():
+            non_field_error = field == api_settings.NON_FIELD_ERRORS_KEY
             field = format_field_name(field)
             pointer = None
-            # pointer can be determined only if there's a serializer.
-            if has_serializer:
+            if non_field_error:
+                # Serializer error does not refer to a specific field.
+                pointer = "/data"
+            elif has_serializer:
+                # pointer can be determined only if there's a serializer.
                 rel = "relationships" if field in relationship_fields else "attributes"
                 pointer = f"/data/{rel}/{field}"
             if isinstance(exc, Http404) and isinstance(error, str):


### PR DESCRIPTION
Fixes #1136

## Description of the Change

Checks if a field matches [NON_FIELD_ERRORS_KEY](https://www.django-rest-framework.org/api-guide/settings/#non_field_errors_key) and sets the error pointer to `"/data"` if it does during DRF error formatting.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`