### PR TITLE
Removed support for Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,13 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Fixed OpenAPI schema generation for `Serializer` when used inside another `Serializer` or as a child of `ListField`.
 
+### Removed
+
+* Removed support for Python 3.7.
+
 ## [6.1.0] - 2023-08-25
+
+This is the last release supporting Python 3.7.
 
 ### Added
 

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ As a Django REST framework JSON:API (short DJA) we are trying to address followi
 Requirements
 ------------
 
-1. Python (3.7, 3.8, 3.9, 3.10, 3.11)
+1. Python (3.8, 3.9, 3.10, 3.11)
 2. Django (3.2, 4.0, 4.1, 4.2)
 3. Django REST framework (3.13, 3.14)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ like the following:
 
 ## Requirements
 
-1. Python (3.7, 3.8, 3.9, 3.10, 3.11)
+1. Python (3.8, 3.9, 3.10, 3.11)
 2. Django (3.2, 4.0, 4.1, 4.2)
 3. Django REST framework (3.13, 3.14)
 

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-django32-drf{313,314,master},
+    py{38,39,310}-django32-drf{313,314,master},
     py{38,39,310}-django40-drf{313,314,master},
     py{38,39,310,311}-django41-drf{314,master},
     py{38,39,310,311}-django42-drf{314,master},
@@ -50,7 +50,7 @@ deps =
 commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
 
-[testenv:py{37,38,39,310}-django32-drfmaster]
+[testenv:py{38,39,310}-django32-drfmaster]
 ignore_outcome = true
 
 [testenv:py{38,39,310}-django40-drfmaster]


### PR DESCRIPTION
## Description of the Change

Python 3.7 is end of life since 27 Jun 2023, so we can remove support for it.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
