### PR TITLE
Drop support for Django 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Removed
 
 * Removed support for Python 3.7.
+* Removed support for Django 3.2.
 * Removed support for Django 4.0.
 * Removed support for Django 4.1.
 * Removed support for Django REST framework 3.13.
@@ -33,7 +34,7 @@ any parts of the framework not mentioned in the documentation should generally b
 
 ## [6.1.0] - 2023-08-25
 
-This is the last release supporting Python 3.7, Django 4.0, Django 4.1 and Django REST framework 3.13.
+This is the last release supporting Python 3.7, Django 3.2, Django 4.0, Django 4.1 and Django REST framework 3.13.
 
 ### Added
 

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Requirements
 ------------
 
 1. Python (3.8, 3.9, 3.10, 3.11, 3.12)
-2. Django (3.2, 4.2, 5.0)
+2. Django (4.2, 5.0)
 3. Django REST framework (3.14, 3.15)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ like the following:
 ## Requirements
 
 1. Python (3.8, 3.9, 3.10, 3.11, 3.12)
-2. Django (3.2, 4.2, 5.0)
+2. Django (4.2, 5.0)
 3. Django REST framework (3.14, 3.15)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.

--- a/example/urls_test.py
+++ b/example/urls_test.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import path, re_path
 from rest_framework import routers
 
 from .api.resources.identity import GenericIdentity, Identity
@@ -46,8 +46,8 @@ router.register(r"identities", Identity)
 
 urlpatterns = [
     # old tests
-    re_path(
-        r"identities/default/(?P<pk>\d+)$",
+    path(
+        "identities/default/<int:pk>",
         GenericIdentity.as_view(),
         name="user-default",
     ),

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     install_requires=[
         "inflection>=0.5.0",
         "djangorestframework>=3.14",
-        "django>=3.2",
+        "django>=4.2",
     ],
     extras_require={
         "django-polymorphic": ["django-polymorphic>=3.0"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py{38,39,310}-django32-drf{314,315,master},
     py{38,39,310,311,312}-django42-drf{314,315,master},
     py{310,311,312}-django50-drf{314,315,master},
     black,
@@ -9,7 +8,6 @@ envlist =
 
 [testenv]
 deps =
-    django32: Django>=3.2,<3.3
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<5.1
     drf314: djangorestframework>=3.14,<3.15
@@ -47,9 +45,6 @@ deps =
     -rrequirements/requirements-documentation.txt
 commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
-
-[testenv:py{38,39,310}-django32-drfmaster]
-ignore_outcome = true
 
 [testenv:py{38,39,310,311,312}-django42-drfmaster]
 ignore_outcome = true


### PR DESCRIPTION
## Description of the Change

Run django-upgrade --target-version 4.2

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
