### PR TITLE
Remove transitive dependency sqlparse from example/requirements.txt

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -8,5 +8,4 @@ pluggy
 py
 pyparsing
 pytz
-sqlparse
 django-filter>=2.0


### PR DESCRIPTION
Fixes #1284

## Description of the Change

As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the transitive dependency `sqlparse`, which is required by Django, is specified as a requirement in the `example/requirements.txt` file, even though it is not used directly and does not need to be listed explicitly.

This PR removes it from `example/requirements.txt` to let pip manage it automatically, which helps keeping the dependency list clean.

Hope this is helpful!

## Checklist

- [ x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
