### PR TITLE
Omit id field from OpenAPI schema attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Refactored handling of the `sort` query parameter to fix duplicate declaration in the generated schema definition
 * Non-field serializer errors are given a source.pointer value of "/data".
+* Fixed "id" field being added to /data/attributes in the OpenAPI schema when it is not rendered there.
 
 ## [6.0.0] - 2022-09-24
 

--- a/example/tests/test_openapi.py
+++ b/example/tests/test_openapi.py
@@ -110,6 +110,21 @@ def test_schema_construction(snapshot):
     assert snapshot == json.dumps(schema, indent=2, sort_keys=True)
 
 
+def test_schema_id_field():
+    """ID field is only included in the root, not the attributes."""
+    patterns = [
+        re_path("^companies/?$", views.CompanyViewset.as_view({"get": "list"})),
+    ]
+    generator = SchemaGenerator(patterns=patterns)
+
+    request = create_request("/")
+    schema = generator.get_schema(request=request)
+
+    company_properties = schema["components"]["schemas"]["Company"]["properties"]
+    assert company_properties["id"] == {"$ref": "#/components/schemas/id"}
+    assert "id" not in company_properties["attributes"]["properties"]
+
+
 def test_schema_parameters_include():
     """Include paramater is only used when serializer defines included_serializers."""
     patterns = [

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -670,6 +670,10 @@ class AutoSchema(drf_openapi.AutoSchema):
                     "$ref": "#/components/schemas/reltomany"
                 }
                 continue
+            if field.field_name == "id":
+                # ID is always provided in the root of JSON:API and removed from the
+                # attributes in JSONRenderer.
+                continue
 
             if field.required:
                 required.append(format_field_name(field.field_name))


### PR DESCRIPTION
## Description of the Change

Omits the "id" field from `/data/attributes` the OpenAPI schema, as the `JSONRenderer` [explicitly removes it from the attributes](https://github.com/django-json-api/django-rest-framework-json-api/blob/main/rest_framework_json_api/renderers.py#L61-L63).

```python
{
    "type": "object",
    "required": ["type", "id"],
    "additionalProperties": False,
    "properties": {
        "type": {"$ref": "#/components/schemas/type"},
        "id": {"$ref": "#/components/schemas/id"},
        "links": { ... },
        "attributes": {
            "type": "object",
            "properties": {
                "id": {"type": "integer", "readOnly": True},  # <- Not real
                "name": {"type": "string", "maxLength": 100},
            },
            "required": ["name"],
        },
        "relationships": { ... },
    },
}
```

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
