### PR TITLE
Ignored pkg_resources deprecation warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,9 @@ filterwarnings =
     error::PendingDeprecationWarning
     # Remove when DRF is not depending on it anymore
     ignore:The django.utils.timezone.utc alias is deprecated.
+    # can be removed once fixed in django polymorphic
+    ignore:pkg_resources is deprecated as an API
+    ignore:Deprecated call to `pkg_resource
 testpaths =
     example
     tests


### PR DESCRIPTION
Fixes #1145

## Description of the Change

This is to fix failing CI. Should actually be fixed in django-polymorphic where pkg_resources is [used](https://github.com/django-polymorphic/django-polymorphic/blob/master/polymorphic/__init__.py#L12).

Initially caused by an update of setuptools.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
