### PR TITLE
Ensured that URL and id field are kept when using sparse fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Added `429 Too Many Requests` as a possible error response in the OpenAPI schema.
 
+### Fixed
+
+* Ensured that URL and id field are kept when using sparse fields (regression since 7.0.0)
+
 ## [7.0.0] - 2024-05-02
 
 ### Added

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -446,7 +446,10 @@ class JSONRenderer(renderers.JSONRenderer):
                 return {
                     field_name: field
                     for field_name, field, in fields.items()
-                    if field_name in sparse_fields
+                    if field.field_name in sparse_fields
+                    # URL field is not considered a field in JSON:API spec
+                    # but a link so need to keep it
+                    or field.field_name == api_settings.URL_FIELD_NAME
                 }
 
         return fields

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -94,10 +94,15 @@ class SparseFieldsetsMixin:
                         field
                         for field in readable_fields
                         if field.field_name in sparse_fields
+                        # URL field is not considered a field in JSON:API spec
+                        # but a link so need to keep it
                         or field.field_name == api_settings.URL_FIELD_NAME
+                        # ID is a required field which might have been overwritten
+                        # so need to keep it
+                        or field.field_name == "id"
                     )
             except AttributeError:
-                # no type on serializer, must be used only as only nested
+                # no type on serializer, may only be used nested
                 pass
 
         return readable_fields

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -1,3 +1,5 @@
+from rest_framework.settings import api_settings
+
 from rest_framework_json_api import serializers
 from tests.models import (
     BasicModel,
@@ -29,6 +31,16 @@ class ForeignKeySourceSerializer(serializers.ModelSerializer):
         fields = (
             "name",
             "target",
+        )
+
+
+class ForeignKeySourcetHyperlinkedSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = ForeignKeySource
+        fields = (
+            "name",
+            "target",
+            api_settings.URL_FIELD_NAME,
         )
 
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -2,12 +2,15 @@ from rest_framework_json_api.views import ModelViewSet
 from tests.models import (
     BasicModel,
     ForeignKeySource,
+    ForeignKeyTarget,
     ManyToManySource,
     NestedRelatedSource,
 )
 from tests.serializers import (
     BasicModelSerializer,
     ForeignKeySourceSerializer,
+    ForeignKeySourcetHyperlinkedSerializer,
+    ForeignKeyTargetSerializer,
     ManyToManySourceSerializer,
     NestedRelatedSourceSerializer,
 )
@@ -22,6 +25,18 @@ class BasicModelViewSet(ModelViewSet):
 class ForeignKeySourceViewSet(ModelViewSet):
     serializer_class = ForeignKeySourceSerializer
     queryset = ForeignKeySource.objects.all()
+    ordering = ["name"]
+
+
+class ForeignKeySourcetHyperlinkedViewSet(ModelViewSet):
+    serializer_class = ForeignKeySourcetHyperlinkedSerializer
+    queryset = ForeignKeySource.objects.all()
+    ordering = ["name"]
+
+
+class ForeignKeyTargetViewSet(ModelViewSet):
+    serializer_class = ForeignKeyTargetSerializer
+    queryset = ForeignKeyTarget.objects.all()
     ordering = ["name"]
 
 


### PR DESCRIPTION
Fixes #1228

## Description of the Change

URL field is considered a field in DRF but it is not in JSON:API spec therefore we may not exclude it during sparse fields. ID on the other hand is a required field and may not be filtered out either as we allow in DJA to overwrite primary key of model.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
