### PR TITLE
Fix many serializer method fields having the incorrect relation schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ any parts of the framework not mentioned in the documentation should generally b
 * Refactored handling of the `sort` query parameter to fix duplicate declaration in the generated schema definition
 * Non-field serializer errors are given a source.pointer value of "/data".
 * Fixed "id" field being added to /data/attributes in the OpenAPI schema when it is not rendered there.
+* Fixed `SerializerMethodResourceRelatedField(many=True)` fields being given
+  a "reltoone" schema reference instead of "reltomany".
 
 ## [6.0.0] - 2022-09-24
 

--- a/example/tests/test_openapi.py
+++ b/example/tests/test_openapi.py
@@ -141,6 +141,28 @@ def test_schema_parameters_include():
     assert include_ref not in schema["paths"]["/project-types/"]["get"]["parameters"]
 
 
+def test_schema_serializer_method_resource_related_field():
+    """SerializerMethodResourceRelatedField fieds have the correct relation ref."""
+    patterns = [
+        re_path("^entries/?$", views.EntryViewSet.as_view({"get": "list"})),
+    ]
+    generator = SchemaGenerator(patterns=patterns)
+
+    request = Request(RequestFactory().get("/", {"include": "featured"}))
+    schema = generator.get_schema(request=request)
+
+    entry_schema = schema["components"]["schemas"]["Entry"]
+    entry_relationships = entry_schema["properties"]["relationships"]["properties"]
+
+    rel_to_many_ref = {"$ref": "#/components/schemas/reltomany"}
+    assert entry_relationships["suggested"] == rel_to_many_ref
+    assert entry_relationships["suggestedHyperlinked"] == rel_to_many_ref
+
+    rel_to_one_ref = {"$ref": "#/components/schemas/reltoone"}
+    assert entry_relationships["featured"] == rel_to_one_ref
+    assert entry_relationships["featuredHyperlinked"] == rel_to_one_ref
+
+
 def test_schema_related_serializers():
     """
     Confirm that paths are generated for related fields. For example:

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -8,6 +8,7 @@ from rest_framework.schemas.utils import is_list_view
 
 from rest_framework_json_api import serializers, views
 from rest_framework_json_api.compat import get_reference
+from rest_framework_json_api.relations import ManySerializerMethodResourceRelatedField
 from rest_framework_json_api.utils import format_field_name
 
 
@@ -660,14 +661,20 @@ class AutoSchema(drf_openapi.AutoSchema):
                 continue
             if isinstance(field, serializers.HiddenField):
                 continue
+            if isinstance(
+                field,
+                (
+                    serializers.ManyRelatedField,
+                    ManySerializerMethodResourceRelatedField,
+                ),
+            ):
+                relationships[format_field_name(field.field_name)] = {
+                    "$ref": "#/components/schemas/reltomany"
+                }
+                continue
             if isinstance(field, serializers.RelatedField):
                 relationships[format_field_name(field.field_name)] = {
                     "$ref": "#/components/schemas/reltoone"
-                }
-                continue
-            if isinstance(field, serializers.ManyRelatedField):
-                relationships[format_field_name(field.field_name)] = {
-                    "$ref": "#/components/schemas/reltomany"
                 }
                 continue
             if field.field_name == "id":


### PR DESCRIPTION
## Description of the Change

`SerializerMethodResourceRelatedField(many=True)` (`ManySerializerMethodResourceRelatedField`) fields would be documented in the OpenAPI schema with "#/components/schemas/reltoone" reference instead of "#/components/schemas/reltomany" reference.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
