### PR TITLE
Release 7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST framework policy](https://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
-## [Unreleased]
+## [7.0.2] - 2024-06-28
 
 ### Fixed
 
-* Re-enabled overwriting of url field (regression since 7.0.0)
+* Allow overwriting of url field again (regression since 7.0.0)
 * Ensured that no fields are rendered when sparse fields is set to an empty value. (regression since 7.0.0)
 
 ## [7.0.1] - 2024-06-06

--- a/rest_framework_json_api/__init__.py
+++ b/rest_framework_json_api/__init__.py
@@ -1,5 +1,5 @@
 __title__ = "djangorestframework-jsonapi"
-__version__ = "7.0.1"
+__version__ = "7.0.2"
 __author__ = ""
 __license__ = "BSD"
 __copyright__ = ""


### PR DESCRIPTION
## Description of the Change

Another release to get the two regressions out of the way, not to hinder anyone from upgrading.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
