### PR TITLE
Ensured that sparse fieldset support formatted field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Ensured that interpreting `include` query parameter is done in internal Python naming.
   This adds full support for using multipart field names for includes while configuring `JSON_API_FORMAT_FIELD_NAMES`.
+* Ensured that sparse fieldset fully supports `JSON_API_FORMAT_FIELD_NAMES`.
 
 ### Removed
 

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -26,6 +26,7 @@ from rest_framework_json_api.utils import (
     get_resource_type_from_instance,
     get_resource_type_from_model,
     get_resource_type_from_serializer,
+    undo_format_field_name,
 )
 
 
@@ -89,7 +90,10 @@ class SparseFieldsetsMixin:
                     sparse_fieldset_query_param
                 )
                 if sparse_fieldset_value is not None:
-                    sparse_fields = sparse_fieldset_value.split(",")
+                    sparse_fields = [
+                        undo_format_field_name(sparse_field)
+                        for sparse_field in sparse_fieldset_value.split(",")
+                    ]
                     return (
                         field
                         for field in readable_fields

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,5 +1,6 @@
 import pytest
 from django.db import models
+from rest_framework.request import Request
 from rest_framework.utils import model_meta
 
 from rest_framework_json_api import serializers
@@ -83,4 +84,23 @@ def test_get_field_names():
         "an_extra_field",
         "verified",
         "uuid",
+    ]
+
+
+def test_readable_fields_with_sparse_fields(client, rf, settings):
+    class TestSerializer(serializers.Serializer):
+        name = serializers.CharField()
+        value = serializers.CharField()
+        multi_part_name = serializers.CharField()
+
+        class Meta:
+            resource_name = "test"
+
+    settings.JSON_API_FORMAT_FIELD_NAMES = "camelCase"
+    request = Request(rf.get("/test/", {"fields[test]": "value,multiPartName"}))
+    context = {"request": request}
+    serializer = TestSerializer(context=context)
+    assert [field.field_name for field in serializer._readable_fields] == [
+        "value",
+        "multi_part_name",
     ]


### PR DESCRIPTION
Fixes #1053

## Description of the Change

Added missed undoing of formatting when interpreting sparse field set field query parameter.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
