### PR TITLE
Ensured that sparse fields only applies when rendering not when parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ any parts of the framework not mentioned in the documentation should generally b
 * Avoided that an empty attributes dict is rendered in case serializer does not
   provide any attribute fields.
 * Avoided shadowing of exception when rendering errors (regression since 4.3.0).
+* Ensured that sparse fields only applies when rendering, not when parsing.
+* Adjusted that sparse fields properly removes meta fields when not defined.
 
 ### Removed
 

--- a/example/tests/integration/test_non_paginated_responses.py
+++ b/example/tests/integration/test_non_paginated_responses.py
@@ -14,7 +14,7 @@ def test_multiple_entries_no_pagination(multiple_entries, client):
     expected = {
         "data": [
             {
-                "type": "posts",
+                "type": "entries",
                 "id": "1",
                 "attributes": {
                     "headline": multiple_entries[0].headline,
@@ -70,7 +70,7 @@ def test_multiple_entries_no_pagination(multiple_entries, client):
                 },
             },
             {
-                "type": "posts",
+                "type": "entries",
                 "id": "2",
                 "attributes": {
                     "headline": multiple_entries[1].headline,

--- a/example/tests/integration/test_pagination.py
+++ b/example/tests/integration/test_pagination.py
@@ -14,7 +14,7 @@ def test_pagination_with_single_entry(single_entry, client):
     expected = {
         "data": [
             {
-                "type": "posts",
+                "type": "entries",
                 "id": "1",
                 "attributes": {
                     "headline": single_entry.headline,

--- a/example/tests/integration/test_sparse_fieldsets.py
+++ b/example/tests/integration/test_sparse_fieldsets.py
@@ -15,6 +15,7 @@ def test_sparse_fieldset_valid_fields(client, entry):
     entry = data[0]
     assert entry["attributes"].keys() == {"headline"}
     assert entry["relationships"].keys() == {"blog"}
+    assert "meta" not in entry
 
 
 @pytest.mark.parametrize(

--- a/example/tests/test_filters.py
+++ b/example/tests/test_filters.py
@@ -470,7 +470,7 @@ class DJATestFilters(APITestCase):
         expected_result = {
             "data": [
                 {
-                    "type": "posts",
+                    "type": "entries",
                     "id": "7",
                     "attributes": {
                         "headline": "ANTH3868X",

--- a/example/tests/unit/test_renderer_class_methods.py
+++ b/example/tests/unit/test_renderer_class_methods.py
@@ -102,8 +102,8 @@ def test_extract_attributes():
     assert sorted(JSONRenderer.extract_attributes(fields, resource)) == sorted(
         expected
     ), "Regular fields should be extracted"
-    assert sorted(JSONRenderer.extract_attributes(fields, {})) == sorted(
-        {"username": ""}
+    assert (
+        JSONRenderer.extract_attributes(fields, {}) == {}
     ), "Should not extract read_only fields on empty serializer"
 
 

--- a/example/views.py
+++ b/example/views.py
@@ -112,7 +112,10 @@ class BlogCustomViewSet(JsonApiViewSet):
 
 class EntryViewSet(ModelViewSet):
     queryset = Entry.objects.all()
-    resource_name = "posts"
+    # TODO it should not be supported to overwrite resource name
+    # of endpoints with serializers as includes and sparse fields
+    # cannot be aware of it
+    # resource_name = "posts"
 
     def get_serializer_class(self):
         return EntrySerializer

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -26,7 +26,10 @@ class ForeignKeySourceSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ForeignKeySource
-        fields = ("target",)
+        fields = (
+            "name",
+            "target",
+        )
 
 
 class ManyToManyTargetSerializer(serializers.ModelSerializer):

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -39,7 +39,9 @@ class TestResourceRelatedField:
         settings.JSON_API_FORMAT_TYPES = format_type
         settings.JSON_API_PLURALIZE_TYPES = pluralize_type
 
-        serializer = ForeignKeySourceSerializer(instance={"target": foreign_key_target})
+        serializer = ForeignKeySourceSerializer(
+            instance={"target": foreign_key_target, "name": "Test"}
+        )
         expected = {
             "type": resource_type,
             "id": str(foreign_key_target.pk),
@@ -85,7 +87,10 @@ class TestResourceRelatedField:
         settings.JSON_API_PLURALIZE_TYPES = pluralize_type
 
         serializer = ForeignKeySourceSerializer(
-            data={"target": {"type": resource_type, "id": str(foreign_key_target.pk)}}
+            data={
+                "target": {"type": resource_type, "id": str(foreign_key_target.pk)},
+                "name": "Test",
+            }
         )
 
         assert serializer.is_valid()
@@ -191,7 +196,9 @@ class TestResourceRelatedField:
         ],
     )
     def test_invalid_resource_id_object(self, resource_identifier, error):
-        serializer = ForeignKeySourceSerializer(data={"target": resource_identifier})
+        serializer = ForeignKeySourceSerializer(
+            data={"target": resource_identifier, "name": "Test"}
+        )
         assert not serializer.is_valid()
         assert serializer.errors == {"target": [error]}
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -237,6 +237,43 @@ class TestModelViewSet:
         assert BasicModel.objects.count() == 0
         assert len(response.rendered_content) == 0
 
+    @pytest.mark.urls(__name__)
+    def test_create_with_sparse_fields(self, client, foreign_key_target):
+        url = reverse("foreign-key-source-list")
+        data = {
+            "data": {
+                "id": None,
+                "type": "ForeignKeySource",
+                "attributes": {"name": "Test"},
+                "relationships": {
+                    "target": {
+                        "data": {
+                            "id": str(foreign_key_target.pk),
+                            "type": "ForeignKeyTarget",
+                        }
+                    }
+                },
+            }
+        }
+        response = client.post(f"{url}?fields[ForeignKeySource]=target", data=data)
+        assert response.status_code == status.HTTP_201_CREATED
+        foreign_key_source = ForeignKeySource.objects.first()
+        assert foreign_key_source.name == "Test"
+        assert response.json() == {
+            "data": {
+                "id": str(foreign_key_source.pk),
+                "type": "ForeignKeySource",
+                "relationships": {
+                    "target": {
+                        "data": {
+                            "id": str(foreign_key_target.pk),
+                            "type": "ForeignKeyTarget",
+                        }
+                    }
+                },
+            }
+        }
+
 
 class TestReadonlyModelViewSet:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1216
Fixes #332

## Description of the Change

The rendering of objects is flawed as the DJA renderer does most of the serialization again which should actually only be done by the serializer. Even though I reduced the readable fields in the serializer when sparse fields is used, it did not work.

I already adjusted `extract_attributes` that it uses the fields provided by the serializer. To adjust `extract_relationships` is more complex. Therefore, to get this critical issue fixed I also added code to exclude fields in the renderer when sparse fields is used.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
