### PR TITLE
Bumped docs Python version to 3.10

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3.10"
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
## Description of the Change

This is needed for Sphinx 8. Fixing current [docs build issue](https://readthedocs.org/projects/django-rest-framework-json-api/builds/25860244/).

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
