### PR TITLE
Fix broken commands in getting-started docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -91,10 +91,10 @@ and add `rest_framework_json_api` to your `INSTALLED_APPS` setting below `rest_f
 	cd django-rest-framework-json-api
 	python3 -m venv env
 	source env/bin/activate
-	pip install -Ur requirements.txt
-	django-admin migrate --settings=example.settings
-	django-admin loaddata drf_example --settings=example.settings
-	django-admin runserver --settings=example.settings
+	pip install -e .
+	python -m django migrate --settings=example.settings
+	python -m django loaddata drf_example --settings=example.settings
+	python -m django runserver --settings=example.settings
 
 
 Browse to

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,12 +89,10 @@ and add `rest_framework_json_api` to your `INSTALLED_APPS` setting below `rest_f
 
 	git clone https://github.com/django-json-api/django-rest-framework-json-api.git
 	cd django-rest-framework-json-api
-	python3 -m venv env
-	source env/bin/activate
-	pip install -e .
-	python -m django migrate --settings=example.settings
-	python -m django loaddata drf_example --settings=example.settings
-	python -m django runserver --settings=example.settings
+	pip install -Ur requirements.txt
+	django-admin migrate --settings=example.settings --pythonpath .
+	django-admin loaddata drf_example --settings=example.settings --pythonpath .
+	django-admin runserver --settings=example.settings --pythonpath .
 
 
 Browse to


### PR DESCRIPTION
django-admin isn't always on PATH after a fresh venv install, and requirements.txt doesn't exist anymore. Switched to python -m django and pip install -e ., which I tested and confirmed work.

Fixes #1326

## Description of the Change
The "Running the example app" section in getting-started.md instructed
users to run `django-admin migrate`, but `django-admin` is not
guaranteed to be on PATH after a fresh venv install, which causes
`ModuleNotFoundError: No module named 'example'`. It also referenced
`pip install -Ur requirements.txt`, which no longer exists in this repo.

I reproduced the bug locally, confirmed `python -m django migrate` and
`pip install -e .` work correctly instead, and updated the docs
accordingly.

## Checklist
- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
