### PR TITLE
Add support for Django 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Added
 
 * Added support for Python 3.11.
+* Added support for Django 4.2.
 
 ### Changed
 

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Requirements
 ------------
 
 1. Python (3.7, 3.8, 3.9, 3.10, 3.11)
-2. Django (3.2, 4.0, 4.1)
+2. Django (3.2, 4.0, 4.1, 4.2)
 3. Django REST framework (3.13, 3.14)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ like the following:
 ## Requirements
 
 1. Python (3.7, 3.8, 3.9, 3.10, 3.11)
-2. Django (3.2, 4.0, 4.1)
+2. Django (3.2, 4.0, 4.1, 4.2)
 3. Django REST framework (3.13, 3.14)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.

--- a/example/settings/dev.py
+++ b/example/settings/dev.py
@@ -60,8 +60,6 @@ ROOT_URLCONF = "example.urls"
 
 SECRET_KEY = "abc123"
 
-PASSWORD_HASHERS = ("django.contrib.auth.hashers.UnsaltedMD5PasswordHasher",)
-
 INTERNAL_IPS = ("127.0.0.1",)
 
 JSON_API_FORMAT_FIELD_NAMES = "camelize"

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     install_requires=[
         "inflection>=0.5.0",
         "djangorestframework>=3.13,<3.15",
-        "django>=3.2,<4.2",
+        "django>=3.2,<4.3",
     ],
     extras_require={
         "django-polymorphic": ["django-polymorphic>=3.0"],

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py{37,38,39,310}-django32-drf{313,314,master},
     py{38,39,310}-django40-drf{313,314,master},
+    py{38,39,310,311}-django41-drf{314,master},
     py{38,39,310,311}-django42-drf{314,master},
     black,
     docs,
@@ -11,6 +12,7 @@ envlist =
 deps =
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
     drf313: djangorestframework>=3.13,<3.14
     drf314: djangorestframework>=3.14,<3.15
@@ -52,6 +54,9 @@ commands =
 ignore_outcome = true
 
 [testenv:py{38,39,310}-django40-drfmaster]
+ignore_outcome = true
+
+[testenv:py{38,39,310,311}-django41-drfmaster]
 ignore_outcome = true
 
 [testenv:py{38,39,310,311}-django42-drfmaster]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py{37,38,39,310}-django32-drf{313,314,master},
     py{38,39,310}-django40-drf{313,314,master},
-    py{38,39,310,311}-django41-drf{314,master},
+    py{38,39,310,311}-django42-drf{314,master},
     black,
     docs,
     lint
@@ -11,7 +11,7 @@ envlist =
 deps =
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<4.3
     drf313: djangorestframework>=3.13,<3.14
     drf314: djangorestframework>=3.14,<3.15
     drfmaster: https://github.com/encode/django-rest-framework/archive/master.zip
@@ -54,5 +54,5 @@ ignore_outcome = true
 [testenv:py{38,39,310}-django40-drfmaster]
 ignore_outcome = true
 
-[testenv:py{38,39,310,311}-django41-drfmaster]
+[testenv:py{38,39,310,311}-django42-drfmaster]
 ignore_outcome = true


### PR DESCRIPTION
Allows library to be installed with Django 4.2.

## Description of the Change

This broadens the range of Django versions this library allows to be installed alongside to include Django 4.2 and any bugfix releases of it.

It also disables the use of the now deprecated `UnsaltedMD5PasswordHasher` hashing algorithm when running tests, as it otherwise would raise deprecation warnings. This will make the tests slightly slower since the default password hashing algorithm uses more resources, but it shouldn't have a big impact all in all as the tests run pretty quickly regardless.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
