### PR TITLE
Ensured that `include` param is properly underscored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ any parts of the framework not mentioned in the documentation should generally b
 * Added support for Django REST framework 3.16.
 * Added support for Django 5.2.
 
+### Fixed
+
+* Ensured that interpreting `include` query parameter is done in internal Python naming.
+  This adds full support for using multipart field names for includes while configuring `JSON_API_FORMAT_FIELD_NAMES`.
+
 ### Removed
 
 * Removed support for Python 3.8.

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -6,7 +6,6 @@ import copy
 from collections import defaultdict
 from collections.abc import Iterable
 
-import inflection
 from django.db.models import Manager
 from django.template import loader
 from django.utils.encoding import force_str
@@ -277,9 +276,6 @@ class JSONRenderer(renderers.JSONRenderer):
             current_serializer, "included_serializers", dict()
         )
         included_resources = copy.copy(included_resources)
-        included_resources = [
-            inflection.underscore(value) for value in included_resources
-        ]
 
         for field_name, field in iter(fields.items()):
             # Skip URL field

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -1,6 +1,5 @@
 from collections.abc import Mapping
 
-import inflection
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.query import QuerySet
 from django.utils.module_loading import import_string as import_class_from_dotted_path
@@ -129,7 +128,7 @@ class IncludedResourcesValidationMixin:
             serializers = getattr(serializer_class, "included_serializers", None)
             if serializers is None:
                 raise ParseError("This endpoint does not support the include parameter")
-            this_field_name = inflection.underscore(field_path[0])
+            this_field_name = field_path[0]
             this_included_serializer = serializers.get(this_field_name)
             if this_included_serializer is None:
                 raise ParseError(

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -316,10 +316,18 @@ def get_resource_id(resource_instance, resource):
 
 
 def get_included_resources(request, serializer=None):
-    """Build a list of included resources."""
+    """
+    Build a list of included resources.
+
+    This method ensures that returned includes are in Python internally used
+    format.
+    """
     include_resources_param = request.query_params.get("include") if request else None
     if include_resources_param:
-        return include_resources_param.split(",")
+        return [
+            undo_format_field_name(include)
+            for include in include_resources_param.split(",")
+        ]
     else:
         return get_default_included_resources_from_serializer(serializer)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from rest_framework.test import APIClient
+from rest_framework.test import APIClient, APIRequestFactory
 
 from tests.models import (
     BasicModel,
@@ -98,3 +98,8 @@ def nested_related_source(
 @pytest.fixture
 def client():
     return APIClient()
+
+
+@pytest.fixture
+def rf():
+    return APIRequestFactory()


### PR DESCRIPTION
Fixes #203
Fixes #871
Fixes #1053

## Description of the Change

`include` query parameter can be in a different formats like `dasherized` when `JSON_API_FORMAT_FIELD_NAMES` is set. In some cases, this was not taken into account when reading the `include` parameter. I have moved the logic of underscoring into the `get_included_resources` so it will be correctly processed in all use cases.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
