### PR TITLE
Add additionalProperties to includes' attributes and relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * `SerializerMethodResourceRelatedField(many=True)` relationship data now includes a meta section.
 * Required relationship fields are now marked as required in the OpenAPI schema.
+* Objects in the included array are documented in the OpenAPI schema to possibly have additional
+  properties in their "attributes" and "relationships" objects.
 
 ### Fixed
 

--- a/example/tests/__snapshots__/test_openapi.ambr
+++ b/example/tests/__snapshots__/test_openapi.ambr
@@ -185,7 +185,7 @@
                 },
                 "included": {
                   "items": {
-                    "$ref": "#/components/schemas/resource"
+                    "$ref": "#/components/schemas/include"
                   },
                   "type": "array",
                   "uniqueItems": true
@@ -340,7 +340,7 @@
                 },
                 "included": {
                   "items": {
-                    "$ref": "#/components/schemas/resource"
+                    "$ref": "#/components/schemas/include"
                   },
                   "type": "array",
                   "uniqueItems": true
@@ -487,7 +487,7 @@
                 },
                 "included": {
                   "items": {
-                    "$ref": "#/components/schemas/resource"
+                    "$ref": "#/components/schemas/include"
                   },
                   "type": "array",
                   "uniqueItems": true
@@ -662,7 +662,7 @@
                 },
                 "included": {
                   "items": {
-                    "$ref": "#/components/schemas/resource"
+                    "$ref": "#/components/schemas/include"
                   },
                   "type": "array",
                   "uniqueItems": true
@@ -962,6 +962,36 @@
           "description": "Each resource object\u2019s type and id pair MUST [identify](https://jsonapi.org/format/#document-resource-object-identification) a single, unique resource.",
           "type": "string"
         },
+        "include": {
+          "additionalProperties": false,
+          "properties": {
+            "attributes": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "id": {
+              "$ref": "#/components/schemas/id"
+            },
+            "links": {
+              "$ref": "#/components/schemas/links"
+            },
+            "meta": {
+              "$ref": "#/components/schemas/meta"
+            },
+            "relationships": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": {
+              "$ref": "#/components/schemas/type"
+            }
+          },
+          "required": [
+            "type",
+            "id"
+          ],
+          "type": "object"
+        },
         "jsonapi": {
           "additionalProperties": false,
           "description": "The server's implementation",
@@ -1252,7 +1282,7 @@
                       },
                       "included": {
                         "items": {
-                          "$ref": "#/components/schemas/resource"
+                          "$ref": "#/components/schemas/include"
                         },
                         "type": "array",
                         "uniqueItems": true

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -49,6 +49,27 @@ class SchemaGenerator(drf_openapi.SchemaGenerator):
                     "meta": {"$ref": "#/components/schemas/meta"},
                 },
             },
+            "include": {
+                "type": "object",
+                "required": ["type", "id"],
+                "additionalProperties": False,
+                "properties": {
+                    "type": {"$ref": "#/components/schemas/type"},
+                    "id": {"$ref": "#/components/schemas/id"},
+                    "attributes": {
+                        "type": "object",
+                        "additionalProperties": True,
+                        # ...
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "additionalProperties": True,
+                        # ...
+                    },
+                    "links": {"$ref": "#/components/schemas/links"},
+                    "meta": {"$ref": "#/components/schemas/meta"},
+                },
+            },
             "link": {
                 "oneOf": [
                     {
@@ -531,7 +552,7 @@ class AutoSchema(drf_openapi.AutoSchema):
                             "included": {
                                 "type": "array",
                                 "uniqueItems": True,
-                                "items": {"$ref": "#/components/schemas/resource"},
+                                "items": {"$ref": "#/components/schemas/include"},
                             },
                             "links": {
                                 "description": "Link members related to primary data",


### PR DESCRIPTION
## Description of the Change

Add `additionalProperties: true` to the `resource` schema's `attributes` and `relationships` objects to document the fact that these objects will contain keys.

```patch
  components:
    schemas:
      resource:
        type: object
        required:
        - type
        - id
        additionalProperties: false
        properties:
          type:
            $ref: '#/components/schemas/type'
          id:
            $ref: '#/components/schemas/id'
          attributes:
            type: object
+           additionalProperties: true
          relationships:
            type: object
+           additionalProperties: true
          links:
            $ref: '#/components/schemas/links'
          meta:
            $ref: '#/components/schemas/meta'
```

Discovered during an OpenAPI schema validation run as the `included` array was found to contain too many keys in those objects.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
