### PR TITLE
Avoided that an empty attributes dict is rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Fixed OpenAPI schema generation for `Serializer` when used inside another `Serializer` or as a child of `ListField`.
 * `ModelSerializer` fields are now returned in the same order than DRF
+* Avoided that an empty attributes dict is rendered in case serializer does not
+  provide any attribute fields.
 
 ### Removed
 

--- a/example/tests/unit/test_renderers.py
+++ b/example/tests/unit/test_renderers.py
@@ -126,7 +126,7 @@ def test_writeonly_not_in_response():
 
         class Meta:
             model = Entry
-            fields = ("comments", "rating")
+            fields = ("headline", "comments", "rating")
 
     class WriteOnlyDummyTestViewSet(views.ReadOnlyModelViewSet):
         queryset = Entry.objects.all()
@@ -136,6 +136,7 @@ def test_writeonly_not_in_response():
     result = json.loads(rendered.decode())
 
     assert "rating" not in result["data"]["attributes"]
+    assert "headline" in result["data"]["attributes"]
     assert "relationships" not in result["data"]
 
 
@@ -153,6 +154,7 @@ def test_render_empty_relationship_reverse_lookup():
 
     rendered = render_dummy_test_serialized_view(EmptyRelationshipViewSet, Author())
     result = json.loads(rendered.decode())
+    assert "attributes" not in result["data"]
     assert "relationships" in result["data"]
     assert "bio" in result["data"]["relationships"]
     assert result["data"]["relationships"]["bio"] == {"data": None}

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -452,8 +452,10 @@ class JSONRenderer(renderers.JSONRenderer):
         resource_data = {
             "type": resource_name,
             "id": utils.get_resource_id(resource_instance, resource),
-            "attributes": cls.extract_attributes(fields, resource),
         }
+        attributes = cls.extract_attributes(fields, resource)
+        if attributes:
+            resource_data["attributes"] = attributes
         relationships = cls.extract_relationships(fields, resource, resource_instance)
         if relationships:
             resource_data["relationships"] = relationships


### PR DESCRIPTION
## Description of the Change

[Attributes](https://jsonapi.org/format/#document-resource-objects) member is actually optional and may not be rendered if there are no serializer attribute fields. But currently it does. The renderer though already made sure, that relationships are not rendered if there are not any, so this change makes it more consistent.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
