### PR TITLE
ignore drfmaster-induced test failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,10 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-django42-drf{314,315,master},
-    py{310,311,312}-django{50,51}-drf{314,315,master},
-    py313-django51-drf{master},
+    py{38,39,310,311,312}-django42-drf{314,315},
+    py{310,311,312}-django{50,51}-drf{314,315},
+    py{38,39,310,311,312}-django42-drfmaster,
+    py{310,311,312}-django{50,51}-drfmaster,
+    py313-django51-drfmaster,
     black,
     docs,
     lint
@@ -24,6 +26,18 @@ setenv =
 
 commands =
     pytest --cov --no-cov-on-fail --cov-report xml {posargs}
+
+[testenv:py{38,39,310,311,312}-django42-drfmaster]
+ignore_errors = true
+ignore_outcome = true
+
+[testenv:py{310,311,312}-django{50,51}-drfmaster]
+ignore_errors = true
+ignore_outcome = true
+
+[testenv:py313-django51-drfmaster]
+ignore_errors = true
+ignore_outcome = true
 
 [testenv:black]
 basepython = python3.10


### PR DESCRIPTION
## Description of the Change

Errors introduced into unreleased drfmaster are causing test failures. This splits out the drfmaster tests to ignore
errors. 

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
