### PR TITLE
Update documentation to include --pythonpath to set up the example app

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,9 +149,9 @@ installed and activated:
     $ git clone https://github.com/django-json-api/django-rest-framework-json-api.git
     $ cd django-rest-framework-json-api
     $ pip install -Ur requirements.txt
-    $ django-admin migrate --settings=example.settings
-    $ django-admin loaddata drf_example --settings=example.settings
-    $ django-admin runserver --settings=example.settings
+    $ django-admin migrate --settings=example.settings --pythonpath .
+    $ django-admin loaddata drf_example --settings=example.settings --pythonpath .
+    $ django-admin runserver --settings=example.settings --pythonpath .
 
 Browse to
 


### PR DESCRIPTION
Fixes #1269

## Description of the Change
This PR updates the documentation to include the `--pythonpath .` option when running `django-admin` commands to set up the example app.
## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
