### PR TITLE
fix the format_errors bug when data is None

### DIFF
--- a/example/tests/unit/test_default_drf_serializers.py
+++ b/example/tests/unit/test_default_drf_serializers.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime
+import logging
 
 import pytest
 from django.urls import reverse
@@ -73,7 +74,6 @@ def test_render_format_field_names(db, settings, entry):
 def test_blog_create(client):
     url = reverse("drf-entry-blog-list")
     name = "Dummy Name"
-
     request_data = {
         "data": {"attributes": {"name": name}, "type": "blogs"},
     }
@@ -102,6 +102,19 @@ def test_blog_create(client):
 
     assert resp.status_code == 201
     assert resp.json() == expected
+
+
+@pytest.mark.django_db
+def test_rest_action_request(client):
+    url = reverse("drf-entry-blog-list") + "/actions/custom_response"
+    name = "Dummy Name"
+    request_data = {
+        "data": {"attributes": {"name": name}, "type": "blogs"},
+    }
+
+    resp = client.post(url, request_data)
+
+    assert resp.status_code == 400
 
 
 @pytest.mark.django_db

--- a/example/views.py
+++ b/example/views.py
@@ -1,9 +1,11 @@
+import logging
 import rest_framework.exceptions as exceptions
 import rest_framework.parsers
 import rest_framework.renderers
 from django_filters import rest_framework as filters
 from rest_framework.filters import SearchFilter
-
+from rest_framework.response import Response
+from rest_framework.decorators import action
 import rest_framework_json_api.metadata
 import rest_framework_json_api.parsers
 import rest_framework_json_api.renderers
@@ -74,6 +76,18 @@ class DRFBlogViewSet(ModelViewSet):
 
         return super().get_object()
 
+    @action(url_path="actions/custom_response", detail=False, methods=["post"])
+    def custom_response(self, request):
+        data = request.data
+        serializer = self.get_serializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        try:
+            test = 1/0
+        except Exception:
+            return Response(status=400)
+
+        return Response(status=201)
 
 class JsonApiViewSet(ModelViewSet):
     """
@@ -254,7 +268,6 @@ class CommentViewSet(ModelViewSet):
 
         return queryset
 
-
 class CompanyViewset(ModelViewSet):
     queryset = Company.objects.all()
     serializer_class = CompanySerializer
@@ -272,7 +285,6 @@ class ProjectTypeViewset(ModelViewSet):
 
 class EntryRelationshipView(RelationshipView):
     queryset = Entry.objects.all()
-
 
 class BlogRelationshipView(RelationshipView):
     queryset = Blog.objects.all()

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -474,6 +474,6 @@ def format_error_object(message, pointer, response):
 
 
 def format_errors(data):
-    if len(data) > 1 and isinstance(data, list):
+    if isinstance(data, list) and len(data) > 1:
         data.sort(key=lambda x: x.get("source", {}).get("pointer", ""))
     return {"errors": data}


### PR DESCRIPTION
Fixes #

Related to the PR: https://github.com/django-json-api/django-rest-framework-json-api/pull/1121
Add the test case to support it

AUTHORS:
 - Eric

## Description of the Change

Fix: TypeError: object of type 'NoneType' has no len()


## Checklist

- [ x ] PR only contains one change (considered splitting up PR)
- [x  ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x ] author name in `AUTHORS`
