### PR TITLE
Use sphinx theme locally and on rtd as extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ main(["-o", "apidoc", "-f", "-e", "-T", "-M", "../rest_framework_json_api"])
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "recommonmark"]
+extensions = ["sphinx.ext.autodoc", "recommonmark", "sphinx_rtd_theme"]
 autodoc_member_order = "bysource"
 autodoc_inherit_docstrings = False
 
@@ -122,15 +122,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "default"
-
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
## Description of the Change

Our current stable docs show in an [old theme](https://django-rest-framework-json-api.readthedocs.io/en/stable/). This should make sure that the rtd theme is used locally as remotely.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
