### PR TITLE
Add HTTP 400 Bad Request as a possible generic error response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Added support for Python 3.11.
 * Added support for Django 4.2.
+* Added `400 Bad Request` as a possible error response in the OpenAPI schema.
 
 ### Changed
 

--- a/example/tests/__snapshots__/test_openapi.ambr
+++ b/example/tests/__snapshots__/test_openapi.ambr
@@ -38,6 +38,16 @@
       "204": {
         "description": "[no content](https://jsonapi.org/format/#crud-deleting-responses-204)"
       },
+      "400": {
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "$ref": "#/components/schemas/failure"
+            }
+          }
+        },
+        "description": "bad request"
+      },
       "401": {
         "content": {
           "application/vnd.api+json": {
@@ -204,6 +214,16 @@
         },
         "description": "update/authors/{id}"
       },
+      "400": {
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "$ref": "#/components/schemas/failure"
+            }
+          }
+        },
+        "description": "bad request"
+      },
       "401": {
         "content": {
           "application/vnd.api+json": {
@@ -349,6 +369,16 @@
         },
         "description": "retrieve/authors/{id}/"
       },
+      "400": {
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "$ref": "#/components/schemas/failure"
+            }
+          }
+        },
+        "description": "bad request"
+      },
       "401": {
         "content": {
           "application/vnd.api+json": {
@@ -485,6 +515,16 @@
           }
         },
         "description": "List/authors/"
+      },
+      "400": {
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "$ref": "#/components/schemas/failure"
+            }
+          }
+        },
+        "description": "bad request"
       },
       "401": {
         "content": {
@@ -663,6 +703,16 @@
       },
       "204": {
         "description": "[Created](https://jsonapi.org/format/#crud-creating-responses-204) with the supplied `id`. No other changes from what was POSTed."
+      },
+      "400": {
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "$ref": "#/components/schemas/failure"
+            }
+          }
+        },
+        "description": "bad request"
       },
       "401": {
         "content": {
@@ -1230,6 +1280,16 @@
                 }
               },
               "description": "List/authors/"
+            },
+            "400": {
+              "content": {
+                "application/vnd.api+json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/failure"
+                  }
+                }
+              },
+              "description": "bad request"
             },
             "401": {
               "content": {

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -779,6 +779,7 @@ class AutoSchema(drf_openapi.AutoSchema):
         Add generic failure response(s) to operation
         """
         for code, reason in [
+            ("400", "bad request"),
             ("401", "not authorized"),
         ]:
             operation["responses"][code] = self._failure_response(reason)


### PR DESCRIPTION
## Description of the Change

Adds `400 Bad Request` as a possible error response, as JSON:API specification says to use it for requests with bad `include` / `sort` or otherwise illegal query parameters, and advocates using it as an appropriate status code for multiple 4xx errors. DJA's documentation also mentions `400 Bad Request` multiple times, so it's a bit weird if it's not documented as a possible response.

Discovered during an OpenAPI schema validation run as our generic error responses were not found in the schema.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
