### PR TITLE
Ensured that patching a To-Many relationship correctly raises request error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Fixed
 
 * Handled zero as a valid ID for resource (regression since 6.1.0)
+* Ensured that patching a To-Many relationship with the `RelationshipView` correctly raises request error when passing in `None`.
+  For emptying a To-Many relationship an empty array should be used as per [JSON:API spec](https://jsonapi.org/format/#crud-updating-to-many-relationships)
 
 ### Added
 

--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -98,7 +98,7 @@ class JSONParser(parsers.JSONParser):
                             "Received data contains one or more malformed JSON:API "
                             "Resource Identifier Object(s)"
                         )
-            elif not (data.get("id") and data.get("type")):
+            elif isinstance(data, dict) and not (data.get("id") and data.get("type")):
                 raise ParseError(
                     "Received data is not a valid JSON:API Resource Identifier Object"
                 )


### PR DESCRIPTION
## Description of the Change

As of DRF upstream change https://github.com/encode/django-rest-framework/pull/9455 our current tests with DRF master are failing. The reason being is that previous to the above change, parser attribute errors would get swallowed.

After this upstream change it occurred that we actually have an error in our code that an attribute error gets hidden and instead of raising a 500-error the code would just continue.

This happened when patching a To-Many relationship with `RelationshipView` with `None`. However, the [JSON:API spec](https://jsonapi.org/format/#crud-updating-to-many-relationships) defines that for emptying a To-Many relationship, caller needs to pass empty array instead of None.

So this PR ensures that when passing on `None` when patching To-Many relationship, a proper request error (400) is returned instead of 500.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
