### PR TITLE
Re-enabled overwriting of URL field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST framework policy](https://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
+## [Unreleased]
+
+### Fixed
+
+* Re-enabled overwriting of url field (regression since 7.0.0)
+
 ## [7.0.1] - 2024-06-06
 
 ### Added

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -6,6 +6,7 @@ from django.db.models.query import QuerySet
 from django.utils.module_loading import import_string as import_class_from_dotted_path
 from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import ParseError
+from rest_framework.relations import HyperlinkedIdentityField
 
 # star import defined so `rest_framework_json_api.serializers` can be
 # a simple drop in for `rest_framework.serializers`
@@ -94,9 +95,12 @@ class SparseFieldsetsMixin:
                         field
                         for field in readable_fields
                         if field.field_name in sparse_fields
-                        # URL field is not considered a field in JSON:API spec
-                        # but a link so need to keep it
-                        or field.field_name == api_settings.URL_FIELD_NAME
+                        # URL_FIELD_NAME is the field used as self-link to resource
+                        # however only when it is a HyperlinkedIdentityField
+                        or (
+                            field.field_name == api_settings.URL_FIELD_NAME
+                            and isinstance(field, HyperlinkedIdentityField)
+                        )
                         # ID is a required field which might have been overwritten
                         # so need to keep it
                         or field.field_name == "id"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from tests.models import (
     ManyToManySource,
     ManyToManyTarget,
     NestedRelatedSource,
+    URLModel,
 )
 
 
@@ -34,6 +35,11 @@ def use_rest_framework_json_api_defaults(settings):
 @pytest.fixture
 def model(db):
     return BasicModel.objects.create(text="Model")
+
+
+@pytest.fixture
+def url_instance(db):
+    return URLModel.objects.create(text="Url", url="https://example.com")
 
 
 @pytest.fixture

--- a/tests/models.py
+++ b/tests/models.py
@@ -18,6 +18,14 @@ class BasicModel(DJAModel):
         ordering = ("id",)
 
 
+class URLModel(DJAModel):
+    url = models.URLField()
+    text = models.CharField(max_length=100)
+
+    class Meta:
+        ordering = ("id",)
+
+
 # Models for relations tests
 # ManyToMany
 class ManyToManyTarget(DJAModel):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -8,6 +8,7 @@ from tests.models import (
     ManyToManySource,
     ManyToManyTarget,
     NestedRelatedSource,
+    URLModel,
 )
 
 
@@ -15,6 +16,15 @@ class BasicModelSerializer(serializers.ModelSerializer):
     class Meta:
         fields = ("text",)
         model = BasicModel
+
+
+class URLModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        fields = (
+            "text",
+            "url",
+        )
+        model = URLModel
 
 
 class ForeignKeyTargetSerializer(serializers.ModelSerializer):

--- a/tests/views.py
+++ b/tests/views.py
@@ -5,6 +5,7 @@ from tests.models import (
     ForeignKeyTarget,
     ManyToManySource,
     NestedRelatedSource,
+    URLModel,
 )
 from tests.serializers import (
     BasicModelSerializer,
@@ -13,6 +14,7 @@ from tests.serializers import (
     ForeignKeyTargetSerializer,
     ManyToManySourceSerializer,
     NestedRelatedSourceSerializer,
+    URLModelSerializer,
 )
 
 
@@ -20,6 +22,12 @@ class BasicModelViewSet(ModelViewSet):
     serializer_class = BasicModelSerializer
     queryset = BasicModel.objects.all()
     ordering = ["text"]
+
+
+class URLModelViewSet(ModelViewSet):
+    serializer_class = URLModelSerializer
+    queryset = URLModel.objects.all()
+    ordering = ["url"]
 
 
 class ForeignKeySourceViewSet(ModelViewSet):


### PR DESCRIPTION
Addresses #1233

## Description of the Change

`URL_FIELD_NAME` is usually used as self-link in links. However, the field name should be allowed to be overwritten as long as the field type is not HyperlinkedIdentifyField which `HyperlinkedModelSerializer` uses.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
