### PR TITLE
Ensured that no fields are returned when sparse fields is set to an empty value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Fixed
 
 * Re-enabled overwriting of url field (regression since 7.0.0)
-* Ensured that no fields are rendered when sparse fields is set to an empty value.
+* Ensured that no fields are rendered when sparse fields is set to an empty value. (regression since 7.0.0)
 
 ## [7.0.1] - 2024-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Fixed
 
 * Re-enabled overwriting of url field (regression since 7.0.0)
+* Ensured that no fields are rendered when sparse fields is set to an empty value.
 
 ## [7.0.1] - 2024-06-06
 

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -439,7 +439,7 @@ class JSONRenderer(renderers.JSONRenderer):
             sparse_fieldset_value = request.query_params.get(
                 sparse_fieldset_query_param
             )
-            if sparse_fieldset_value:
+            if sparse_fieldset_value is not None:
                 sparse_fields = sparse_fieldset_value.split(",")
                 return {
                     field_name: field

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -89,7 +89,7 @@ class SparseFieldsetsMixin:
                 sparse_fieldset_value = request.query_params.get(
                     sparse_fieldset_query_param
                 )
-                if sparse_fieldset_value:
+                if sparse_fieldset_value is not None:
                     sparse_fields = sparse_fieldset_value.split(",")
                     return (
                         field

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -220,6 +220,19 @@ class TestModelViewSet:
         ]
 
     @pytest.mark.urls(__name__)
+    def test_list_with_sparse_fields_empty_value(self, client, model):
+        url = reverse("basic-model-list")
+        response = client.get(url, data={"fields[BasicModel]": ""})
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()["data"]
+        assert data == [
+            {
+                "type": "BasicModel",
+                "id": str(model.pk),
+            }
+        ]
+
+    @pytest.mark.urls(__name__)
     def test_retrieve(self, client, model):
         url = reverse("basic-model-detail", kwargs={"pk": model.pk})
         response = client.get(url)


### PR DESCRIPTION
Fixes #1238

## Description of the Change

When a sparse field is set to an empty value no fields (attributes/relationships) should be rendered whereas currently it rendered all fields.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
