### PR TITLE
Ensure that ModelSerializer fields are in same order than in DRF

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ Adam Wróbel <https://adamwrobel.com>
 Adam Ziolkowski <adam@adsized.com>
 Alan Crosswell <alan@columbia.edu>
 Alex Seidmann <alex@leanpnt.de>
+Antoine Auger <https://antoineauger.fr/en>
 Anton Shutik <shutikanton@gmail.com>
 Arttu Perälä <arttu@perala.me>
 Ashley Loewen <github@ashleycodes.tech>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Fixed
 
 * Fixed OpenAPI schema generation for `Serializer` when used inside another `Serializer` or as a child of `ListField`.
+* `ModelSerializer` fields are now returned in the same order than DRF
 
 ### Removed
 

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -309,11 +309,11 @@ class ModelSerializer(
         """
         meta_fields = getattr(self.Meta, "meta_fields", [])
 
-        declared = {}
-        for field_name in set(declared_fields.keys()):
-            field = declared_fields[field_name]
-            if field_name not in meta_fields:
-                declared[field_name] = field
+        declared = {
+            field_name: field
+            for field_name, field in declared_fields.items()
+            if field_name not in meta_fields
+        }
         fields = super().get_field_names(declared, info)
         return list(fields) + list(getattr(self.Meta, "meta_fields", list()))
 


### PR DESCRIPTION
## Description of the Change

 For serializers inheriting from `ModelSerializer` that declare additional fields, the order of field names returned by `get_field_names` can get unpredictable. It is not necessarily following alphabetical order but can also change between several runs of schema generation (tested with `drf-spectacular` for instance). 

This is especially true when a `ModelSerializer` has `fields = "__all__"` and inherits from several serializers.

```python
class MyTestModel(DJAModel):
    verified = models.BooleanField(default=False)
    uuid = models.UUIDField()

class AnotherSerializer(serializers.Serializer):
    ref_id = serializers.CharField()
    reference_string = serializers.CharField()

class MyTestModelSerializer(AnotherSerializer, serializers.ModelSerializer):
    an_extra_field = serializers.CharField()

    class Meta:
        model = MyTestModel
        fields = "__all__"
        extra_kwargs = {
            "verified": {"read_only": True},
        }
```

I believe this PR could lead to more stable OpenAPI specs, which could be nice for users comparing specs using exact diff. 
What do you think of this proposal? 🙇🏻 

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`

:hammer_and_wrench: with :heart: by [Siemens](https://opensource.siemens.com/)