### PR TITLE
Removed Django support 4.2 and 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ any parts of the framework not mentioned in the documentation should generally b
 
 * Removed support for Python 3.9.
 * Removed support for Django REST framework 3.15.
+* Removed support for Django 4.2.
+* Removed support for Django 5.1.
 
 ## [8.1.0] - 2025-10-17
 
-This is the last release supporting Python 3.9 and Django REST framework 3.15.
+This is the last release supporting Python 3.9, Django 4.2, Django 5.1 and Django REST framework 3.15.
 
 ### Fixed
 

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Requirements
 ------------
 
 1. Python (3.10, 3.11, 3.12, 3.13, 3.14)
-2. Django (4.2, 5.1, 5.2, 6.0)
+2. Django (5.2, 6.0)
 3. Django REST framework (3.16, 3.17)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ like the following:
 ## Requirements
 
 1. Python (3.10, 3.11, 3.12, 3.13, 3.14)
-2. Django (4.2, 5.1, 5.2, 6.0)
+2. Django (5.2, 6.0)
 3. Django REST framework (3.16, 3.17)
 
 We **highly** recommend and only officially support the latest patch release of each Python, Django and REST framework series.

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     install_requires=[
         "inflection>=0.5.0",
         "djangorestframework>=3.16",
-        "django>=4.2",
+        "django>=5.2",
     ],
     extras_require={
         "django-polymorphic": ["django-polymorphic>=4.0.0"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,16 @@
 [tox]
 envlist =
-    py{310,311}-django{42,51,52}-drf{316,317,main},
-    py{312}-django{42,51,52,60}-drf{316,317,main},
-    py{313}-django{51,52,60}-drf{316,317,main},
-    py{314}-django{52,60}-drf{317,main},
+    py310-django{52}-drf{316,317,main},
+    py311-django{52}-drf{316,317,main},
+    py312-django{52,60}-drf{316,317,main},
+    py313-django{52,60}-drf{316,317,main},
+    py314-django{52,60}-drf{317,main},
     black,
     docs,
     lint
 
 [testenv]
 deps =
-    django42: Django>=4.2,<4.3
-    django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
     django60: Django>=6.0,<6.1
     drf316: djangorestframework>=3.16,<3.17


### PR DESCRIPTION
## Description of the Change

Removed support for outdated Django version 4.2 and 5.1.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
