### PR TITLE
Added support for 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev"]
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:
@@ -28,7 +28,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
       - name: Run tox targets for ${{ matrix.python-version }}
-        run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d .)
+        run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d . | cut -f 1 -d '-')
       - name: Upload coverage report
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ any parts of the framework not mentioned in the documentation should generally b
 ### Added
 
 * Added support for Django 5.1
+* Added support for Python 3.13
 
 ### Deprecated
 

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ As a Django REST framework JSON:API (short DJA) we are trying to address followi
 Requirements
 ------------
 
-1. Python (3.8, 3.9, 3.10, 3.11, 3.12)
+1. Python (3.8, 3.9, 3.10, 3.11, 3.12, 3.13)
 2. Django (4.2, 5.0, 5.1)
 3. Django REST framework (3.14, 3.15)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ like the following:
 
 ## Requirements
 
-1. Python (3.8, 3.9, 3.10, 3.11, 3.12)
+1. Python (3.8, 3.9, 3.10, 3.11, 3.12, 3.13)
 2. Django (4.2, 5.0, 5.1)
 3. Django REST framework (3.14, 3.15)
 

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Software Development :: Libraries :: Application Frameworks",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -47,12 +47,3 @@ deps =
     -rrequirements/requirements-documentation.txt
 commands =
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
-
-[testenv:py{38,39,310,311,312}-django42-drfmaster]
-ignore_outcome = true
-
-[testenv:py{310,311,312}-django{50,51}-drfmaster]
-ignore_outcome = true
-
-[testenv:py313-django51-drfmaster]
-ignore_outcome = true

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py{38,39,310,311,312}-django42-drf{314,315,master},
     py{310,311,312}-django{50,51}-drf{314,315,master},
+    py313-django51-drf{315,master},
     black,
     docs,
     lint
@@ -51,4 +52,7 @@ commands =
 ignore_outcome = true
 
 [testenv:py{310,311,312}-django{50,51}-drfmaster]
+ignore_outcome = true
+
+[testenv:py313-django51-drfmaster]
 ignore_outcome = true

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py{38,39,310,311,312}-django42-drf{314,315,master},
     py{310,311,312}-django{50,51}-drf{314,315,master},
-    py313-django51-drf{315,master},
+    py313-django51-drf{master},
     black,
     docs,
     lint


### PR DESCRIPTION
## Description of the Change

Python 3.13 will only be supported by [Django 5.1 and above](https://forum.djangoproject.com/t/backport-python-3-13-support-in-django-5-0/34671).

Currently, 3.13 has not been released yet on [Github](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json) so using Python 3.13-dev. This should be removed once it is released.

Additionally, DRF made a [change](https://github.com/encode/django-rest-framework/pull/9527/files) to how description is retrieved. Tests with DRF 3.15 are failing because of that, so only testing on drfmaster. However, as schema support is deprecated anyway, I suppose we can still mark DJA to support Python 3.13 before DRF releases another version. 

As only drfmaster is tested for Python 3.13 it does not make sense to ignore it. As of the issue we had in #1251 I removed all ignores, so we get notified if something goes wrong.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
