### PR TITLE
Set django polymorphic version to newest

### DIFF
--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,5 +1,2 @@
 django-filter==24.3
-# once next version has been released (>3.1.0) this
-# should be set to pinned version again
-# see https://github.com/django-polymorphic/django-polymorphic/pull/541
-django-polymorphic@git+https://github.com/django-polymorphic/django-polymorphic@master  # pyup: ignore
+django-polymorphic==4.1.0


### PR DESCRIPTION
## Description of the Change

Seems when merging #1289 this change went missing.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
