### PR TITLE
Removed obsolete warning filter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,9 +66,6 @@ filterwarnings =
     # Django filter schema generation. Can be removed once we remove
     # schema support
     ignore:Built-in schema generation is deprecated.
-    # can be removed once django filter has released a new version including
-    # https://github.com/carltongibson/django-filter/pull/1623
-    ignore:'pkgutil.find_loader' is deprecated and slated for removal
 testpaths =
     example
     tests


### PR DESCRIPTION
## Description of the Change

Removed obsolete warning filter

## Checklist

- [ ] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
