### PR TITLE
Include meta section for SerializerMethodResourceRelatedField(many=True)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ any parts of the framework not mentioned in the documentation should generally b
             return value.name
     ```
 
+* `SerializerMethodResourceRelatedField(many=True)` relationship data now includes a meta section.
+
 ### Fixed
 
 * Refactored handling of the `sort` query parameter to fix duplicate declaration in the generated schema definition

--- a/example/tests/integration/test_non_paginated_responses.py
+++ b/example/tests/integration/test_non_paginated_responses.py
@@ -51,6 +51,7 @@ def test_multiple_entries_no_pagination(multiple_entries, client):
                             "related": "http://testserver/entries/1/suggested/",
                             "self": "http://testserver/entries/1/relationships/suggested",
                         },
+                        "meta": {"count": 1},
                     },
                     "suggestedHyperlinked": {
                         "links": {
@@ -106,6 +107,7 @@ def test_multiple_entries_no_pagination(multiple_entries, client):
                             "related": "http://testserver/entries/2/suggested/",
                             "self": "http://testserver/entries/2/relationships/suggested",
                         },
+                        "meta": {"count": 1},
                     },
                     "suggestedHyperlinked": {
                         "links": {

--- a/example/tests/integration/test_pagination.py
+++ b/example/tests/integration/test_pagination.py
@@ -51,6 +51,7 @@ def test_pagination_with_single_entry(single_entry, client):
                             "related": "http://testserver/entries/1/suggested/",
                             "self": "http://testserver/entries/1/relationships/suggested",
                         },
+                        "meta": {"count": 0},
                     },
                     "suggestedHyperlinked": {
                         "links": {

--- a/example/tests/test_filters.py
+++ b/example/tests/test_filters.py
@@ -512,6 +512,7 @@ class DJATestFilters(APITestCase):
                                 {"type": "entries", "id": "11"},
                                 {"type": "entries", "id": "12"},
                             ],
+                            "meta": {"count": 11},
                         },
                         "suggestedHyperlinked": {
                             "links": {

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -19,6 +19,7 @@ import rest_framework_json_api
 from rest_framework_json_api import utils
 from rest_framework_json_api.relations import (
     HyperlinkedMixin,
+    ManySerializerMethodResourceRelatedField,
     ResourceRelatedField,
     SkipDataMixin,
 )
@@ -151,6 +152,11 @@ class JSONRenderer(renderers.JSONRenderer):
             if isinstance(field, (ResourceRelatedField,)):
                 if not isinstance(field, SkipDataMixin):
                     relation_data.update({"data": resource.get(field_name)})
+
+                    if isinstance(field, ManySerializerMethodResourceRelatedField):
+                        relation_data.update(
+                            {"meta": {"count": len(resource.get(field_name))}}
+                        )
 
                 data.update({field_name: relation_data})
                 continue


### PR DESCRIPTION
Fixes #572

## Description of the Change

`SerializerMethodResourceRelatedField(many=True)` (`ManySerializerMethodResourceRelatedField`) fields are given a meta section with a count much like `ManyRelatedField`.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
