### PR TITLE
Removed upper bounds of Django and DRF

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,8 @@ setup(
     ],
     install_requires=[
         "inflection>=0.5.0",
-        "djangorestframework>=3.13,<3.15",
-        "django>=3.2,<4.3",
+        "djangorestframework>=3.13",
+        "django>=3.2",
     ],
     extras_require={
         "django-polymorphic": ["django-polymorphic>=3.0"],


### PR DESCRIPTION
## Description of the Change

In the last couple of new releases of Django and Django REST framework there were no real changes needed in DJA to work with those new versions. With the upper bound, we have currently set in our setup.py, our users need to wait for a new release to use a new Django or DRF version even though no changes are needed in DJA itself.

In #808 we introduced the upper bounds the main reason was to fix a documentation build, so a pipeline issue on our end and not an issue of a user as such.

The problem now is though that our users cannot use Django 4.2 with DJA as we are waiting for DRF to release a version for Django 4.2. (see #1142). As DRF does not have an upper bound though, users can easily use DRF with a new version but not DJA.

As of this, I recommend we remove the upper bound. We only officially support the version mentioned in the changelog/README, but this way we do not stop user using DJA with newer versions, which most likely works just as well.

If there is an actual issue with a new version, we can then temporarily set an upper bound till we have fixed it. In the long run it might also be good to have pinned version for testing, building our documentation etc. (like using poetry), but this is a discussion/work item or another day. 

Of course as this change will only be available with the next release this won't directly solve the issue with the Django 4.2 update but with similar situations like this in the future.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
