### PR TITLE
Deprecated built-in support for OpenAPI schema generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Added support for Django 5.1
 
+### Deprecated
+
+* Deprecated built-in support for generating OpenAPI schema. Use [drf-spectacular-json-api](https://github.com/jokiefer/drf-spectacular-json-api/) instead.
+
 ## [7.0.2] - 2024-06-28
 
 ### Fixed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,7 +31,6 @@ REST_FRAMEWORK = {
         'rest_framework_json_api.renderers.BrowsableAPIRenderer'
     ),
     'DEFAULT_METADATA_CLASS': 'rest_framework_json_api.metadata.JSONAPIMetadata',
-    'DEFAULT_SCHEMA_CLASS': 'rest_framework_json_api.schemas.openapi.AutoSchema',
     'DEFAULT_FILTER_BACKENDS': (
         'rest_framework_json_api.filters.QueryParameterValidationFilter',
         'rest_framework_json_api.filters.OrderingFilter',
@@ -1057,6 +1056,20 @@ The `prefetch_related` case will issue 4 queries, but they will be small and fas
 
 ## Generating an OpenAPI Specification (OAS) 3.0 schema document
 
+---
+
+**Deprecation notice:**
+
+REST framework's built-in support for generating OpenAPI schemas is
+**deprecated** in favor of 3rd party packages that can provide this
+functionality instead. Therefore we have also deprecated the schema support in
+Django REST framework JSON:API. The built-in support will be retired over the
+next releases.
+
+As a full-fledged replacement, we recommend the [drf-spectacular-json-api] package.
+
+---
+
 DRF has a [OAS schema functionality](https://www.django-rest-framework.org/api-guide/schemas/) to generate an
 [OAS 3.0 schema](https://www.openapis.org/) as a YAML or JSON file.
 
@@ -1187,3 +1200,8 @@ We aim to make creating third party packages as easy as possible, whilst keeping
 To submit new content, [open an issue](https://github.com/django-json-api/django-rest-framework-json-api/issues/new/choose) or [create a pull request](https://github.com/django-json-api/django-rest-framework-json-api/compare).
 
 * [drf-yasg-json-api](https://github.com/glowka/drf-yasg-json-api) - Automated generation of Swagger/OpenAPI 2.0 from Django REST framework JSON:API endpoints.
+* [drf-spectacular-json-api] - OpenAPI 3 schema generator for Django REST framework JSON:API based on drf-spectacular.
+
+
+
+[drf-spectacular-json-api]: https://github.com/jokiefer/drf-spectacular-json-api/

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1056,6 +1056,11 @@ The `prefetch_related` case will issue 4 queries, but they will be small and fas
 
 ## Generating an OpenAPI Specification (OAS) 3.0 schema document
 
+DRF has a [OAS schema functionality](https://www.django-rest-framework.org/api-guide/schemas/) to generate an
+[OAS 3.0 schema](https://www.openapis.org/) as a YAML or JSON file.
+
+DJA extends DRF's schema support to generate an OAS schema in the JSON:API format.
+
 ---
 
 **Deprecation notice:**
@@ -1069,11 +1074,6 @@ next releases.
 As a full-fledged replacement, we recommend the [drf-spectacular-json-api] package.
 
 ---
-
-DRF has a [OAS schema functionality](https://www.django-rest-framework.org/api-guide/schemas/) to generate an
-[OAS 3.0 schema](https://www.openapis.org/) as a YAML or JSON file.
-
-DJA extends DRF's schema support to generate an OAS schema in the JSON:API format.
 
 ### AutoSchema Settings
 

--- a/example/tests/test_openapi.py
+++ b/example/tests/test_openapi.py
@@ -1,6 +1,7 @@
 # largely based on DRF's test_openapi
 import json
 
+import pytest
 from django.test import RequestFactory, override_settings
 from django.urls import re_path
 from rest_framework.request import Request
@@ -8,6 +9,8 @@ from rest_framework.request import Request
 from rest_framework_json_api.schemas.openapi import AutoSchema, SchemaGenerator
 
 from example import views
+
+pytestmark = pytest.mark.filterwarnings("ignore:Built-in support")
 
 
 def create_request(path):

--- a/rest_framework_json_api/schemas/openapi.py
+++ b/rest_framework_json_api/schemas/openapi.py
@@ -423,6 +423,16 @@ class AutoSchema(drf_openapi.AutoSchema):
         - collections
         - special handling for POST, PATCH, DELETE
         """
+
+        warnings.warn(
+            DeprecationWarning(
+                "Built-in support for generating OpenAPI schema is deprecated. "
+                "Use drf-spectacular-json-api instead see "
+                "https://github.com/jokiefer/drf-spectacular-json-api/"
+            ),
+            stacklevel=2,
+        )
+
         operation = {}
         operation["operationId"] = self.get_operation_id(path, method)
         operation["description"] = self.get_description(path, method)


### PR DESCRIPTION
Addresses #1082

## Description of the Change

As discussed, we deprecate built-in support for OpenAPI schema generation and promote [drf-spectacular-json-api](https://github.com/jokiefer/drf-spectacular-json-api/) instead.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
