### PR TITLE
Handle zero as valid pk/id in get_resource_id util method

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ David Guillot, for Contexte <dguillot@contexte.com>
 David Vogt <david.vogt@adfinis-sygroup.ch>
 Felix Viernickel <felix@gedankenspieler.org>
 Greg Aker <greg@gregaker.net>
+Humayun Ahmad <humayunahbh@gmail.com>
 Jamie Bliss <astronouth7303@gmail.com>
 Jason Housley <housleyjk@gmail.com>
 Jeppe Fihl-Pearson <jeppe@tenzer.dk>
@@ -52,4 +53,3 @@ Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
 Ulrich Schuster <ulrich.schuster@mailworks.org>
 Yaniv Peer <yanivpeer@gmail.com>
-Humayun Ahmad <humayunahbh@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -52,3 +52,4 @@ Tim Selman <timcbaoth@gmail.com>
 Tom Glowka <glowka.tom@gmail.com>
 Ulrich Schuster <ulrich.schuster@mailworks.org>
 Yaniv Peer <yanivpeer@gmail.com>
+Humayun Ahmad <humayunahbh@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST framework policy](https://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
+## [Unreleased]
+
+### Fixed
+
+* Handled zero as a valid ID for resource (regression since 6.1.0)
+
 ## [7.0.2] - 2024-06-28
 
 ### Fixed
 
 * Allow overwriting of url field again (regression since 7.0.0)
 * Ensured that no fields are rendered when sparse fields is set to an empty value. (regression since 7.0.0)
-* Handled zero as a valid ID in `get_resource_id` function.
 
 ## [7.0.1] - 2024-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Allow overwriting of url field again (regression since 7.0.0)
 * Ensured that no fields are rendered when sparse fields is set to an empty value. (regression since 7.0.0)
+* Handled zero as a valid ID in `get_resource_id` function.
 
 ## [7.0.1] - 2024-06-06
 

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -307,15 +307,11 @@ def get_resource_type_from_serializer(serializer):
 def get_resource_id(resource_instance, resource):
     """Returns the resource identifier for a given instance (`id` takes priority over `pk`)."""
     if resource and "id" in resource:
-        return (
-            encoding.force_str(resource["id"]) if resource["id"] is not None else None
-        )
+        _id = resource["id"]
+        return encoding.force_str(_id) if _id is not None else None
     if resource_instance:
-        return (
-            encoding.force_str(resource_instance.pk)
-            if hasattr(resource_instance, "pk") and resource_instance.pk is not None
-            else None
-        )
+        pk = getattr(resource_instance, "pk", None)
+        return encoding.force_str(pk) if pk is not None else None
     return None
 
 

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -307,12 +307,14 @@ def get_resource_type_from_serializer(serializer):
 def get_resource_id(resource_instance, resource):
     """Returns the resource identifier for a given instance (`id` takes priority over `pk`)."""
     if resource and "id" in resource:
-        return resource["id"] and encoding.force_str(resource["id"]) or None
+        return (
+            encoding.force_str(resource["id"]) if resource["id"] is not None else None
+        )
     if resource_instance:
         return (
-            hasattr(resource_instance, "pk")
-            and encoding.force_str(resource_instance.pk)
-            or None
+            encoding.force_str(resource_instance.pk)
+            if hasattr(resource_instance, "pk") and resource_instance.pk is not None
+            else None
         )
     return None
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -403,6 +403,13 @@ def test_get_resource_type_from_serializer_without_resource_name_raises_error():
         (None, {"id": 11}, "11"),
         (object(), {"pk": 11}, None),
         (BasicModel(id=6), {"id": 11}, "11"),
+        (BasicModel(id=0), None, "0"),
+        (None, {"id": 0}, "0"),
+        (
+            BasicModel(id=0),
+            {"id": 0},
+            "0",
+        ),
     ],
 )
 def test_get_resource_id(resource_instance, resource, expected):


### PR DESCRIPTION
Fixes #1244 

## Description of the Change
- handle zero as valid pk/id in get_resource_id util method
- update tests to include cases where ID is zero

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
