### PR TITLE
Added missing grouping of dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/requirements"
     schedule:
       interval: "monthly"
+    groups:
+      all-deps:
+        patterns: ["*"]


### PR DESCRIPTION
## Description of the Change

To avoid the noise, all dependency updates should be grouped in one PR as pyup did as well.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
