### PR TITLE
Specify required relationship fields in OpenAPI schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ any parts of the framework not mentioned in the documentation should generally b
     ```
 
 * `SerializerMethodResourceRelatedField(many=True)` relationship data now includes a meta section.
+* Required relationship fields are now marked as required in the OpenAPI schema.
 
 ### Fixed
 

--- a/example/tests/__snapshots__/test_openapi.ambr
+++ b/example/tests/__snapshots__/test_openapi.ambr
@@ -587,6 +587,11 @@
                         "$ref": "#/components/schemas/reltoone"
                       }
                     },
+                    "required": [
+                      "bio",
+                      "entries",
+                      "comments"
+                    ],
                     "type": "object"
                   },
                   "type": {
@@ -801,6 +806,11 @@
                   "$ref": "#/components/schemas/reltoone"
                 }
               },
+              "required": [
+                "bio",
+                "entries",
+                "comments"
+              ],
               "type": "object"
             },
             "type": {


### PR DESCRIPTION
## Description of the Change

Required relationships are added to the `required` array under `relationships` in the OpenAPI schema.

```yaml
    post:
      operationId: create/entries
      requestBody:
        content:
          application/vnd.api+json:
            schema:
              required: ...
              properties:
                data:
                  type: object
                  required: ...
                  properties:
                    type: ...
                    id: ...
                    links: ....
                    attributes: ...
                    relationships:
                      type: object
                      properties:
                        blog:
                          $ref: '#/components/schemas/reltoone'
                        blogHyperlinked:
                          $ref: '#/components/schemas/reltoone'
                        authors:
                          $ref: '#/components/schemas/reltomany'
                        comments:
                          $ref: '#/components/schemas/reltomany'
                        commentsHyperlinked:
                          $ref: '#/components/schemas/reltomany'
                        suggested:
                          $ref: '#/components/schemas/reltomany'
                        suggestedHyperlinked:
                          $ref: '#/components/schemas/reltomany'
                        tags:
                          $ref: '#/components/schemas/reltomany'
                        featuredHyperlinked:
                          $ref: '#/components/schemas/reltoone'
                      required:
                      - blog
                      - authors
```

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
