### PR TITLE
Removed support for Python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST framework policy](https://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
+## [unreleased]
+
+### Removed
+
+* Removed support for Python 3.8.
+
+
 ## [7.1.0] - 2024-10-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ any parts of the framework not mentioned in the documentation should generally b
 
 ## [7.1.0] - 2024-10-25
 
+This is the last release supporting Python 3.8.
+
 ### Fixed
 
 * Handled zero as a valid ID for resource (regression since 6.1.0)

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ As a Django REST framework JSON:API (short DJA) we are trying to address followi
 Requirements
 ------------
 
-1. Python (3.8, 3.9, 3.10, 3.11, 3.12, 3.13)
+1. Python (3.9, 3.10, 3.11, 3.12, 3.13)
 2. Django (4.2, 5.0, 5.1)
 3. Django REST framework (3.14, 3.15)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ like the following:
 
 ## Requirements
 
-1. Python (3.8, 3.9, 3.10, 3.11, 3.12, 3.13)
+1. Python (3.9, 3.10, 3.11, 3.12, 3.13)
 2. Django (4.2, 5.0, 5.1)
 3. Django REST framework (3.14, 3.15)
 

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -116,6 +115,6 @@ setup(
         "openapi": ["pyyaml>=5.4", "uritemplate>=3.0.1"],
     },
     setup_requires=wheel,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-django42-drf{314,315,master},
+    py{39,310,311,312}-django42-drf{314,315,master},
     py{310,311,312}-django{50,51}-drf{314,315,master},
     py313-django51-drf{master},
     black,


### PR DESCRIPTION
## Description of the Change
Remove Python 3.8 which is EOL per [PEP 569](https://peps.python.org/pep-0569/)

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
