### PR TITLE
Added support for Django REST framework 3.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Note that in line with [Django REST framework policy](https://www.django-rest-framework.org/topics/release-notes/),
 any parts of the framework not mentioned in the documentation should generally be considered private API, and may be subject to change.
 
-## [unreleased]
+## [Unreleased]
+
+### Added
+
+* Added support for Django REST framework 3.16.
 
 ### Removed
 
 * Removed support for Python 3.8.
+* Removed support for Django REST framework 3.14.
 
 
 ## [7.1.0] - 2024-10-25
 
-This is the last release supporting Python 3.8.
+This is the last release supporting Python 3.8 and Django REST framework 3.14.
 
 ### Fixed
 

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Requirements
 
 1. Python (3.9, 3.10, 3.11, 3.12, 3.13)
 2. Django (4.2, 5.0, 5.1)
-3. Django REST framework (3.14, 3.15)
+3. Django REST framework (3.15, 3.16)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ like the following:
 
 1. Python (3.9, 3.10, 3.11, 3.12, 3.13)
 2. Django (4.2, 5.0, 5.1)
-3. Django REST framework (3.14, 3.15)
+3. Django REST framework (3.15, 3.16)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.
 

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
     },
     install_requires=[
         "inflection>=0.5.0",
-        "djangorestframework>=3.14",
+        "djangorestframework>=3.15",
         "django>=4.2",
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{39,310,311,312}-django42-drf{314,315,master},
-    py{310,311,312}-django{50,51}-drf{314,315,master},
+    py{39,310,311,312}-django42-drf{315,316,master},
+    py{310,311,312}-django{50,51}-drf{315,316,master},
     py313-django51-drf{master},
     black,
     docs,
@@ -12,8 +12,8 @@ deps =
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
-    drf314: djangorestframework>=3.14,<3.15
     drf315: djangorestframework>=3.15,<3.16
+    drf316: djangorestframework>=3.16,<3.17
     drfmaster: https://github.com/encode/django-rest-framework/archive/master.zip
     -rrequirements/requirements-testing.txt
     -rrequirements/requirements-optionals.txt


### PR DESCRIPTION
## Description of the Change

Added new Django REST framework 3.16 and as of our policy as we only support the two last DRF releases dropped support for Django REST framework 3.14.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
