### PR TITLE
Deprecated support for django-polymorphic resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Ensured that an empty `included` array is returned in responses when the `include` query parameter is present but no related resources exist.
 
+### Deprecated
+
+* Deprecated support for using Polymorphic resources through [django-polymorphic](https://github.com/jazzband/django-polymorphic). There is currently no replacement. In case you are affected of this change please join [our discussion](https://github.com/django-json-api/django-rest-framework-json-api/discussions/1194).
+
 ## [8.0.0] - 2025-07-24
 
 ### Added

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -863,6 +863,17 @@ field_name_mapping = {
 
 ### Working with polymorphic resources
 
+--
+
+**Deprecation notice:**
+
+
+Support for using Polymorphic resources through [django-polymorphic](https://github.com/jazzband/django-polymorphic) is deprecated and will be removed in a future release.
+
+There is currently no replacement. In case you are affected of this change please join [our discussion](https://github.com/django-json-api/django-rest-framework-json-api/discussions/1194).
+
+---
+
 Polymorphic resources allow you to use specialized subclasses without requiring
 special endpoints to expose the specialized versions. For example, if you had a
 `Project` that could be either an `ArtProject` or a `ResearchProject`, you can

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Mapping
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -341,6 +342,16 @@ class PolymorphicSerializerMetaclass(SerializerMetaclass):
         parents = [b for b in bases if isinstance(b, PolymorphicSerializerMetaclass)]
         if not parents:
             return new_class
+
+        warnings.warn(
+            DeprecationWarning(
+                "Support for polymorphic resources is deprecated."
+                "There is currently no replacement. In case you are affected of this "
+                "change please join discussion at "
+                "https://github.com/django-json-api/django-rest-framework-json-api/discussions/1194."
+            ),
+            stacklevel=2,
+        )
 
         polymorphic_serializers = getattr(new_class, "polymorphic_serializers", None)
         assert (

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ DJANGO_SETTINGS_MODULE=example.settings.test
 filterwarnings =
     error::DeprecationWarning
     error::PendingDeprecationWarning
+    ignore:Support for polymorphic resources is deprecated
 testpaths =
     example
     tests


### PR DESCRIPTION
## Description of the Change

I have started discussion #1194 almost two years ago in terms of Django Polymorphic support in DJA and what it is used for. I have pinged people in the different PRs and issues about Polymorphic. The only response I got is at https://github.com/django-json-api/django-rest-framework-json-api/issues/1087#issuecomment-2102289619, but otherwise no feedback.

My feeling is that either Django Polymorphic support in DJA is not really used or people are not aware of the surrounding discussion.

The goal of deprecation is that users who use it will become aware of the discussion, and we get a group of people who hopefully will be able to work on Django Polymorphic support in an external library.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
