### PR TITLE
Increased minimum Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,6 @@ setup(
         "openapi": ["pyyaml>=5.4", "uritemplate>=3.0.1"],
     },
     setup_requires=wheel,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     zip_safe=False,
 )


### PR DESCRIPTION
## Description of the Change

This was missed when removing Python 3.7.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
