### PR TITLE
Removed support for Django 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Removed
 
 * Removed support for Python 3.7.
+* Removed support for Django 4.0.
 
 ## [6.1.0] - 2023-08-25
 
-This is the last release supporting Python 3.7.
+This is the last release supporting Python 3.7 and Django 4.0.
 
 ### Added
 

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Requirements
 ------------
 
 1. Python (3.8, 3.9, 3.10, 3.11)
-2. Django (3.2, 4.0, 4.1, 4.2)
+2. Django (3.2, 4.1, 4.2)
 3. Django REST framework (3.13, 3.14)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ like the following:
 ## Requirements
 
 1. Python (3.8, 3.9, 3.10, 3.11)
-2. Django (3.2, 4.0, 4.1, 4.2)
+2. Django (3.2, 4.1, 4.2)
 3. Django REST framework (3.13, 3.14)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py{38,39,310}-django32-drf{313,314,master},
-    py{38,39,310}-django40-drf{313,314,master},
     py{38,39,310,311}-django41-drf{314,master},
     py{38,39,310,311}-django42-drf{314,master},
     black,
@@ -11,7 +10,6 @@ envlist =
 [testenv]
 deps =
     django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
     drf313: djangorestframework>=3.13,<3.14
@@ -51,9 +49,6 @@ commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
 
 [testenv:py{38,39,310}-django32-drfmaster]
-ignore_outcome = true
-
-[testenv:py{38,39,310}-django40-drfmaster]
 ignore_outcome = true
 
 [testenv:py{38,39,310,311}-django41-drfmaster]


### PR DESCRIPTION
## Description of the Change

Django support for version 4.0 ended 01 Apr 2023 so according to our policy we can remove it.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
